### PR TITLE
Ignore the Serena agent folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vs/
 .codex/
+.serena/
 .dotnet/
 .appdata/
 .packages/


### PR DESCRIPTION
`.serena/` is local state written by an MCP server, like the `.codex/` folder already ignored beside it. It was showing up as untracked in every status check and triggering an uncommitted-change warning from `gh`.

Grouped with the other agent and IDE folders rather than appended, so the file keeps its existing structure.