### PR TITLE
Do not generate a changelog for GitHub releases

### DIFF
--- a/.azure/pipelines/build-whiteboard.yaml
+++ b/.azure/pipelines/build-whiteboard.yaml
@@ -290,7 +290,9 @@ stages:
           settings, and does not take over the `.wboard` file type.
         assets: '$(Build.ArtifactStagingDirectory)/release/*'
         isPreRelease: true
-        addChangeLog: true
+        # Off because with no previous release the task tries to build a changelog spanning
+        # every commit from the initial one, which fails. The notes above say what matters.
+        addChangeLog: false
 
 - stage: Release
   displayName: Promote to released
@@ -334,4 +336,4 @@ stages:
                 SQLBI Whiteboard $(AppSemVer).
               assets: '$(Build.ArtifactStagingDirectory)/release/*'
               isPreRelease: false
-              addChangeLog: true
+              addChangeLog: false


### PR DESCRIPTION
Run #20260817.7 built and signed everything, collected the right assets, and then failed in `GitHubRelease@1`:

```
Fetching the latest published release...   -> No releases are published yet
Found the initial commit: 27e1ffa...
Fetching the list of commits since the last published release...
##[error]An unexpected error occurred while fetching the list of changes.
##[error]Error: Not Found
```

With no previous release to compare against, the task attempts a changelog spanning every
commit from the repository's initial one. That is a cosmetic feature blocking the release it
is supposed to decorate, so it is off for both channels. The inline notes already say what
each build is.

Everything else in that run worked: both matrix legs built and signed, the assets were
collected per channel, and the Release stage correctly paused for approval.