### PR TITLE
Publish both channels to GitHub Releases

### DIFF
--- a/.azure/pipelines/build-whiteboard.yaml
+++ b/.azure/pipelines/build-whiteboard.yaml
@@ -1,9 +1,9 @@
-# Builds, signs, and packages SQLBI Whiteboard.
+# Builds, signs, packages, and publishes SQLBI Whiteboard.
 #
-# Produces per architecture and publish mode:
-#   - SQLBI.Whiteboard.<version>.<arch>.msi                 per-machine installer
-#   - SQLBI.Whiteboard.<version>.<arch>-userinstaller.msi   per-user installer, no elevation
-#   - SQLBI.Whiteboard.<version>.<arch>-portable.zip        no-install copy
+# Every merge to main publishes the pre-release channel to a GitHub prerelease. The same
+# run can then be promoted to a full release by approving the Release stage, which uploads
+# the released-channel installers that run already produced - nothing is rebuilt, so what
+# ships is what was tested. See docs/decisions.md, decisions 9 and 10.
 #
 # Both variable groups live in the 'SQLBI Whiteboard' Azure DevOps project. Signing is
 # kept in its own group so that group's Security can be restricted independently of the
@@ -15,7 +15,6 @@
 #     Whiteboard-specific service principal so access can be revoked on its own.
 #
 #   SQLBI.Whiteboard
-#     AzureSubscriptionName, AzurePublishStorageAccountName, AzurePublishStorageContainerName
 #     AppInformationalVersionExtendedInfo  (optional, 'true' appends build and commit details)
 #
 # The version is not a pipeline variable: it comes from VersionPrefix in
@@ -31,33 +30,22 @@ parameters:
   displayName: Code sign the outputs
   type: boolean
   default: true
-# Bravo keeps this in a separate release pipeline. Here it is one pipeline with a switch:
-# leave it off for ordinary builds, turn it on for a release that needs a durable download URL.
-- name: publishToStorage
-  displayName: Copy artifacts to Azure Storage
-  type: boolean
-  default: false
 
-trigger: none
+# Documentation-only changes do not need a signed build.
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    exclude:
+    - docs/*
+    - .github/*
+    - '*.md'
 
 # Pull requests are validated by .github/workflows/pull-request.yml, unsigned. Without this,
 # Azure DevOps validates every pull request against a GitHub repository by default, which
 # would run a signed build over unreviewed code.
 pr: none
-
-pool:
-  vmImage: 'windows-latest'
-
-strategy:
-  matrix:
-    whiteboard-x64:
-      arch: 'x64'
-      selfcontained: 'true'
-      flavor: ''
-    whiteboard-x64-frameworkdependent:
-      arch: 'x64'
-      selfcontained: 'false'
-      flavor: '-frameworkdependent'
 
 variables:
 - group: 'SQLBI-CodeSigning'
@@ -73,194 +61,272 @@ variables:
 # Keep in step with the wix tool version pinned in .config/dotnet-tools.json.
 - name: wixVersion
   value: '5.0.2'
+- name: gitHubConnection
+  value: 'sql-bi write assets'
+- name: isMain
+  value: $[ eq(variables['Build.SourceBranch'], 'refs/heads/main') ]
 
-steps:
-- task: UseDotNet@2
-  displayName: 'Use .NET 8 SDK'
-  inputs:
-    packageType: sdk
-    version: '8.0.x'
-
-- script: dotnet restore "$(csproj)" --runtime "win-$(arch)" --verbosity "${{ parameters.verbosity }}"
-  displayName: 'dotnet restore'
-
-- task: PowerShell@2
-  displayName: 'Set version variables'
-  inputs:
-    targetType: 'inline'
-    script: |
-      # Pipeline variables are read from the environment rather than interpolated into this
-      # script. An undefined $(Name) macro is left verbatim, and PowerShell then treats
-      # "$(Name)" as a subexpression and tries to run Name as a command.
-      $extendedInfo = $env:APP_INFORMATIONAL_VERSION_EXTENDED_INFO
-
-      # The product version comes from VersionPrefix in Directory.Build.props, so it is
-      # reviewed in a pull request rather than edited in a variable group.
-      $semVer = (dotnet msbuild "$env:PROJECT_FILE" -getProperty:VersionPrefix --nologo).Trim()
-      if ($semVer -notmatch '^\d+\.\d+\.\d+$') {
-          throw "VersionPrefix in Directory.Build.props must be major.minor.patch, but reads '$semVer'."
-      }
-      $semVerParts = $semVer.Split('.')
-
-      # Built with -f rather than interpolation: in "$env:BUILD_BUILDID?api-version=1"
-      # PowerShell reads '?' as part of the variable name and the id disappears.
-      # The build start time comes from the server so every matrix job stamps the same version.
-      $url = '{0}{1}/_apis/build/builds/{2}?api-version=7.1' -f $env:SYSTEM_COLLECTIONURI, $env:SYSTEM_TEAMPROJECTID, $env:BUILD_BUILDID
-      try {
-          $build = Invoke-RestMethod -Uri $url -Headers @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" } -Method Get -ErrorAction Stop
-      }
-      catch {
-          throw "Could not read build details from $url - $($_.Exception.Message)"
-      }
-      $buildTime = [datetime]$build.startTime
-      $buildNumberRevision = $build.buildNumberRevision
-      $midnightTime = (Get-Date -Year $buildTime.Year -Month $buildTime.Month -Day $buildTime.Day -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
-      # Build Number - number of days since 2000-01-01 (same algorithm as msbuild)
-      $versionBuild = (New-TimeSpan -Start ([datetime]"2000-01-01") -End $buildTime).Days
-      # Revision - number of seconds since midnight divided by 2 (same algorithm as msbuild)
-      $versionRevision = [math]::Round((New-TimeSpan -Start $midnightTime -End $buildTime).TotalSeconds / 2)
-      $buildNumber = '{0:yyyyMMdd}.{1}' -f $buildTime, $buildNumberRevision
-      $storagePath = '{0:yyyy}/{0:MM}/{0:dd}' -f $buildTime
-      $versionNumber = '{0}.{1}.{2}.{3}' -f $semVerParts[0], $semVerParts[1], $versionBuild, $versionRevision
-      $informationalVersion = $semVer
-      $artifact = 'SQLBI.Whiteboard.{0}.{1}{2}' -f $semVer, $env:MATRIX_ARCH, $env:MATRIX_FLAVOR
-      if ($extendedInfo -eq 'true') {
-          $informationalVersion += '-{0}-{1}-{2}-{3}' -f $buildNumber, $versionNumber, $env:BUILD_SOURCEBRANCHNAME, $env:BUILD_SOURCEVERSION
-      }
-      Write-Host "##vso[task.setvariable variable=artifact;]$artifact"
-      Write-Host "##vso[task.setvariable variable=AppSemVer;]$semVer"
-      Write-Host "##vso[task.setvariable variable=AzurePublishStoragePath;]$storagePath"
-      Write-Host "##vso[task.setvariable variable=AppBuildNumber;]$buildNumber"
-      Write-Host "##vso[task.setvariable variable=AppVersionNumber;]$versionNumber"
-      Write-Host "##vso[task.setvariable variable=AppInformationalVersion;]$informationalVersion"
-      Write-Host "##vso[build.updatebuildnumber]$buildNumber-$versionNumber"
-      Write-Host "Version is $semVer, assembly version $versionNumber"
-      Write-Host "Artifact is $artifact"
-  env:
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    PROJECT_FILE: $(csproj)
-    MATRIX_ARCH: $(arch)
-    MATRIX_FLAVOR: $(flavor)
-    # Optional; an undefined macro arrives here as a harmless literal string.
-    APP_INFORMATIONAL_VERSION_EXTENDED_INFO: $(AppInformationalVersionExtendedInfo)
-
-- script: >-
-    dotnet publish "$(csproj)"
-    --configuration "$(configuration)"
-    --no-restore
-    --runtime "win-$(arch)"
-    --self-contained "$(selfcontained)"
-    --output "$(Build.BinariesDirectory)"
-    --verbosity "${{ parameters.verbosity }}"
-    -p:Version="$(AppVersionNumber)"
-    -p:InformationalVersion="$(AppInformationalVersion)"
-    -p:ContinuousIntegrationBuild=true
-    -p:DebugType=none
-  displayName: 'dotnet publish'
-
-- ${{ if parameters.sign }}:
-  - script: dotnet tool install --global AzureSignTool
-    displayName: 'Install AzureSignTool'
-
-  # Signed before packaging so the MSI and the ZIP both carry the signed binaries.
-  - task: CmdLine@2
-    displayName: 'Code signing application binaries'
+stages:
+- stage: Build
+  displayName: Build and package
+  jobs:
+  - job: Package
+    pool:
+      vmImage: 'windows-latest'
+    strategy:
+      matrix:
+        whiteboard-x64:
+          arch: 'x64'
+          selfcontained: 'true'
+          flavor: ''
+        whiteboard-x64-frameworkdependent:
+          arch: 'x64'
+          selfcontained: 'false'
+          flavor: '-frameworkdependent'
+    steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET 8 SDK'
     inputs:
-      script: >-
-        AzureSignTool sign
-        -kvu "$(SigningVaultURL)"
-        -kvt "$(SigningTenantId)"
-        -kvi "$(SigningClientId)"
-        -kvs "$(SigningClientSecret)"
-        -kvc "$(SigningCertName)"
-        -tr "$(timestampUrl)"
-        -v
-        "$(Build.BinariesDirectory)\SQLBI.Whiteboard.exe"
-        "$(Build.BinariesDirectory)\SQLBI.Whiteboard.Core.dll"
-        "$(Build.BinariesDirectory)\SQLBI.Whiteboard.Dax.dll"
-        "$(Build.BinariesDirectory)\SQLBI.Whiteboard.SqlServer.dll"
-      failOnStderr: true
+      packageType: sdk
+      version: '8.0.x'
 
-- script: dotnet tool restore
-  displayName: 'Restore the pinned WiX toolset'
-  workingDirectory: '$(Build.SourcesDirectory)'
+  - script: dotnet restore "$(csproj)" --runtime "win-$(arch)" --verbosity "${{ parameters.verbosity }}"
+    displayName: 'dotnet restore'
 
-# WiX extensions are per-machine state, not part of the tool manifest, so a fresh
-# hosted agent has none. Adding an extension that is already present is a no-op.
-- script: >-
-    dotnet wix extension add -g WixToolset.UI.wixext/$(wixVersion)
-    && dotnet wix extension add -g WixToolset.Util.wixext/$(wixVersion)
-    && dotnet wix extension list -g
-  displayName: 'Add the WiX extensions'
-  workingDirectory: '$(Build.SourcesDirectory)'
-
-- script: >-
-    dotnet wix build "$(installerRoot)/SQLBI.Whiteboard.wxs"
-    -arch "$(arch)"
-    -d Scope=perMachine
-    -d "PublishFolder=$(Build.BinariesDirectory)"
-    -d "AssetsFolder=$(installerRoot)/assets"
-    -ext WixToolset.UI.wixext
-    -ext WixToolset.Util.wixext
-    -culture en-us
-    -loc "$(installerRoot)/SQLBI.Whiteboard.en-us.wxl"
-    -pdbtype none
-    -out "$(Build.ArtifactStagingDirectory)/$(artifact).msi"
-  displayName: 'WiX build MSI (per-machine)'
-  workingDirectory: '$(Build.SourcesDirectory)'
-
-- script: >-
-    dotnet wix build "$(installerRoot)/SQLBI.Whiteboard.wxs"
-    -arch "$(arch)"
-    -d Scope=perUser
-    -d "PublishFolder=$(Build.BinariesDirectory)"
-    -d "AssetsFolder=$(installerRoot)/assets"
-    -ext WixToolset.UI.wixext
-    -ext WixToolset.Util.wixext
-    -culture en-us
-    -loc "$(installerRoot)/SQLBI.Whiteboard.en-us.wxl"
-    -pdbtype none
-    -out "$(Build.ArtifactStagingDirectory)/$(artifact)-userinstaller.msi"
-  displayName: 'WiX build MSI (per-user)'
-  workingDirectory: '$(Build.SourcesDirectory)'
-
-- ${{ if parameters.sign }}:
-  - task: CmdLine@2
-    displayName: 'Code signing MSI packages'
+  - task: PowerShell@2
+    displayName: 'Set version variables'
     inputs:
-      script: >-
-        AzureSignTool sign
-        -kvu "$(SigningVaultURL)"
-        -kvt "$(SigningTenantId)"
-        -kvi "$(SigningClientId)"
-        -kvs "$(SigningClientSecret)"
-        -kvc "$(SigningCertName)"
-        -tr "$(timestampUrl)"
-        -v
-        "$(Build.ArtifactStagingDirectory)\$(artifact).msi"
-        "$(Build.ArtifactStagingDirectory)\$(artifact)-userinstaller.msi"
-      failOnStderr: true
+      targetType: 'inline'
+      script: |
+        # Pipeline variables are read from the environment rather than interpolated into this
+        # script. An undefined $(Name) macro is left verbatim, and PowerShell then treats
+        # "$(Name)" as a subexpression and tries to run Name as a command.
+        $extendedInfo = $env:APP_INFORMATIONAL_VERSION_EXTENDED_INFO
 
-- task: ArchiveFiles@2
-  displayName: 'Portable ZIP archive'
-  inputs:
-    rootFolderOrFile: '$(Build.BinariesDirectory)'
-    includeRootFolder: false
-    archiveType: 'zip'
-    archiveFile: '$(Build.ArtifactStagingDirectory)/$(artifact)-portable.zip'
-    replaceExistingArchive: true
+        # The product version comes from VersionPrefix in Directory.Build.props, so it is
+        # reviewed in a pull request rather than edited in a variable group.
+        $semVer = (dotnet msbuild "$env:PROJECT_FILE" -getProperty:VersionPrefix --nologo).Trim()
+        if ($semVer -notmatch '^\d+\.\d+\.\d+$') {
+            throw "VersionPrefix in Directory.Build.props must be major.minor.patch, but reads '$semVer'."
+        }
+        $semVerParts = $semVer.Split('.')
 
-- publish: '$(Build.ArtifactStagingDirectory)'
-  displayName: 'Publish artifacts to the pipeline'
-  artifact: 'drop-$(arch)-$(selfcontained)'
+        # Built with -f rather than interpolation: in "$env:BUILD_BUILDID?api-version=1"
+        # PowerShell reads '?' as part of the variable name and the id disappears.
+        # The build start time comes from the server so every matrix job stamps the same version.
+        $url = '{0}{1}/_apis/build/builds/{2}?api-version=7.1' -f $env:SYSTEM_COLLECTIONURI, $env:SYSTEM_TEAMPROJECTID, $env:BUILD_BUILDID
+        try {
+            $build = Invoke-RestMethod -Uri $url -Headers @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" } -Method Get -ErrorAction Stop
+        }
+        catch {
+            throw "Could not read build details from $url - $($_.Exception.Message)"
+        }
+        $buildTime = [datetime]$build.startTime
+        $buildNumberRevision = $build.buildNumberRevision
+        $midnightTime = (Get-Date -Year $buildTime.Year -Month $buildTime.Month -Day $buildTime.Day -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
+        # Build Number - number of days since 2000-01-01 (same algorithm as msbuild)
+        $versionBuild = (New-TimeSpan -Start ([datetime]"2000-01-01") -End $buildTime).Days
+        # Revision - number of seconds since midnight divided by 2 (same algorithm as msbuild)
+        $versionRevision = [math]::Round((New-TimeSpan -Start $midnightTime -End $buildTime).TotalSeconds / 2)
+        $buildNumber = '{0:yyyyMMdd}.{1}' -f $buildTime, $buildNumberRevision
+        $versionNumber = '{0}.{1}.{2}.{3}' -f $semVerParts[0], $semVerParts[1], $versionBuild, $versionRevision
+        $informationalVersion = $semVer
+        $artifact = 'SQLBI.Whiteboard.{0}.{1}{2}' -f $semVer, $env:MATRIX_ARCH, $env:MATRIX_FLAVOR
+        if ($extendedInfo -eq 'true') {
+            $informationalVersion += '-{0}-{1}-{2}-{3}' -f $buildNumber, $versionNumber, $env:BUILD_SOURCEBRANCHNAME, $env:BUILD_SOURCEVERSION
+        }
+        Write-Host "##vso[task.setvariable variable=artifact;]$artifact"
+        Write-Host "##vso[task.setvariable variable=AppSemVer;]$semVer"
+        Write-Host "##vso[task.setvariable variable=AppBuildNumber;]$buildNumber"
+        Write-Host "##vso[task.setvariable variable=AppVersionNumber;]$versionNumber"
+        Write-Host "##vso[task.setvariable variable=AppInformationalVersion;]$informationalVersion"
+        Write-Host "##vso[build.updatebuildnumber]$buildNumber-$versionNumber"
+        Write-Host "Version is $semVer, assembly version $versionNumber"
+        Write-Host "Artifact is $artifact"
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      PROJECT_FILE: $(csproj)
+      MATRIX_ARCH: $(arch)
+      MATRIX_FLAVOR: $(flavor)
+      # Optional; an undefined macro arrives here as a harmless literal string.
+      APP_INFORMATIONAL_VERSION_EXTENDED_INFO: $(AppInformationalVersionExtendedInfo)
 
-- ${{ if parameters.publishToStorage }}:
-  - task: AzureFileCopy@6
-    displayName: 'Copy artifacts to Azure Storage'
+  - script: >-
+      dotnet publish "$(csproj)"
+      --configuration "$(configuration)"
+      --no-restore
+      --runtime "win-$(arch)"
+      --self-contained "$(selfcontained)"
+      --output "$(Build.BinariesDirectory)"
+      --verbosity "${{ parameters.verbosity }}"
+      -p:Version="$(AppVersionNumber)"
+      -p:InformationalVersion="$(AppInformationalVersion)"
+      -p:ContinuousIntegrationBuild=true
+      -p:DebugType=none
+    displayName: 'dotnet publish'
+
+  - ${{ if parameters.sign }}:
+    - script: dotnet tool install --global AzureSignTool
+      displayName: 'Install AzureSignTool'
+
+    # Signed before packaging so the MSI and the ZIP both carry the signed binaries.
+    - task: CmdLine@2
+      displayName: 'Code signing application binaries'
+      inputs:
+        script: >-
+          AzureSignTool sign
+          -kvu "$(SigningVaultURL)"
+          -kvt "$(SigningTenantId)"
+          -kvi "$(SigningClientId)"
+          -kvs "$(SigningClientSecret)"
+          -kvc "$(SigningCertName)"
+          -tr "$(timestampUrl)"
+          -v
+          "$(Build.BinariesDirectory)\SQLBI.Whiteboard.exe"
+          "$(Build.BinariesDirectory)\SQLBI.Whiteboard.Core.dll"
+          "$(Build.BinariesDirectory)\SQLBI.Whiteboard.Dax.dll"
+          "$(Build.BinariesDirectory)\SQLBI.Whiteboard.SqlServer.dll"
+        failOnStderr: true
+
+  - script: dotnet tool restore
+    displayName: 'Restore the pinned WiX toolset'
+    workingDirectory: '$(Build.SourcesDirectory)'
+
+  # WiX extensions are per-machine state, not part of the tool manifest, so a fresh
+  # hosted agent has none. Adding an extension that is already present is a no-op.
+  - script: >-
+      dotnet wix extension add -g WixToolset.UI.wixext/$(wixVersion)
+      && dotnet wix extension add -g WixToolset.Util.wixext/$(wixVersion)
+      && dotnet wix extension list -g
+    displayName: 'Add the WiX extensions'
+    workingDirectory: '$(Build.SourcesDirectory)'
+
+  # The same script the pull request validation runs, packaging the binaries signed above
+  # rather than publishing its own. Sharing one code path is why the pipeline no longer
+  # invokes wix directly: the two drifted apart the last time the authoring gained a
+  # preprocessor variable.
+  - task: PowerShell@2
+    displayName: 'Build installers'
     inputs:
-      SourcePath: '$(Build.ArtifactStagingDirectory)'
-      azureSubscription: '$(AzureSubscriptionName)'
-      Destination: 'AzureBlob'
-      storage: '$(AzurePublishStorageAccountName)'
-      ContainerName: '$(AzurePublishStorageContainerName)'
-      BlobPrefix: '$(AzurePublishStoragePath)/$(Build.BuildNumber)'
+      filePath: '$(Build.SourcesDirectory)/scripts/build-installer.ps1'
+      arguments: >-
+        -Version "$(AppSemVer)"
+        -Architecture "$(arch)"
+        -SelfContained "$(selfcontained)"
+        -PublishFolder "$(Build.BinariesDirectory)"
+        -OutputFolder "$(Build.ArtifactStagingDirectory)"
+      workingDirectory: '$(Build.SourcesDirectory)'
+      pwsh: true
+
+  - ${{ if parameters.sign }}:
+    - task: PowerShell@2
+      displayName: 'Code signing MSI packages'
+      inputs:
+        targetType: 'inline'
+        pwsh: true
+        script: |
+          $packages = Get-ChildItem "$env:STAGING\*.msi" | ForEach-Object { $_.FullName }
+          if (-not $packages) { throw "No MSI packages found in $env:STAGING" }
+          AzureSignTool sign `
+            -kvu $env:VAULT_URL -kvt $env:TENANT_ID -kvi $env:CLIENT_ID `
+            -kvs $env:CLIENT_SECRET -kvc $env:CERT_NAME `
+            -tr $env:TIMESTAMP_URL -v @packages
+          if ($LASTEXITCODE -ne 0) { throw "Signing failed with exit code $LASTEXITCODE" }
+      env:
+        STAGING: $(Build.ArtifactStagingDirectory)
+        VAULT_URL: $(SigningVaultURL)
+        TENANT_ID: $(SigningTenantId)
+        CLIENT_ID: $(SigningClientId)
+        CLIENT_SECRET: $(SigningClientSecret)
+        CERT_NAME: $(SigningCertName)
+        TIMESTAMP_URL: $(timestampUrl)
+
+  - publish: '$(Build.ArtifactStagingDirectory)'
+    displayName: 'Publish artifacts to the pipeline'
+    artifact: 'drop-$(arch)-$(selfcontained)'
+
+# Both publishing stages read the version from the repository rather than carrying it
+# across stage boundaries, which is possible because Directory.Build.props is the single
+# definition (decision 8).
+- stage: PreRelease
+  displayName: Publish pre-release
+  dependsOn: Build
+  condition: and(succeeded(), eq(variables.isMain, true))
+  jobs:
+  - job: Publish
+    displayName: Publish to a GitHub prerelease
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - checkout: self
+    - download: current
+      displayName: 'Download the packaged artifacts'
+
+    - template: templates/collect-release-assets.yml
+      parameters:
+        channel: dev
+
+    - task: GitHubRelease@1
+      displayName: 'Create the GitHub prerelease'
+      inputs:
+        gitHubConnection: '$(gitHubConnection)'
+        repositoryName: '$(Build.Repository.Name)'
+        action: create
+        target: '$(Build.SourceVersion)'
+        tagSource: userSpecified
+        # Unique per run, so successive pre-releases of one version do not collide.
+        tag: 'v$(AppSemVer)-dev.$(Build.BuildId)'
+        title: 'SQLBI Whiteboard $(AppSemVer) (dev $(Build.BuildId))'
+        releaseNotesSource: inline
+        releaseNotes: |
+          Pre-release build of SQLBI Whiteboard $(AppSemVer).
+
+          Installs alongside a released copy as **SQLBI Whiteboard (Dev)**, with its own
+          settings, and does not take over the `.wboard` file type.
+        assets: '$(Build.ArtifactStagingDirectory)/release/*'
+        isPreRelease: true
+        addChangeLog: true
+
+- stage: Release
+  displayName: Promote to released
+  dependsOn: Build
+  condition: and(succeeded(), eq(variables.isMain, true))
+  jobs:
+  - deployment: Promote
+    displayName: Publish the released channel
+    # The approvals configured on this environment are the promotion gate. If the
+    # environment does not exist Azure DevOps creates one silently, and an auto-created
+    # environment has no approvals - so confirm the name matches before trusting the gate.
+    environment: whiteboard-release
+    pool:
+      vmImage: 'ubuntu-latest'
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - checkout: self
+          - download: current
+            displayName: 'Download the packaged artifacts'
+
+          - template: templates/collect-release-assets.yml
+            parameters:
+              channel: stable
+
+          - task: GitHubRelease@1
+            displayName: 'Create the GitHub release'
+            inputs:
+              gitHubConnection: '$(gitHubConnection)'
+              repositoryName: '$(Build.Repository.Name)'
+              action: create
+              target: '$(Build.SourceVersion)'
+              tagSource: userSpecified
+              # Fails if the tag exists, which is the intended guard against releasing the
+              # same version twice: bump VersionPrefix instead.
+              tag: 'v$(AppSemVer)'
+              title: 'SQLBI Whiteboard $(AppSemVer)'
+              releaseNotesSource: inline
+              releaseNotes: |
+                SQLBI Whiteboard $(AppSemVer).
+              assets: '$(Build.ArtifactStagingDirectory)/release/*'
+              isPreRelease: false
+              addChangeLog: true

--- a/.azure/pipelines/templates/collect-release-assets.yml
+++ b/.azure/pipelines/templates/collect-release-assets.yml
@@ -1,0 +1,54 @@
+# Gathers the assets belonging to one channel from the artifacts the Build stage produced,
+# and reads the version from the repository so no variable has to cross a stage boundary.
+#
+# The released and pre-release installers come out of the same build, so promoting a build
+# is a matter of uploading the other half of what it already produced.
+
+parameters:
+- name: channel
+  type: string
+  values: [stable, dev]
+
+steps:
+- task: PowerShell@2
+  displayName: 'Collect ${{ parameters.channel }} assets'
+  inputs:
+    targetType: 'inline'
+    pwsh: true
+    script: |
+      $ErrorActionPreference = 'Stop'
+      Set-StrictMode -Version Latest
+
+      $semVer = (dotnet msbuild "$env:PROJECT_FILE" -getProperty:VersionPrefix --nologo).Trim()
+      if ($semVer -notmatch '^\d+\.\d+\.\d+$') {
+          throw "VersionPrefix in Directory.Build.props must be major.minor.patch, but reads '$semVer'."
+      }
+      Write-Host "##vso[task.setvariable variable=AppSemVer;]$semVer"
+
+      $destination = Join-Path $env:STAGING 'release'
+      New-Item -ItemType Directory -Path $destination -Force | Out-Null
+
+      # Installer names carry '-dev' for the pre-release channel and nothing for the
+      # released one. The portable ZIP has no channel: the binaries are identical.
+      $wantsDev = '${{ parameters.channel }}' -eq 'dev'
+      $installers = Get-ChildItem -Path $env:ARTIFACTS -Recurse -Filter '*.msi' |
+          Where-Object { ($_.Name -like '*-dev*') -eq $wantsDev }
+      $portable = Get-ChildItem -Path $env:ARTIFACTS -Recurse -Filter '*-portable.zip'
+
+      $assets = @($installers) + @($portable)
+      if (-not $assets) {
+          throw "No ${{ parameters.channel }} assets found under $env:ARTIFACTS."
+      }
+
+      foreach ($asset in $assets) {
+          Copy-Item $asset.FullName -Destination $destination -Force
+      }
+
+      Write-Host "Collected for ${{ parameters.channel }}:"
+      Get-ChildItem $destination | ForEach-Object {
+          '  {0,-52} {1,8:N1} MB' -f $_.Name, ($_.Length / 1MB)
+      }
+  env:
+    PROJECT_FILE: $(csproj)
+    STAGING: $(Build.ArtifactStagingDirectory)
+    ARTIFACTS: $(Pipeline.Workspace)

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -120,7 +120,10 @@ build time.
 
 ## 9. Promote artifacts, not commits
 
-**Agreed, not yet built.**
+**Implemented.** The pipeline has three stages: Build, PreRelease, and Release. PreRelease
+publishes automatically; Release is gated by approvals on the `whiteboard-release`
+environment and uploads the released-channel installers **that the same run already
+produced**.
 
 Rebuilding from a tagged commit ships bits that were never tested. Promotion instead
 publishes the already-built, already-signed artifacts from the run that was verified.
@@ -130,9 +133,8 @@ installers already exist when promotion happens.
 
 ## 10. GitHub Releases hosts the downloads
 
-**Agreed, not yet built.** The pipeline still carries a disabled `AzureFileCopy` step and a
-`publishToStorage` parameter from the superseded plan; both should be replaced by
-`GitHubRelease@1`.
+**Implemented.** `GitHubRelease@1` publishes both channels; the `AzureFileCopy` step and the
+`publishToStorage` parameter are gone, and no storage account is needed.
 
 The repository is public, so release assets are downloadable without authentication — this
 was the deciding factor, not cost. GitHub serves them from a CDN at no bandwidth cost, the
@@ -141,8 +143,8 @@ a permanent link the download page can hard-code, and winget reads the same sour
 
 No storage account, service connection, or blob RBAC is therefore needed.
 
-Creating a release requires a GitHub service connection with `contents: write`; the
-connection used to read source may not carry it.
+Creating a release requires a GitHub service connection with `contents: write`, separate
+from the one used to read source. It is named `sql-bi write assets`.
 
 ## 11. `main` is protected and every change arrives by pull request
 

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -93,7 +93,6 @@ Parameters:
 | --- | --- | --- |
 | `verbosity` | `normal` | MSBuild verbosity |
 | `sign` | on | Code sign binaries and MSIs |
-| `publishToStorage` | off | Superseded by GitHub Releases (decision 10) |
 
 Two variable groups supply its settings; both must be authorised for the pipeline before it
 can run. The signing group's contents are described in decision 1 and held by the
@@ -145,14 +144,10 @@ hand.
 
 Roughly in dependency order:
 
-1. Add a CI trigger to the Azure pipeline so `main` builds and signs on every merge.
-2. Replace the `AzureFileCopy` step with `GitHubRelease@1`, and create a GitHub service
-   connection with `contents: write`.
-3. Split the pipeline into Build / Pre-release / Release stages with an approval gate.
-4. Publish `stable.json` and `dev.json` manifests alongside the binaries, for the download
+1. Publish `stable.json` and `dev.json` manifests alongside the binaries, for the download
    page, a future in-app update check, and winget automation to share one source.
-5. Add winget submission triggered by a published release.
-6. MSIX packaging and Store submission (decision 13).
+2. Add winget submission triggered by a published release.
+3. MSIX packaging and Store submission (decision 13).
 
 ## Verification before a public release
 

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -16,7 +16,11 @@ param(
     [string] $Architecture = 'x64',
     [ValidateSet('true', 'false')]
     [string] $SelfContained = 'true',
-    [string] $Configuration = 'Release'
+    [string] $Configuration = 'Release',
+    # Supply an existing publish folder to package binaries that are already built, and
+    # signed. The build pipeline does this so signing happens between publish and packaging.
+    [string] $PublishFolder,
+    [string] $OutputFolder
 )
 
 $ErrorActionPreference = 'Stop'
@@ -25,8 +29,13 @@ Set-StrictMode -Version Latest
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $project = Join-Path $repoRoot 'src/SQLBI.Whiteboard/SQLBI.Whiteboard.csproj'
 $installerRoot = Join-Path $repoRoot 'installer/wix'
-$publishFolder = Join-Path $repoRoot 'artifacts/publish'
-$outputFolder = Join-Path $repoRoot 'artifacts/installer'
+$skipPublish = -not [string]::IsNullOrWhiteSpace($PublishFolder)
+$publishFolder = if ($skipPublish) { $PublishFolder } else { Join-Path $repoRoot 'artifacts/publish' }
+$outputFolder = if ([string]::IsNullOrWhiteSpace($OutputFolder)) {
+    Join-Path $repoRoot 'artifacts/installer'
+} else {
+    $OutputFolder
+}
 
 if ([string]::IsNullOrWhiteSpace($Version)) {
     $Version = (dotnet msbuild $project -getProperty:VersionPrefix --nologo).Trim()
@@ -40,23 +49,27 @@ $artifactName = "SQLBI.Whiteboard.$Version.$Architecture$suffix"
 # WiX v4 requires a four-part numeric version; the informational version keeps the semver string.
 $fileVersion = if ($Version -match '^\d+\.\d+\.\d+$') { "$Version.0" } else { $Version }
 
+if (-not $skipPublish -and (Test-Path $publishFolder)) { Remove-Item $publishFolder -Recurse -Force }
 foreach ($folder in @($publishFolder, $outputFolder)) {
-    if (Test-Path $folder) { Remove-Item $folder -Recurse -Force }
     New-Item -ItemType Directory -Path $folder -Force | Out-Null
 }
 
-Write-Host "==> dotnet publish ($Architecture, self-contained=$SelfContained)" -ForegroundColor Cyan
-dotnet publish $project `
-    --configuration $Configuration `
-    --runtime "win-$Architecture" `
-    --self-contained $SelfContained `
-    --output $publishFolder `
-    -p:Version=$fileVersion `
-    -p:InformationalVersion=$Version `
-    -p:ContinuousIntegrationBuild=true `
-    -p:DebugType=none `
-    --nologo
-if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed with exit code $LASTEXITCODE" }
+if ($skipPublish) {
+    Write-Host "==> Packaging the existing publish folder $publishFolder" -ForegroundColor Cyan
+} else {
+    Write-Host "==> dotnet publish ($Architecture, self-contained=$SelfContained)" -ForegroundColor Cyan
+    dotnet publish $project `
+        --configuration $Configuration `
+        --runtime "win-$Architecture" `
+        --self-contained $SelfContained `
+        --output $publishFolder `
+        -p:Version=$fileVersion `
+        -p:InformationalVersion=$Version `
+        -p:ContinuousIntegrationBuild=true `
+        -p:DebugType=none `
+        --nologo
+    if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed with exit code $LASTEXITCODE" }
+}
 
 Write-Host '==> Restoring the WiX tool' -ForegroundColor Cyan
 Push-Location $repoRoot


### PR DESCRIPTION
Completes the release design: every merge to `main` publishes a pre-release, and approving
one stage promotes that same build to a release.

**Three stages.** Build compiles, signs, and packages. PreRelease runs automatically on
`main` and publishes the pre-release installers to a GitHub prerelease tagged
`v<version>-dev.<build id>`. Release waits on approvals configured on the
`whiteboard-release` environment, then publishes the released-channel installers **from the
same run** — nothing is rebuilt, so what ships is what was tested (decision 9).

Neither publishing stage carries a variable across a stage boundary: both re-read the
version from `Directory.Build.props`, which is possible now that the repository is its
single definition.

**A bug this fixes.** Adding the `Channel` preprocessor variable to the WiX authoring
updated `build-installer.ps1` but not the pipeline, which still invoked `wix build` without
it. The pipeline would have failed on its next run. Rather than patch the duplicate, the
pipeline now calls the same script the pull request validation already exercises, so the
two cannot drift again. The script gained `-PublishFolder` and `-OutputFolder` so the
pipeline can sign between publishing and packaging.

**Removed.** The `AzureFileCopy` step, the `publishToStorage` parameter, and the
`AzurePublishStoragePath` variable, superseded by GitHub Releases (decision 10). No storage
account is needed.

The trigger excludes `docs/`, `.github/` and `*.md`, so documentation changes do not consume
a signed build.

Verified locally: the exact script invocation the pipeline uses packages a pre-built publish
folder into all four MSIs plus the ZIP, and the channel asset filter selects the right three
files for each channel.