### PR TITLE
Upgrade to .NET 10 and enable ReadyToRun

### DIFF
--- a/.azure/pipelines/build-whiteboard.yaml
+++ b/.azure/pipelines/build-whiteboard.yaml
@@ -92,10 +92,10 @@ stages:
           flavor: '-frameworkdependent'
     steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET 8 SDK'
+      displayName: 'Use .NET 10 SDK'
       inputs:
         packageType: sdk
-        version: '8.0.x'
+        version: '10.0.x'
 
     - script: dotnet restore "$(csproj)" --runtime "win-$(arch)" --verbosity "${{ parameters.verbosity }}"
       displayName: 'dotnet restore'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         if: needs.changes.outputs.code == 'true'
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore
         if: needs.changes.outputs.code == 'true'
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         if: needs.changes.outputs.code == 'true'
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       # Catches WiX authoring errors here rather than after a merge, when Azure Pipelines
       # would sign and publish. Unsigned, and the output is discarded; the version is a

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ How the project is developed and shipped is documented separately:
 Requirements:
 
 - Windows 11
-- .NET 8 SDK
+- .NET 10 SDK
 - Visual Studio 2022 or newer with the **Windows application development** workload if using the IDE
 
 From PowerShell in the repository root:

--- a/TODO.md
+++ b/TODO.md
@@ -17,30 +17,20 @@ release.
 
 ## Before the first stable release
 
-### Upgrade to .NET 10
+### Re-check ink on real hardware after the .NET 10 upgrade
 
-Ship 1.0 on the current LTS rather than upgrading immediately after. Touches seven project
-files:
+All seven projects now target .NET 10 and both CI definitions install the 10.0.x SDK. The
+solution builds with no warnings, the core smoke tests pass, all four installer variants
+package, and the published build starts.
 
-| Project | Now |
-| --- | --- |
-| `src/SQLBI.Whiteboard` | `net8.0-windows10.0.26100.0` |
-| `src/SQLBI.Whiteboard.Core`, `.Dax`, `.SqlServer` | `net8.0` |
-| `tests/SQLBI.Whiteboard.Core.SmokeTests` | `net8.0` |
-| `tools/AssetGenerator` | `net8.0-windows` |
-| `prototypes/…CalligraphyPrototype` | `net8.0-windows` |
-
-Also update the SDK version in `.azure/pipelines/build-whiteboard.yaml` (`UseDotNet@2`) and
-`.github/workflows/pull-request.yml` (`actions/setup-dotnet`).
-
-Watch for: `TreatWarningsAsErrors` is on everywhere, so new analyzer warnings fail the build;
-the self-contained publish size changes, which shows up in the installers; and WPF behaviour
-around ink and `RenderTargetBitmap` should be re-checked on real hardware rather than assumed.
+What that does not cover is the part that matters most: WPF ink and `RenderTargetBitmap`
+behaviour on a real pen display. Run the Wacom Cintiq Pro checks at the end of
+[README.md](README.md) before shipping.
 
 ### Decide the first version number
 
-`VersionPrefix` in `Directory.Build.props` is the placeholder `0.1.0`. Changing that line is
-what starts a release (decision 8).
+`VersionPrefix` in `Directory.Build.props` reads `0.2.0`, bumped for the .NET 10 upgrade but
+still a development number. Changing that line is what starts a release (decision 8).
 
 ### Verify the installers on a real machine
 
@@ -91,12 +81,12 @@ the primary route rather than a fallback (decision 10).
 
 ### Shorten pull request validation
 
-`Build installers` takes around six minutes, almost all of it CAB-compressing a 78 MB
-self-contained payload into a 60 MB MSI, four times over. The WiX authoring work itself is
+`Build installers` takes around six minutes, almost all of it CAB-compressing a 252 MB
+self-contained payload into a 73 MB MSI, four times over. The WiX authoring work itself is
 almost free. Two changes, expected to bring it under two minutes:
 
 1. **Package the framework-dependent build.** Pass `-SelfContained false` in
-   `.github/workflows/pull-request.yml`. The payload drops to roughly 8 MB while the same
+   `.github/workflows/pull-request.yml`. The installer drops to roughly 11 MB while the same
    authoring and the same file harvesting are still exercised.
 2. **Build two diagonal variants instead of four.** `scripts/build-installer.ps1` currently
    loops every channel and scope. Give it a parameter to restrict the combinations, and have

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -222,9 +222,23 @@ the portable ZIP, all self-contained. Publishing both flavours meant six assets 
 like `SQLBI.Whiteboard.0.1.0.x64-frameworkdependent-dev-userinstaller.msi`, which asks a
 visitor to decode four dimensions before downloading anything.
 
-The self-contained build is roughly 60 MB against 8 MB, and needs no .NET runtime installed.
-That trade favours the visitor. The framework-dependent build is still produced and kept as
-a pipeline artifact.
+The self-contained installer is roughly 73 MB against 11 MB, and needs no .NET runtime
+installed. That trade favours the visitor. The framework-dependent build is still produced
+and kept as a pipeline artifact.
+
+## 17. Published builds are ReadyToRun-compiled
+
+**Implemented.**
+
+`PublishReadyToRun` is set in `src/SQLBI.Whiteboard/SQLBI.Whiteboard.csproj`, so publishing
+compiles IL ahead of time instead of leaving every method to the JIT on first call. Startup
+latency is what a pen application is judged on, and it is paid on every launch rather than
+once.
+
+It costs about 22% on disk — the self-contained publish folder measured 207 MB without it
+and 252 MB with it — which compresses down to a few MB in the installer. It applies only to
+`dotnet publish`, and only when a runtime identifier is given; both publish paths pass one,
+so a plain `dotnet build` is unaffected and local iteration does not slow down.
 
 ## 16. SQLBI Whiteboard is MIT-licensed open source
 
@@ -239,8 +253,9 @@ nobody had decided to grant.
 
 ## Open questions
 
-- Whether the first public release is `0.1.0` or `1.0.0`. `VersionPrefix` in
-  `Directory.Build.props` is still the placeholder `0.1.0`.
+- Whether the first public release is `0.2.0` or `1.0.0`. `VersionPrefix` in
+  `Directory.Build.props` reads `0.2.0`, bumped for the .NET 10 upgrade but still a
+  development number.
 - When the Store listing happens, and who owns the one-time listing work.
 - arm64 is not built; add it if Surface devices matter for a pen application.
 - The brand mark is placeholder-grade (decision 12).

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -11,7 +11,7 @@ repository yet.
 `main` is protected. Work on short-lived branches and merge through a pull request — the
 workflow is in [CONTRIBUTING.md](../CONTRIBUTING.md), and the reasoning is decision 11.
 
-Everything builds with the .NET 8 SDK on Windows:
+Everything builds with the .NET 10 SDK on Windows:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\build.ps1

--- a/prototypes/SQLBI.Whiteboard.CalligraphyPrototype/SQLBI.Whiteboard.CalligraphyPrototype.csproj
+++ b/prototypes/SQLBI.Whiteboard.CalligraphyPrototype/SQLBI.Whiteboard.CalligraphyPrototype.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <AssemblyName>SQLBI.Whiteboard.CalligraphyPrototype</AssemblyName>
     <RootNamespace>SQLBI.Whiteboard.CalligraphyPrototype</RootNamespace>

--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -5,10 +5,16 @@ param(
 
 $ErrorActionPreference = "Stop"
 $workspaceDirectory = Split-Path -Parent $PSScriptRoot
-$executable = Join-Path $workspaceDirectory "src\SQLBI.Whiteboard\bin\$Configuration\net8.0-windows\SQLBI.Whiteboard.exe"
+$outputRoot = Join-Path $workspaceDirectory "src\SQLBI.Whiteboard\bin\$Configuration"
 
-if (-not (Test-Path $executable)) {
+# The target framework folder is found rather than named. It carries the Windows SDK version
+# ("net10.0-windows10.0.26100.0"), so spelling it out here goes stale on every retarget.
+$executable = Get-ChildItem -Path $outputRoot -Filter 'SQLBI.Whiteboard.exe' -Recurse -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+
+if (-not $executable) {
     throw "SQLBI Whiteboard has not been built. Run scripts\build.ps1 first."
 }
 
-Start-Process -FilePath $executable
+Start-Process -FilePath $executable.FullName

--- a/src/SQLBI.Whiteboard.Core/SQLBI.Whiteboard.Core.csproj
+++ b/src/SQLBI.Whiteboard.Core/SQLBI.Whiteboard.Core.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/SQLBI.Whiteboard.Dax/SQLBI.Whiteboard.Dax.csproj
+++ b/src/SQLBI.Whiteboard.Dax/SQLBI.Whiteboard.Dax.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>SQLBI.Whiteboard.Dax</AssemblyName>
     <RootNamespace>SQLBI.Whiteboard.Dax</RootNamespace>
   </PropertyGroup>

--- a/src/SQLBI.Whiteboard.SqlServer/SQLBI.Whiteboard.SqlServer.csproj
+++ b/src/SQLBI.Whiteboard.SqlServer/SQLBI.Whiteboard.SqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>SQLBI.Whiteboard.SqlServer</AssemblyName>
     <RootNamespace>SQLBI.Whiteboard.SqlServer</RootNamespace>
   </PropertyGroup>

--- a/src/SQLBI.Whiteboard/SQLBI.Whiteboard.csproj
+++ b/src/SQLBI.Whiteboard/SQLBI.Whiteboard.csproj
@@ -1,9 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <UseWPF>true</UseWPF>
+    <!--
+      Ahead-of-time compiles the IL that startup touches, which is what a pen application is
+      judged on. It only applies to `dotnet publish`, and only when a runtime identifier is
+      given - both publish paths pass one. It costs about 22% on disk: the self-contained
+      publish measured 207 MB without it and 252 MB with it.
+    -->
+    <PublishReadyToRun>true</PublishReadyToRun>
     <AssemblyName>SQLBI.Whiteboard</AssemblyName>
     <RootNamespace>SQLBI.Whiteboard</RootNamespace>
     <AssemblyTitle>SQLBI Whiteboard</AssemblyTitle>

--- a/tests/SQLBI.Whiteboard.Core.SmokeTests/SQLBI.Whiteboard.Core.SmokeTests.csproj
+++ b/tests/SQLBI.Whiteboard.Core.SmokeTests/SQLBI.Whiteboard.Core.SmokeTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SQLBI.Whiteboard.Core\SQLBI.Whiteboard.Core.csproj" />

--- a/tools/AssetGenerator/AssetGenerator.csproj
+++ b/tools/AssetGenerator/AssetGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <AssemblyName>AssetGenerator</AssemblyName>
     <RootNamespace>SQLBI.Whiteboard.AssetGenerator</RootNamespace>


### PR DESCRIPTION
.NET 10 is the current LTS, and shipping 1.0 on it avoids a framework upgrade immediately
after the first release. This was the first item under "Before the first stable release" in
TODO.md.

All seven projects are retargeted (`net10.0`, `net10.0-windows`,
`net10.0-windows10.0.26100.0`), and both CI definitions now install the 10.0.x SDK.

`PublishReadyToRun` is enabled on the application, because startup latency is what a pen
application is judged on and it is paid on every launch rather than once. It applies only to
`dotnet publish` with a runtime identifier — both publish paths pass one — so `dotnet build`
and local iteration are unaffected. Recorded as decision 17.

`VersionPrefix` moves to `0.2.0`. This is still a development number, not a decision to
release `0.2.0`; the open question in decisions.md is updated to say so.

### Sizes

Measured rather than estimated, since several documents carried figures that were stale:

| | Before, recorded | Now, measured |
| --- | --- | --- |
| Self-contained publish | 78 MB | 252 MB (207 MB without ReadyToRun) |
| Self-contained installer | 60 MB | 72.7 MB |
| Framework-dependent installer | 8 MB | 10.9 MB |

ReadyToRun accounts for 45 MB of the publish folder, roughly 22%, which compresses to a few
MB in the installer. Most of the rest is `Microsoft.Windows.SDK.NET.dll` at 55.8 MB — the
Windows SDK projection the LiveView capture needs, unchanged by this work. Decision 15,
decision 17 and the TODO housekeeping note now carry the measured numbers.

### Unrelated fix included

`scripts/run.ps1` pointed at `bin\$Configuration\net8.0-windows`, but the application has
targeted `net8.0-windows10.0.26100.0` for some time, so that path never existed and the
script always threw "has not been built". It now locates the executable under the
configuration folder instead, so the next retarget cannot break it the same way.

### Verified

Solution builds with no warnings (`TreatWarningsAsErrors` is on), core smoke tests pass,
AssetGenerator builds, all four installer variants package in both self-contained and
framework-dependent flavours, and the published ReadyToRun executable starts.

Not covered: WPF ink and `RenderTargetBitmap` on a real pen display. The .NET 10 entry in
TODO.md is replaced by that check rather than removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5PF5wmsRMAxyuXvxPr5Gx