### PR TITLE
Publish only the self-contained build

### DIFF
--- a/.azure/pipelines/templates/collect-release-assets.yml
+++ b/.azure/pipelines/templates/collect-release-assets.yml
@@ -28,12 +28,19 @@ steps:
       $destination = Join-Path $env:STAGING 'release'
       New-Item -ItemType Directory -Path $destination -Force | Out-Null
 
+      # Only the self-contained build is published. It needs no .NET runtime installed, so
+      # it is the one to hand a visitor who just wants the application. The
+      # framework-dependent build stays a pipeline artifact for anyone who prefers the
+      # smaller download and can manage the prerequisite themselves.
+      #
       # Installer names carry '-dev' for the pre-release channel and nothing for the
       # released one. The portable ZIP has no channel: the binaries are identical.
       $wantsDev = '${{ parameters.channel }}' -eq 'dev'
       $installers = Get-ChildItem -Path $env:ARTIFACTS -Recurse -Filter '*.msi' |
+          Where-Object { $_.Name -notlike '*-frameworkdependent*' } |
           Where-Object { ($_.Name -like '*-dev*') -eq $wantsDev }
-      $portable = Get-ChildItem -Path $env:ARTIFACTS -Recurse -Filter '*-portable.zip'
+      $portable = Get-ChildItem -Path $env:ARTIFACTS -Recurse -Filter '*-portable.zip' |
+          Where-Object { $_.Name -notlike '*-frameworkdependent*' }
 
       $assets = @($installers) + @($portable)
       if (-not $assets) {

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -213,11 +213,34 @@ Bravo's installer carries a custom-action DLL and opt-in telemetry checkboxes wi
 a long sequence of remember-properties. None of it was carried over, and the installer is
 considerably simpler for it. Port it only if the data is actually wanted.
 
+## 15. Only the self-contained build is published
+
+**Implemented.**
+
+Each release carries three assets: the per-machine installer, the per-user installer, and
+the portable ZIP, all self-contained. Publishing both flavours meant six assets with names
+like `SQLBI.Whiteboard.0.1.0.x64-frameworkdependent-dev-userinstaller.msi`, which asks a
+visitor to decode four dimensions before downloading anything.
+
+The self-contained build is roughly 60 MB against 8 MB, and needs no .NET runtime installed.
+That trade favours the visitor. The framework-dependent build is still produced and kept as
+a pipeline artifact.
+
+## 16. SQLBI Whiteboard is MIT-licensed open source
+
+**Implemented.**
+
+The repository is public and carries the MIT licence, the same as Bravo, and the installer
+presents the same terms. This was confirmed deliberately rather than inherited: the licence
+text was copied from Bravo early on, and shipping it unexamined would have granted rights
+nobody had decided to grant.
+
 ---
 
 ## Open questions
 
-- Whether the first public release is `0.1.0` or `1.0.0`.
+- Whether the first public release is `0.1.0` or `1.0.0`. `VersionPrefix` in
+  `Directory.Build.props` is still the placeholder `0.1.0`.
 - When the Store listing happens, and who owns the one-time listing work.
 - arm64 is not built; add it if Surface devices matter for a pen application.
 - The brand mark is placeholder-grade (decision 12).

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -151,7 +151,8 @@ Roughly in dependency order:
 
 ## Verification before a public release
 
-None of this has been done for a real release yet.
+The build, signing, and publishing chain is proven (see above). What has **not** been done
+for a real release is everything that involves installing the result.
 
 - `signtool verify /pa /v` on each MSI.
 - Install, upgrade, and uninstall for each scope; confirm uninstall removes the install


### PR DESCRIPTION
Each release carried six assets, including names like
\`SQLBI.Whiteboard.0.1.0.x64-frameworkdependent-dev-userinstaller.msi\`, which asks a visitor
to decode four dimensions before downloading anything.

Releases now carry three: the per-machine installer, the per-user installer, and the portable
ZIP, all self-contained. Self-contained is about 60 MB against 8 MB but needs no .NET runtime
installed, which is the right trade for someone who just wants the application. The
framework-dependent build is still produced and kept as a pipeline artifact.

Documentation updated alongside: `release-management.md` records that the chain is proven by
run 3209 and the prerelease it published, and notes the ten-to-fifteen minute delay before
Azure DevOps queues a run so nobody concludes the trigger is broken. Decisions 15 and 16 record
the asset choice and confirm the MIT licence, which until now had been copied from Bravo
rather than chosen.

The pipeline could not be validated server-side this time — the diagnostic PAT is revoked —
so this carries only a local YAML parse. The change is inside a PowerShell script block, not
the YAML structure.