### PR TITLE
Use userSpecifiedTag for the GitHub release tasks

### DIFF
--- a/.azure/pipelines/build-whiteboard.yaml
+++ b/.azure/pipelines/build-whiteboard.yaml
@@ -278,7 +278,7 @@ stages:
         repositoryName: '$(Build.Repository.Name)'
         action: create
         target: '$(Build.SourceVersion)'
-        tagSource: userSpecified
+        tagSource: userSpecifiedTag
         # Unique per run, so successive pre-releases of one version do not collide.
         tag: 'v$(AppSemVer)-dev.$(Build.BuildId)'
         title: 'SQLBI Whiteboard $(AppSemVer) (dev $(Build.BuildId))'
@@ -324,7 +324,7 @@ stages:
               repositoryName: '$(Build.Repository.Name)'
               action: create
               target: '$(Build.SourceVersion)'
-              tagSource: userSpecified
+              tagSource: userSpecifiedTag
               # Fails if the tag exists, which is the intended guard against releasing the
               # same version twice: bump VersionPrefix instead.
               tag: 'v$(AppSemVer)'


### PR DESCRIPTION
Run 3207 built and signed everything successfully, then both publishing stages failed on the
same input:

> Invalid tag source: userSpecified. Only 'gitTag', or 'userSpecifiedTag' options are allowed.

`GitHubRelease@1` spells the value `userSpecifiedTag`. Corrected in both tasks.

Everything before this point is now proven on a real run: the Build stage succeeded on both
matrix legs, signing included, and the asset collection picked the right files for each
channel from the artifacts of both legs.

The service connection's write access is still unproven — the task failed on input
validation, before it contacted GitHub.