### PR TITLE
Validate pull requests on GitHub Actions

### DIFF
--- a/.azure/pipelines/build-whiteboard.yaml
+++ b/.azure/pipelines/build-whiteboard.yaml
@@ -38,6 +38,11 @@ parameters:
 
 trigger: none
 
+# Pull requests are validated by .github/workflows/pull-request.yml, unsigned. Without this,
+# Azure DevOps validates every pull request against a GitHub repository by default, which
+# would run a signed build over unreviewed code.
+pr: none
+
 pool:
   vmImage: 'windows-latest'
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,59 @@
+# Validation for pull requests.
+#
+# Deliberately does no signing and publishes nothing: anything touching the code-signing
+# certificate runs in Azure Pipelines, because this repository is public and so are these
+# logs. See docs/decisions.md, decision 3.
+name: Pull request
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A new push to the same pull request supersedes the run already in flight.
+concurrency:
+  group: pull-request-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore Whiteboard.sln
+
+      # TreatWarningsAsErrors is on for every project, so a warning fails here.
+      - name: Build
+        run: dotnet build Whiteboard.sln --configuration Release --no-restore
+
+      - name: Core smoke tests
+        run: >-
+          dotnet run
+          --project tests/SQLBI.Whiteboard.Core.SmokeTests/SQLBI.Whiteboard.Core.SmokeTests.csproj
+          --configuration Release
+
+  installer:
+    name: Build installers
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      # Catches WiX authoring errors here rather than at release time. Unsigned, and the
+      # output is discarded; the version is a placeholder with no meaning.
+      - name: Build installers
+        shell: pwsh
+        run: ./scripts/build-installer.ps1 -Version 0.0.0

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -155,11 +155,10 @@ merge.
 
 Configuration, in two stages because the second has a prerequisite:
 
-- **Now** — require a pull request before merging, and disallow bypassing the setting for
-  administrators. Protection that can be silently sidestepped tends to be.
-- **Once pull-request validation exists** (see `release-management.md`) — additionally
-  require that check to pass. GitHub can only require checks it has seen, so this cannot be
-  configured before the workflow runs at least once.
+- **Done** — a pull request is required before merging, and the bypass list is empty.
+  Protection that can be silently sidestepped tends to be.
+- **Remaining** — require the pull request validation checks to pass. GitHub only offers
+  checks it has already seen, so select them once the workflow has run.
 
 Approvals are deliberately **not** required. A two-person core team should not be blocked by
 one member's travel; review is welcome, waiting is not. Add required review only if

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -68,6 +68,21 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-assets.ps1
 Colours live in two places that must be changed together: the SVG, and
 `tools/AssetGenerator/Program.cs`.
 
+## Pull request validation
+
+`.github/workflows/pull-request.yml` runs on every pull request against `main`, in two jobs:
+
+- **Build and test** — restores, builds the solution in Release, and runs the Core smoke
+  tests. `TreatWarningsAsErrors` means a warning fails it.
+- **Build installers** — runs `scripts/build-installer.ps1` unsigned, so WiX authoring
+  errors surface here rather than at release time. The output is discarded.
+
+It signs nothing and publishes nothing. Everything that touches the certificate stays in
+Azure Pipelines, because this repository is public and so are these logs (decision 3).
+
+Running on GitHub also means it works for pull requests from forks, which have no access to
+secrets and need none.
+
 ## The pipeline
 
 `.azure/pipelines/build-whiteboard.yaml`, in the `SQLBI Whiteboard` Azure DevOps project.
@@ -114,17 +129,14 @@ hand.
 Roughly in dependency order:
 
 1. Move the version out of the variable group and into the repository (decision 8).
-2. Add CI triggers: pull requests unsigned, `main` signed. Until a pull-request check exists
-   and has run once, branch protection can require a pull request but cannot require a
-   passing check — GitHub only offers checks it has already seen.
+2. Add a CI trigger to the Azure pipeline so `main` builds and signs on every merge.
 3. Replace the `AzureFileCopy` step with `GitHubRelease@1`, and create a GitHub service
    connection with `contents: write`.
 4. Split the pipeline into Build / Pre-release / Release stages with an approval gate.
 5. Publish `stable.json` and `dev.json` manifests alongside the binaries, for the download
    page, a future in-app update check, and winget automation to share one source.
-6. Add a GitHub Actions workflow for unsigned pull-request validation.
-7. Add winget submission triggered by a published release.
-8. MSIX packaging and Store submission (decision 13).
+6. Add winget submission triggered by a published release.
+7. MSIX packaging and Store submission (decision 13).
 
 ## Verification before a public release
 


### PR DESCRIPTION
Branch protection can require a pull request but not a passing check, because no check
exists yet. This adds one.

`.github/workflows/pull-request.yml` runs two jobs on every pull request against `main`:
the solution build plus the Core smoke tests, and an unsigned installer build so WiX
authoring errors surface here instead of at release time. `TreatWarningsAsErrors` means a
warning fails the first job.

It signs nothing and publishes nothing. Everything touching the certificate stays in Azure
Pipelines, because this repository is public and so are these logs — decision 3. Running
here also means pull requests from forks are validated, since they need no secrets.

The workflow runs against this pull request, so its first execution is also its own test.

Documentation is updated to match: the item is removed from the still-to-build list,
decision 11's second stage is now unblocked, and release-management.md describes what the
validation covers.