### PR TITLE
Shorten pull request installer validation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -94,7 +94,14 @@ jobs:
       # Catches WiX authoring errors here rather than after a merge, when Azure Pipelines
       # would sign and publish. Unsigned, and the output is discarded; the version is a
       # placeholder with no meaning.
+      #
+      # Two variants rather than all four. The four are not repetition - they are four paths
+      # through the <?if?> branches in installer/wix/SQLBI.Whiteboard.wxs - but this diagonal
+      # pair still takes both sides of each conditional, so a typo in the dev branch or a
+      # broken per-user directory is still caught. Packaging is almost entirely CAB
+      # compression, so dropping two halves the job. Azure Pipelines builds all four on every
+      # merge to main.
       - name: Build installers
         if: needs.changes.outputs.code == 'true'
         shell: pwsh
-        run: ./scripts/build-installer.ps1 -Version 0.0.0
+        run: ./scripts/build-installer.ps1 -Version 0.0.0 -Variants stable/perMachine,dev/perUser

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -95,13 +95,25 @@ jobs:
       # would sign and publish. Unsigned, and the output is discarded; the version is a
       # placeholder with no meaning.
       #
-      # Two variants rather than all four. The four are not repetition - they are four paths
-      # through the <?if?> branches in installer/wix/SQLBI.Whiteboard.wxs - but this diagonal
-      # pair still takes both sides of each conditional, so a typo in the dev branch or a
-      # broken per-user directory is still caught. Packaging is almost entirely CAB
-      # compression, so dropping two halves the job. Azure Pipelines builds all four on every
-      # merge to main.
+      # Deliberately smaller than what ships, because this job is almost entirely CAB
+      # compression and none of that compression is what needs validating:
+      #
+      #   -SelfContained false  packages the framework-dependent build, a payload of roughly
+      #                         15 MB rather than 252 MB. The same authoring and the same file
+      #                         harvesting run over it.
+      #   -Variants             builds a diagonal pair. The four variants are not repetition -
+      #                         they are four paths through the <?if?> branches in
+      #                         installer/wix/SQLBI.Whiteboard.wxs - but this pair still takes
+      #                         both sides of every conditional, so a typo in the dev branch or
+      #                         a broken per-user directory is still caught.
+      #
+      # Azure Pipelines builds all four variants self-contained on every merge to main, so
+      # what is skipped here is still checked before anything is signed or published.
       - name: Build installers
         if: needs.changes.outputs.code == 'true'
         shell: pwsh
-        run: ./scripts/build-installer.ps1 -Version 0.0.0 -Variants stable/perMachine,dev/perUser
+        run: >-
+          ./scripts/build-installer.ps1
+          -Version 0.0.0
+          -SelfContained false
+          -Variants stable/perMachine,dev/perUser

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Build all of them locally with:
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-installer.ps1 -Version 1.0.0
 ```
 
+Packaging is almost entirely CAB compression, so building every variant is slow. Pass
+`-Variants` to restrict it while iterating on the authoring — pull request validation builds
+the diagonal pair, which still exercises both sides of every conditional in the source:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-installer.ps1 -Variants stable/perMachine,dev/perUser
+```
+
 The WiX toolset is pinned in `.config/dotnet-tools.json`. The script restores it and adds
 the UI and Util extensions, so no manual setup is required.
 

--- a/TODO.md
+++ b/TODO.md
@@ -81,16 +81,17 @@ the primary route rather than a fallback (decision 10).
 
 ### Shorten pull request validation
 
-`Build installers` takes around six minutes, almost all of it CAB-compressing a 252 MB
+`Build installers` took around six minutes, almost all of it CAB-compressing a 252 MB
 self-contained payload into a 73 MB MSI, four times over. The WiX authoring work itself is
-almost free. Two changes, expected to bring it under two minutes:
+almost free. Two changes were planned; the second is done:
 
 1. **Package the framework-dependent build.** Pass `-SelfContained false` in
    `.github/workflows/pull-request.yml`. The installer drops to roughly 11 MB while the same
-   authoring and the same file harvesting are still exercised.
-2. **Build two diagonal variants instead of four.** `scripts/build-installer.ps1` currently
-   loops every channel and scope. Give it a parameter to restrict the combinations, and have
-   the pull request job build `stable`/`perMachine` and `dev`/`perUser`.
+   authoring and the same file harvesting are still exercised. This is the larger of the two
+   savings and is still outstanding.
+2. ~~**Build two diagonal variants instead of four.**~~ Done. `scripts/build-installer.ps1`
+   takes a `-Variants` parameter, and the pull request job passes
+   `stable/perMachine,dev/perUser`. It defaults to all four, so Azure Pipelines is unchanged.
 
 The four variants are not repetition: they are four paths through the `<?if?>` branches in
 `installer/wix/SQLBI.Whiteboard.wxs`. Building one would miss a typo in the dev branch or a

--- a/TODO.md
+++ b/TODO.md
@@ -77,30 +77,6 @@ Note the Store signs the package itself, so the SQLBI certificate is not involve
 availability is also uneven on managed corporate machines, which is why the MSI channel stays
 the primary route rather than a fallback (decision 10).
 
-## Housekeeping
-
-### Shorten pull request validation
-
-`Build installers` took around six minutes, almost all of it CAB-compressing a 252 MB
-self-contained payload into a 73 MB MSI, four times over. The WiX authoring work itself is
-almost free. Two changes were planned; the second is done:
-
-1. **Package the framework-dependent build.** Pass `-SelfContained false` in
-   `.github/workflows/pull-request.yml`. The installer drops to roughly 11 MB while the same
-   authoring and the same file harvesting are still exercised. This is the larger of the two
-   savings and is still outstanding.
-2. ~~**Build two diagonal variants instead of four.**~~ Done. `scripts/build-installer.ps1`
-   takes a `-Variants` parameter, and the pull request job passes
-   `stable/perMachine,dev/perUser`. It defaults to all four, so Azure Pipelines is unchanged.
-
-The four variants are not repetition: they are four paths through the `<?if?>` branches in
-`installer/wix/SQLBI.Whiteboard.wxs`. Building one would miss a typo in the dev branch or a
-broken per-user directory. The diagonal pair covers both sides of each conditional.
-
-What this stops covering, both thin and both caught before anything ships: a failure specific
-to self-contained output, and the two untested channel-scope combinations. Azure Pipelines
-builds all four variants self-contained on every merge to `main`.
-
 ## Deferred, deliberately
 
 - **arm64.** Not built. Worth adding if Surface devices matter for a pen application.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -249,6 +249,32 @@ presents the same terms. This was confirmed deliberately rather than inherited: 
 text was copied from Bravo early on, and shipping it unexamined would have granted rights
 nobody had decided to grant.
 
+## 18. Pull request validation packages less than it ships
+
+**Implemented.**
+
+`Build installers` in `.github/workflows/pull-request.yml` packages the framework-dependent
+build and only two of the four channel-scope variants. It took 6m 17s building everything;
+the reduced job runs in well under two minutes.
+
+Almost all of that time was CAB compression, and compression is not what the job validates —
+the WiX authoring is. The framework-dependent payload is roughly 15 MB against 252 MB, and
+runs through the same authoring and the same `<Files Include>` harvesting.
+
+The two variants are the diagonal pair, `stable/perMachine` and `dev/perUser`. The four are
+not repetition: they are four paths through the `<?if?>` branches in
+`installer/wix/SQLBI.Whiteboard.wxs`, so building only one would miss a typo in the dev
+branch or a broken per-user directory. The diagonal pair still takes both sides of every
+conditional.
+
+What this stops covering is narrow: a failure specific to self-contained output, and the two
+untested channel-scope combinations. Azure Pipelines builds all four variants self-contained
+on every merge to `main`, so both are caught before anything is signed or published.
+
+`scripts/build-installer.ps1` defaults to all four variants and to self-contained. The
+reduction is expressed in the workflow that wants it, not in the script, so nothing that
+ships can inherit it by accident.
+
 ---
 
 ## Open questions

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -20,7 +20,12 @@ param(
     # Supply an existing publish folder to package binaries that are already built, and
     # signed. The build pipeline does this so signing happens between publish and packaging.
     [string] $PublishFolder,
-    [string] $OutputFolder
+    [string] $OutputFolder,
+    # Which channel/scope combinations to package. Anything that ships must build all four.
+    # Pull request validation restricts this to a diagonal pair, because packaging is almost
+    # entirely CAB compression and the authoring being validated is the same either way.
+    [ValidateSet('stable/perMachine', 'stable/perUser', 'dev/perMachine', 'dev/perUser')]
+    [string[]] $Variants = @('stable/perMachine', 'stable/perUser', 'dev/perMachine', 'dev/perUser')
 )
 
 $ErrorActionPreference = 'Stop'
@@ -95,29 +100,27 @@ try {
 
     # Both channels are built from one publish, so the released installers are produced by
     # the same run that produced the pre-release ones and can be promoted without rebuilding.
-    foreach ($channel in @('stable', 'dev')) {
+    foreach ($variant in $Variants) {
+        $channel, $scope = $variant.Split('/')
         $channelSuffix = if ($channel -eq 'dev') { '-dev' } else { '' }
+        $scopeSuffix = if ($scope -eq 'perUser') { '-userinstaller' } else { '' }
+        $msiPath = Join-Path $outputFolder "$artifactName$channelSuffix$scopeSuffix.msi"
 
-        foreach ($scope in @('perMachine', 'perUser')) {
-            $scopeSuffix = if ($scope -eq 'perUser') { '-userinstaller' } else { '' }
-            $msiPath = Join-Path $outputFolder "$artifactName$channelSuffix$scopeSuffix.msi"
-
-            Write-Host "==> wix build ($channel, $scope)" -ForegroundColor Cyan
-            dotnet wix build $sourceFile `
-                -arch $Architecture `
-                -d "Channel=$channel" `
-                -d "Scope=$scope" `
-                -d "PublishFolder=$publishFolder" `
-                -d "AssetsFolder=$assetsFolder" `
-                -ext WixToolset.UI.wixext `
-                -ext WixToolset.Util.wixext `
-                -culture en-us `
-                -loc $localizationFile `
-                -pdbtype none `
-                -out $msiPath
-            if ($LASTEXITCODE -ne 0) {
-                throw "wix build ($channel, $scope) failed with exit code $LASTEXITCODE"
-            }
+        Write-Host "==> wix build ($channel, $scope)" -ForegroundColor Cyan
+        dotnet wix build $sourceFile `
+            -arch $Architecture `
+            -d "Channel=$channel" `
+            -d "Scope=$scope" `
+            -d "PublishFolder=$publishFolder" `
+            -d "AssetsFolder=$assetsFolder" `
+            -ext WixToolset.UI.wixext `
+            -ext WixToolset.Util.wixext `
+            -culture en-us `
+            -loc $localizationFile `
+            -pdbtype none `
+            -out $msiPath
+        if ($LASTEXITCODE -ne 0) {
+            throw "wix build ($channel, $scope) failed with exit code $LASTEXITCODE"
         }
     }
 }


### PR DESCRIPTION
`Build installers` took 6m 17s, almost all of it CAB-compressing a 252 MB self-contained
payload into a 73 MB MSI four times over. Compression is not what the job validates — the
WiX authoring is — so it now packages considerably less than what ships.

Two changes, both from the housekeeping note in TODO.md:

1. **`-SelfContained false`.** The framework-dependent payload is roughly 15 MB against
   252 MB, and runs through the same authoring and the same `<Files Include>` harvesting.
   This is the larger saving by far.
2. **`-Variants stable/perMachine,dev/perUser`.** A new parameter on
   `scripts/build-installer.ps1`, which previously looped every channel and scope
   unconditionally.

Locally the reduced job runs in **1m 15s**.

### Why this still validates the authoring

The four variants are not repetition: they are four paths through the `<?if?>` branches in
`installer/wix/SQLBI.Whiteboard.wxs`. Building only one would miss a typo in the dev branch
or a broken per-user directory. The diagonal pair takes both sides of every conditional.

What stops being covered is narrow: a failure specific to self-contained output, and the two
untested channel-scope *combinations* — not the branches themselves. Azure Pipelines builds
all four variants self-contained on every merge to `main`, so both are caught before anything
is signed or published.

`build-installer.ps1` defaults to all four variants and to self-contained. The reduction
lives in the workflow that wants it, not in the script, so nothing that ships can inherit it
by accident — Azure Pipelines passes neither flag and is unchanged.

### Documentation

Both halves of the housekeeping note are now done, so it moves out of TODO.md and becomes
decision 18 in docs/decisions.md, where the coverage trade-off is recorded for anyone
tempted to re-expand the job later.

### Verified

- The reduced invocation produces exactly two correctly-named MSIs.
- The default still runs all four `wix build` invocations and produces all four MSIs.
- An unrecognised variant is rejected by `ValidateSet` at parameter binding, before any
  publish or packaging work starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5PF5wmsRMAxyuXvxPr5Gx