### PR TITLE
Use exact paths in the trigger path filters

### DIFF
--- a/.azure/pipelines/build-whiteboard.yaml
+++ b/.azure/pipelines/build-whiteboard.yaml
@@ -31,16 +31,21 @@ parameters:
   type: boolean
   default: true
 
-# Documentation-only changes do not need a signed build.
+# Documentation-only changes do not need a signed build. Path filters are prefixes, not
+# globs: Azure DevOps supports wildcards in branch and tag filters but not in path filters,
+# so every entry here names a directory or a file exactly.
 trigger:
   branches:
     include:
     - main
   paths:
     exclude:
-    - docs/*
-    - .github/*
-    - '*.md'
+    - docs
+    - .github
+    - README.md
+    - CONTRIBUTING.md
+    - CLAUDE.md
+    - AGENTS.md
 
 # Pull requests are validated by .github/workflows/pull-request.yml, unsigned. Without this,
 # Azure DevOps validates every pull request against a GitHub repository by default, which


### PR DESCRIPTION
No build ran for the previous merge, which touched only the pipeline YAML, while the merge
before it — touching several paths — did trigger one.

The cause is `'*.md'` in the trigger's path excludes. Azure DevOps supports wildcards in
branch and tag filters but **not** in path filters, where each entry is a path prefix. An
entry that cannot be interpreted takes the rest of the filter set with it.

Every exclude now names a directory or a file exactly. The comment says why, since `docs/*`
looks correct and is the form most people reach for.