### PR TITLE
Fix step indentation inside the Build stage

### DIFF
--- a/.azure/pipelines/build-whiteboard.yaml
+++ b/.azure/pipelines/build-whiteboard.yaml
@@ -84,166 +84,166 @@ stages:
           selfcontained: 'false'
           flavor: '-frameworkdependent'
     steps:
-  - task: UseDotNet@2
-    displayName: 'Use .NET 8 SDK'
-    inputs:
-      packageType: sdk
-      version: '8.0.x'
-
-  - script: dotnet restore "$(csproj)" --runtime "win-$(arch)" --verbosity "${{ parameters.verbosity }}"
-    displayName: 'dotnet restore'
-
-  - task: PowerShell@2
-    displayName: 'Set version variables'
-    inputs:
-      targetType: 'inline'
-      script: |
-        # Pipeline variables are read from the environment rather than interpolated into this
-        # script. An undefined $(Name) macro is left verbatim, and PowerShell then treats
-        # "$(Name)" as a subexpression and tries to run Name as a command.
-        $extendedInfo = $env:APP_INFORMATIONAL_VERSION_EXTENDED_INFO
-
-        # The product version comes from VersionPrefix in Directory.Build.props, so it is
-        # reviewed in a pull request rather than edited in a variable group.
-        $semVer = (dotnet msbuild "$env:PROJECT_FILE" -getProperty:VersionPrefix --nologo).Trim()
-        if ($semVer -notmatch '^\d+\.\d+\.\d+$') {
-            throw "VersionPrefix in Directory.Build.props must be major.minor.patch, but reads '$semVer'."
-        }
-        $semVerParts = $semVer.Split('.')
-
-        # Built with -f rather than interpolation: in "$env:BUILD_BUILDID?api-version=1"
-        # PowerShell reads '?' as part of the variable name and the id disappears.
-        # The build start time comes from the server so every matrix job stamps the same version.
-        $url = '{0}{1}/_apis/build/builds/{2}?api-version=7.1' -f $env:SYSTEM_COLLECTIONURI, $env:SYSTEM_TEAMPROJECTID, $env:BUILD_BUILDID
-        try {
-            $build = Invoke-RestMethod -Uri $url -Headers @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" } -Method Get -ErrorAction Stop
-        }
-        catch {
-            throw "Could not read build details from $url - $($_.Exception.Message)"
-        }
-        $buildTime = [datetime]$build.startTime
-        $buildNumberRevision = $build.buildNumberRevision
-        $midnightTime = (Get-Date -Year $buildTime.Year -Month $buildTime.Month -Day $buildTime.Day -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
-        # Build Number - number of days since 2000-01-01 (same algorithm as msbuild)
-        $versionBuild = (New-TimeSpan -Start ([datetime]"2000-01-01") -End $buildTime).Days
-        # Revision - number of seconds since midnight divided by 2 (same algorithm as msbuild)
-        $versionRevision = [math]::Round((New-TimeSpan -Start $midnightTime -End $buildTime).TotalSeconds / 2)
-        $buildNumber = '{0:yyyyMMdd}.{1}' -f $buildTime, $buildNumberRevision
-        $versionNumber = '{0}.{1}.{2}.{3}' -f $semVerParts[0], $semVerParts[1], $versionBuild, $versionRevision
-        $informationalVersion = $semVer
-        $artifact = 'SQLBI.Whiteboard.{0}.{1}{2}' -f $semVer, $env:MATRIX_ARCH, $env:MATRIX_FLAVOR
-        if ($extendedInfo -eq 'true') {
-            $informationalVersion += '-{0}-{1}-{2}-{3}' -f $buildNumber, $versionNumber, $env:BUILD_SOURCEBRANCHNAME, $env:BUILD_SOURCEVERSION
-        }
-        Write-Host "##vso[task.setvariable variable=artifact;]$artifact"
-        Write-Host "##vso[task.setvariable variable=AppSemVer;]$semVer"
-        Write-Host "##vso[task.setvariable variable=AppBuildNumber;]$buildNumber"
-        Write-Host "##vso[task.setvariable variable=AppVersionNumber;]$versionNumber"
-        Write-Host "##vso[task.setvariable variable=AppInformationalVersion;]$informationalVersion"
-        Write-Host "##vso[build.updatebuildnumber]$buildNumber-$versionNumber"
-        Write-Host "Version is $semVer, assembly version $versionNumber"
-        Write-Host "Artifact is $artifact"
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      PROJECT_FILE: $(csproj)
-      MATRIX_ARCH: $(arch)
-      MATRIX_FLAVOR: $(flavor)
-      # Optional; an undefined macro arrives here as a harmless literal string.
-      APP_INFORMATIONAL_VERSION_EXTENDED_INFO: $(AppInformationalVersionExtendedInfo)
-
-  - script: >-
-      dotnet publish "$(csproj)"
-      --configuration "$(configuration)"
-      --no-restore
-      --runtime "win-$(arch)"
-      --self-contained "$(selfcontained)"
-      --output "$(Build.BinariesDirectory)"
-      --verbosity "${{ parameters.verbosity }}"
-      -p:Version="$(AppVersionNumber)"
-      -p:InformationalVersion="$(AppInformationalVersion)"
-      -p:ContinuousIntegrationBuild=true
-      -p:DebugType=none
-    displayName: 'dotnet publish'
-
-  - ${{ if parameters.sign }}:
-    - script: dotnet tool install --global AzureSignTool
-      displayName: 'Install AzureSignTool'
-
-    # Signed before packaging so the MSI and the ZIP both carry the signed binaries.
-    - task: CmdLine@2
-      displayName: 'Code signing application binaries'
+    - task: UseDotNet@2
+      displayName: 'Use .NET 8 SDK'
       inputs:
-        script: >-
-          AzureSignTool sign
-          -kvu "$(SigningVaultURL)"
-          -kvt "$(SigningTenantId)"
-          -kvi "$(SigningClientId)"
-          -kvs "$(SigningClientSecret)"
-          -kvc "$(SigningCertName)"
-          -tr "$(timestampUrl)"
-          -v
-          "$(Build.BinariesDirectory)\SQLBI.Whiteboard.exe"
-          "$(Build.BinariesDirectory)\SQLBI.Whiteboard.Core.dll"
-          "$(Build.BinariesDirectory)\SQLBI.Whiteboard.Dax.dll"
-          "$(Build.BinariesDirectory)\SQLBI.Whiteboard.SqlServer.dll"
-        failOnStderr: true
+        packageType: sdk
+        version: '8.0.x'
 
-  - script: dotnet tool restore
-    displayName: 'Restore the pinned WiX toolset'
-    workingDirectory: '$(Build.SourcesDirectory)'
+    - script: dotnet restore "$(csproj)" --runtime "win-$(arch)" --verbosity "${{ parameters.verbosity }}"
+      displayName: 'dotnet restore'
 
-  # WiX extensions are per-machine state, not part of the tool manifest, so a fresh
-  # hosted agent has none. Adding an extension that is already present is a no-op.
-  - script: >-
-      dotnet wix extension add -g WixToolset.UI.wixext/$(wixVersion)
-      && dotnet wix extension add -g WixToolset.Util.wixext/$(wixVersion)
-      && dotnet wix extension list -g
-    displayName: 'Add the WiX extensions'
-    workingDirectory: '$(Build.SourcesDirectory)'
-
-  # The same script the pull request validation runs, packaging the binaries signed above
-  # rather than publishing its own. Sharing one code path is why the pipeline no longer
-  # invokes wix directly: the two drifted apart the last time the authoring gained a
-  # preprocessor variable.
-  - task: PowerShell@2
-    displayName: 'Build installers'
-    inputs:
-      filePath: '$(Build.SourcesDirectory)/scripts/build-installer.ps1'
-      arguments: >-
-        -Version "$(AppSemVer)"
-        -Architecture "$(arch)"
-        -SelfContained "$(selfcontained)"
-        -PublishFolder "$(Build.BinariesDirectory)"
-        -OutputFolder "$(Build.ArtifactStagingDirectory)"
-      workingDirectory: '$(Build.SourcesDirectory)'
-      pwsh: true
-
-  - ${{ if parameters.sign }}:
     - task: PowerShell@2
-      displayName: 'Code signing MSI packages'
+      displayName: 'Set version variables'
       inputs:
         targetType: 'inline'
-        pwsh: true
         script: |
-          $packages = Get-ChildItem "$env:STAGING\*.msi" | ForEach-Object { $_.FullName }
-          if (-not $packages) { throw "No MSI packages found in $env:STAGING" }
-          AzureSignTool sign `
-            -kvu $env:VAULT_URL -kvt $env:TENANT_ID -kvi $env:CLIENT_ID `
-            -kvs $env:CLIENT_SECRET -kvc $env:CERT_NAME `
-            -tr $env:TIMESTAMP_URL -v @packages
-          if ($LASTEXITCODE -ne 0) { throw "Signing failed with exit code $LASTEXITCODE" }
-      env:
-        STAGING: $(Build.ArtifactStagingDirectory)
-        VAULT_URL: $(SigningVaultURL)
-        TENANT_ID: $(SigningTenantId)
-        CLIENT_ID: $(SigningClientId)
-        CLIENT_SECRET: $(SigningClientSecret)
-        CERT_NAME: $(SigningCertName)
-        TIMESTAMP_URL: $(timestampUrl)
+          # Pipeline variables are read from the environment rather than interpolated into this
+          # script. An undefined $(Name) macro is left verbatim, and PowerShell then treats
+          # "$(Name)" as a subexpression and tries to run Name as a command.
+          $extendedInfo = $env:APP_INFORMATIONAL_VERSION_EXTENDED_INFO
 
-  - publish: '$(Build.ArtifactStagingDirectory)'
-    displayName: 'Publish artifacts to the pipeline'
-    artifact: 'drop-$(arch)-$(selfcontained)'
+          # The product version comes from VersionPrefix in Directory.Build.props, so it is
+          # reviewed in a pull request rather than edited in a variable group.
+          $semVer = (dotnet msbuild "$env:PROJECT_FILE" -getProperty:VersionPrefix --nologo).Trim()
+          if ($semVer -notmatch '^\d+\.\d+\.\d+$') {
+              throw "VersionPrefix in Directory.Build.props must be major.minor.patch, but reads '$semVer'."
+          }
+          $semVerParts = $semVer.Split('.')
+
+          # Built with -f rather than interpolation: in "$env:BUILD_BUILDID?api-version=1"
+          # PowerShell reads '?' as part of the variable name and the id disappears.
+          # The build start time comes from the server so every matrix job stamps the same version.
+          $url = '{0}{1}/_apis/build/builds/{2}?api-version=7.1' -f $env:SYSTEM_COLLECTIONURI, $env:SYSTEM_TEAMPROJECTID, $env:BUILD_BUILDID
+          try {
+              $build = Invoke-RestMethod -Uri $url -Headers @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" } -Method Get -ErrorAction Stop
+          }
+          catch {
+              throw "Could not read build details from $url - $($_.Exception.Message)"
+          }
+          $buildTime = [datetime]$build.startTime
+          $buildNumberRevision = $build.buildNumberRevision
+          $midnightTime = (Get-Date -Year $buildTime.Year -Month $buildTime.Month -Day $buildTime.Day -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
+          # Build Number - number of days since 2000-01-01 (same algorithm as msbuild)
+          $versionBuild = (New-TimeSpan -Start ([datetime]"2000-01-01") -End $buildTime).Days
+          # Revision - number of seconds since midnight divided by 2 (same algorithm as msbuild)
+          $versionRevision = [math]::Round((New-TimeSpan -Start $midnightTime -End $buildTime).TotalSeconds / 2)
+          $buildNumber = '{0:yyyyMMdd}.{1}' -f $buildTime, $buildNumberRevision
+          $versionNumber = '{0}.{1}.{2}.{3}' -f $semVerParts[0], $semVerParts[1], $versionBuild, $versionRevision
+          $informationalVersion = $semVer
+          $artifact = 'SQLBI.Whiteboard.{0}.{1}{2}' -f $semVer, $env:MATRIX_ARCH, $env:MATRIX_FLAVOR
+          if ($extendedInfo -eq 'true') {
+              $informationalVersion += '-{0}-{1}-{2}-{3}' -f $buildNumber, $versionNumber, $env:BUILD_SOURCEBRANCHNAME, $env:BUILD_SOURCEVERSION
+          }
+          Write-Host "##vso[task.setvariable variable=artifact;]$artifact"
+          Write-Host "##vso[task.setvariable variable=AppSemVer;]$semVer"
+          Write-Host "##vso[task.setvariable variable=AppBuildNumber;]$buildNumber"
+          Write-Host "##vso[task.setvariable variable=AppVersionNumber;]$versionNumber"
+          Write-Host "##vso[task.setvariable variable=AppInformationalVersion;]$informationalVersion"
+          Write-Host "##vso[build.updatebuildnumber]$buildNumber-$versionNumber"
+          Write-Host "Version is $semVer, assembly version $versionNumber"
+          Write-Host "Artifact is $artifact"
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        PROJECT_FILE: $(csproj)
+        MATRIX_ARCH: $(arch)
+        MATRIX_FLAVOR: $(flavor)
+        # Optional; an undefined macro arrives here as a harmless literal string.
+        APP_INFORMATIONAL_VERSION_EXTENDED_INFO: $(AppInformationalVersionExtendedInfo)
+
+    - script: >-
+        dotnet publish "$(csproj)"
+        --configuration "$(configuration)"
+        --no-restore
+        --runtime "win-$(arch)"
+        --self-contained "$(selfcontained)"
+        --output "$(Build.BinariesDirectory)"
+        --verbosity "${{ parameters.verbosity }}"
+        -p:Version="$(AppVersionNumber)"
+        -p:InformationalVersion="$(AppInformationalVersion)"
+        -p:ContinuousIntegrationBuild=true
+        -p:DebugType=none
+      displayName: 'dotnet publish'
+
+    - ${{ if parameters.sign }}:
+      - script: dotnet tool install --global AzureSignTool
+        displayName: 'Install AzureSignTool'
+
+      # Signed before packaging so the MSI and the ZIP both carry the signed binaries.
+      - task: CmdLine@2
+        displayName: 'Code signing application binaries'
+        inputs:
+          script: >-
+            AzureSignTool sign
+            -kvu "$(SigningVaultURL)"
+            -kvt "$(SigningTenantId)"
+            -kvi "$(SigningClientId)"
+            -kvs "$(SigningClientSecret)"
+            -kvc "$(SigningCertName)"
+            -tr "$(timestampUrl)"
+            -v
+            "$(Build.BinariesDirectory)\SQLBI.Whiteboard.exe"
+            "$(Build.BinariesDirectory)\SQLBI.Whiteboard.Core.dll"
+            "$(Build.BinariesDirectory)\SQLBI.Whiteboard.Dax.dll"
+            "$(Build.BinariesDirectory)\SQLBI.Whiteboard.SqlServer.dll"
+          failOnStderr: true
+
+    - script: dotnet tool restore
+      displayName: 'Restore the pinned WiX toolset'
+      workingDirectory: '$(Build.SourcesDirectory)'
+
+    # WiX extensions are per-machine state, not part of the tool manifest, so a fresh
+    # hosted agent has none. Adding an extension that is already present is a no-op.
+    - script: >-
+        dotnet wix extension add -g WixToolset.UI.wixext/$(wixVersion)
+        && dotnet wix extension add -g WixToolset.Util.wixext/$(wixVersion)
+        && dotnet wix extension list -g
+      displayName: 'Add the WiX extensions'
+      workingDirectory: '$(Build.SourcesDirectory)'
+
+    # The same script the pull request validation runs, packaging the binaries signed above
+    # rather than publishing its own. Sharing one code path is why the pipeline no longer
+    # invokes wix directly: the two drifted apart the last time the authoring gained a
+    # preprocessor variable.
+    - task: PowerShell@2
+      displayName: 'Build installers'
+      inputs:
+        filePath: '$(Build.SourcesDirectory)/scripts/build-installer.ps1'
+        arguments: >-
+          -Version "$(AppSemVer)"
+          -Architecture "$(arch)"
+          -SelfContained "$(selfcontained)"
+          -PublishFolder "$(Build.BinariesDirectory)"
+          -OutputFolder "$(Build.ArtifactStagingDirectory)"
+        workingDirectory: '$(Build.SourcesDirectory)'
+        pwsh: true
+
+    - ${{ if parameters.sign }}:
+      - task: PowerShell@2
+        displayName: 'Code signing MSI packages'
+        inputs:
+          targetType: 'inline'
+          pwsh: true
+          script: |
+            $packages = Get-ChildItem "$env:STAGING\*.msi" | ForEach-Object { $_.FullName }
+            if (-not $packages) { throw "No MSI packages found in $env:STAGING" }
+            AzureSignTool sign `
+              -kvu $env:VAULT_URL -kvt $env:TENANT_ID -kvi $env:CLIENT_ID `
+              -kvs $env:CLIENT_SECRET -kvc $env:CERT_NAME `
+              -tr $env:TIMESTAMP_URL -v @packages
+            if ($LASTEXITCODE -ne 0) { throw "Signing failed with exit code $LASTEXITCODE" }
+        env:
+          STAGING: $(Build.ArtifactStagingDirectory)
+          VAULT_URL: $(SigningVaultURL)
+          TENANT_ID: $(SigningTenantId)
+          CLIENT_ID: $(SigningClientId)
+          CLIENT_SECRET: $(SigningClientSecret)
+          CERT_NAME: $(SigningCertName)
+          TIMESTAMP_URL: $(timestampUrl)
+
+    - publish: '$(Build.ArtifactStagingDirectory)'
+      displayName: 'Publish artifacts to the pipeline'
+      artifact: 'drop-$(arch)-$(selfcontained)'
 
 # Both publishing stages read the version from the repository rather than carrying it
 # across stage boundaries, which is possible because Directory.Build.props is the single


### PR DESCRIPTION
Run 3205 failed before any job started: `Unexpected value 'task'` and eight similar errors.
When the existing steps were moved inside a job for the staged pipeline they were indented by
one level instead of two, so the step list sat at the job's own indentation rather than under
`steps:`.

Validated by having Azure DevOps compile it, through the pipeline preview API, rather than by
parsing the YAML locally — a local parse accepts this file happily, which is why the error
reached `main`.