### PR TITLE
Read the product version from Directory.Build.props

### DIFF
--- a/.azure/pipelines/build-whiteboard.yaml
+++ b/.azure/pipelines/build-whiteboard.yaml
@@ -15,9 +15,11 @@
 #     Whiteboard-specific service principal so access can be revoked on its own.
 #
 #   SQLBI.Whiteboard
-#     AppVersionMajor, AppVersionMinor, AppVersionPatch
 #     AzureSubscriptionName, AzurePublishStorageAccountName, AzurePublishStorageContainerName
 #     AppInformationalVersionExtendedInfo  (optional, 'true' appends build and commit details)
+#
+# The version is not a pipeline variable: it comes from VersionPrefix in
+# Directory.Build.props, so releasing is a reviewed change to the repository.
 
 parameters:
 - name: verbosity
@@ -51,11 +53,11 @@ strategy:
     whiteboard-x64:
       arch: 'x64'
       selfcontained: 'true'
-      artifact: 'SQLBI.Whiteboard.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).x64'
+      flavor: ''
     whiteboard-x64-frameworkdependent:
       arch: 'x64'
       selfcontained: 'false'
-      artifact: 'SQLBI.Whiteboard.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).x64-frameworkdependent'
+      flavor: '-frameworkdependent'
 
 variables:
 - group: 'SQLBI-CodeSigning'
@@ -73,6 +75,15 @@ variables:
   value: '5.0.2'
 
 steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET 8 SDK'
+  inputs:
+    packageType: sdk
+    version: '8.0.x'
+
+- script: dotnet restore "$(csproj)" --runtime "win-$(arch)" --verbosity "${{ parameters.verbosity }}"
+  displayName: 'dotnet restore'
+
 - task: PowerShell@2
   displayName: 'Set version variables'
   inputs:
@@ -82,16 +93,14 @@ steps:
       # script. An undefined $(Name) macro is left verbatim, and PowerShell then treats
       # "$(Name)" as a subexpression and tries to run Name as a command.
       $extendedInfo = $env:APP_INFORMATIONAL_VERSION_EXTENDED_INFO
-      $versionParts = [ordered]@{
-          AppVersionMajor = $env:APP_VERSION_MAJOR
-          AppVersionMinor = $env:APP_VERSION_MINOR
-          AppVersionPatch = $env:APP_VERSION_PATCH
+
+      # The product version comes from VersionPrefix in Directory.Build.props, so it is
+      # reviewed in a pull request rather than edited in a variable group.
+      $semVer = (dotnet msbuild "$env:PROJECT_FILE" -getProperty:VersionPrefix --nologo).Trim()
+      if ($semVer -notmatch '^\d+\.\d+\.\d+$') {
+          throw "VersionPrefix in Directory.Build.props must be major.minor.patch, but reads '$semVer'."
       }
-      foreach ($entry in $versionParts.GetEnumerator()) {
-          if ([string]::IsNullOrWhiteSpace($entry.Value) -or $entry.Value -like '$(*') {
-              throw "Pipeline variable $($entry.Key) is not set. Define AppVersionMajor, AppVersionMinor and AppVersionPatch in the SQLBI.Whiteboard variable group."
-          }
-      }
+      $semVerParts = $semVer.Split('.')
 
       # Built with -f rather than interpolation: in "$env:BUILD_BUILDID?api-version=1"
       # PowerShell reads '?' as part of the variable name and the id disappears.
@@ -112,34 +121,28 @@ steps:
       $versionRevision = [math]::Round((New-TimeSpan -Start $midnightTime -End $buildTime).TotalSeconds / 2)
       $buildNumber = '{0:yyyyMMdd}.{1}' -f $buildTime, $buildNumberRevision
       $storagePath = '{0:yyyy}/{0:MM}/{0:dd}' -f $buildTime
-      $versionNumber = '{0}.{1}.{2}.{3}' -f $versionParts.AppVersionMajor, $versionParts.AppVersionMinor, $versionBuild, $versionRevision
-      $informationalVersion = '{0}.{1}.{2}' -f $versionParts.AppVersionMajor, $versionParts.AppVersionMinor, $versionParts.AppVersionPatch
+      $versionNumber = '{0}.{1}.{2}.{3}' -f $semVerParts[0], $semVerParts[1], $versionBuild, $versionRevision
+      $informationalVersion = $semVer
+      $artifact = 'SQLBI.Whiteboard.{0}.{1}{2}' -f $semVer, $env:MATRIX_ARCH, $env:MATRIX_FLAVOR
       if ($extendedInfo -eq 'true') {
           $informationalVersion += '-{0}-{1}-{2}-{3}' -f $buildNumber, $versionNumber, $env:BUILD_SOURCEBRANCHNAME, $env:BUILD_SOURCEVERSION
       }
+      Write-Host "##vso[task.setvariable variable=artifact;]$artifact"
+      Write-Host "##vso[task.setvariable variable=AppSemVer;]$semVer"
       Write-Host "##vso[task.setvariable variable=AzurePublishStoragePath;]$storagePath"
       Write-Host "##vso[task.setvariable variable=AppBuildNumber;]$buildNumber"
       Write-Host "##vso[task.setvariable variable=AppVersionNumber;]$versionNumber"
       Write-Host "##vso[task.setvariable variable=AppInformationalVersion;]$informationalVersion"
       Write-Host "##vso[build.updatebuildnumber]$buildNumber-$versionNumber"
-      Write-Host "VersionNumber is $versionNumber"
-      Write-Host "InformationalVersion is $informationalVersion"
+      Write-Host "Version is $semVer, assembly version $versionNumber"
+      Write-Host "Artifact is $artifact"
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    APP_VERSION_MAJOR: $(AppVersionMajor)
-    APP_VERSION_MINOR: $(AppVersionMinor)
-    APP_VERSION_PATCH: $(AppVersionPatch)
+    PROJECT_FILE: $(csproj)
+    MATRIX_ARCH: $(arch)
+    MATRIX_FLAVOR: $(flavor)
     # Optional; an undefined macro arrives here as a harmless literal string.
     APP_INFORMATIONAL_VERSION_EXTENDED_INFO: $(AppInformationalVersionExtendedInfo)
-
-- task: UseDotNet@2
-  displayName: 'Use .NET 8 SDK'
-  inputs:
-    packageType: sdk
-    version: '8.0.x'
-
-- script: dotnet restore "$(csproj)" --runtime "win-$(arch)" --verbosity "${{ parameters.verbosity }}"
-  displayName: 'dotnet restore'
 
 - script: >-
     dotnet publish "$(csproj)"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,11 @@
 <Project>
   <PropertyGroup>
+    <!--
+      The product version, and the single place it is defined. The build pipeline and
+      scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
+      to this line rather than an edit in a pipeline variable group.
+    -->
+    <VersionPrefix>0.1.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -107,8 +107,10 @@ Three consequences were chosen deliberately:
 
 ## 8. Version belongs in the repository
 
-**Agreed, not yet built.** Today the version still comes from the Azure DevOps variable
-group, as Bravo's does.
+**Implemented.** `VersionPrefix` in `Directory.Build.props` is the single definition. The
+pipeline and `scripts/build-installer.ps1` both read it with `dotnet msbuild -getProperty`,
+so nothing restates it. `AppVersionMajor`, `AppVersionMinor` and `AppVersionPatch` are no
+longer used and can be deleted from the variable group.
 
 Moving it into the repository makes the version reviewable in a pull request, attaches it to
 the commit that carries it, and makes "1.0.0 shipped from exactly this tree" answerable from

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -99,6 +99,10 @@ Two variable groups supply its settings; both must be authorised for the pipelin
 can run. The signing group's contents are described in decision 1 and held by the
 maintainers.
 
+The version is **not** among them: it comes from `VersionPrefix` in `Directory.Build.props`
+(decision 8). `AppVersionMajor`, `AppVersionMinor` and `AppVersionPatch` are obsolete and
+can be removed from the `SQLBI.Whiteboard` group.
+
 Signing uses `AzureSignTool` against the certificate in Azure Key Vault.
 
 > **When adding a new first-party project, add its assembly to the signing step.** The
@@ -107,6 +111,19 @@ Signing uses `AzureSignTool` against the certificate in Azure Key Vault.
 
 To run it: **Run pipeline**, set parameters, **Run**. Do not use **Re-run** to pick up a
 fix — that replays the original commit.
+
+## Versioning
+
+`VersionPrefix` in `Directory.Build.props` is the only place the product version is written.
+Everything else derives from it:
+
+- assemblies are stamped `major.minor.<days since 2000-01-01>.<seconds since midnight / 2>`,
+  the algorithm MSBuild and the Bravo pipeline use, so every matrix job in a run stamps the
+  same number;
+- the informational version is the plain `major.minor.patch`;
+- artifact and installer file names use it directly.
+
+Releasing therefore starts with a pull request that changes one line.
 
 ## Releasing
 
@@ -128,15 +145,14 @@ hand.
 
 Roughly in dependency order:
 
-1. Move the version out of the variable group and into the repository (decision 8).
-2. Add a CI trigger to the Azure pipeline so `main` builds and signs on every merge.
-3. Replace the `AzureFileCopy` step with `GitHubRelease@1`, and create a GitHub service
+1. Add a CI trigger to the Azure pipeline so `main` builds and signs on every merge.
+2. Replace the `AzureFileCopy` step with `GitHubRelease@1`, and create a GitHub service
    connection with `contents: write`.
-4. Split the pipeline into Build / Pre-release / Release stages with an approval gate.
-5. Publish `stable.json` and `dev.json` manifests alongside the binaries, for the download
+3. Split the pipeline into Build / Pre-release / Release stages with an approval gate.
+4. Publish `stable.json` and `dev.json` manifests alongside the binaries, for the download
    page, a future in-app update check, and winget automation to share one source.
-6. Add winget submission triggered by a published release.
-7. MSIX packaging and Store submission (decision 13).
+5. Add winget submission triggered by a published release.
+6. MSIX packaging and Store submission (decision 13).
 
 ## Verification before a public release
 

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -10,7 +10,8 @@
 #>
 [CmdletBinding()]
 param(
-    [string] $Version = '0.1.0',
+    # Defaults to VersionPrefix in Directory.Build.props, the one place the version is defined.
+    [string] $Version,
     [ValidateSet('x64')]
     [string] $Architecture = 'x64',
     [ValidateSet('true', 'false')]
@@ -26,6 +27,12 @@ $project = Join-Path $repoRoot 'src/SQLBI.Whiteboard/SQLBI.Whiteboard.csproj'
 $installerRoot = Join-Path $repoRoot 'installer/wix'
 $publishFolder = Join-Path $repoRoot 'artifacts/publish'
 $outputFolder = Join-Path $repoRoot 'artifacts/installer'
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = (dotnet msbuild $project -getProperty:VersionPrefix --nologo).Trim()
+    if ($LASTEXITCODE -ne 0) { throw "Could not read VersionPrefix from $project" }
+    Write-Host "Version from Directory.Build.props: $Version" -ForegroundColor DarkGray
+}
 
 $suffix = if ($SelfContained -eq 'true') { '' } else { '-frameworkdependent' }
 $artifactName = "SQLBI.Whiteboard.$Version.$Architecture$suffix"


### PR DESCRIPTION
The version lived in an Azure DevOps variable group, so releasing meant editing a value in a
portal with no review, no history, and no link to the commit it described. Decision 8 called
for moving it into the repository; this does that.

`VersionPrefix` in `Directory.Build.props` is now the single definition. The pipeline and
`scripts/build-installer.ps1` both read it with `dotnet msbuild -getProperty:VersionPrefix`
rather than restating it, so the two cannot disagree. Releasing starts with a pull request
that changes one line.

Two consequences in the pipeline. The version step moved after `UseDotNet` and `dotnet
restore`, because it now runs the SDK and previously ran before either was set up. And the
artifact name is computed in that step instead of being assembled in the matrix, since the
matrix can no longer reference version variables that do not exist until the step runs.

`AppVersionMajor`, `AppVersionMinor` and `AppVersionPatch` are now unused and can be deleted
from the `SQLBI.Whiteboard` variable group.

Verified locally: `build-installer.ps1` with no arguments reads 0.1.0 and produces the four
MSIs and the ZIP named accordingly.