### PR TITLE
Carry the channel marker in the pre-release portable ZIP

### DIFF
--- a/.azure/pipelines/templates/collect-release-assets.yml
+++ b/.azure/pipelines/templates/collect-release-assets.yml
@@ -33,14 +33,17 @@ steps:
       # framework-dependent build stays a pipeline artifact for anyone who prefers the
       # smaller download and can manage the prerequisite themselves.
       #
-      # Installer names carry '-dev' for the pre-release channel and nothing for the
-      # released one. The portable ZIP has no channel: the binaries are identical.
+      # Asset names carry '-dev' for the pre-release channel and nothing for the released
+      # one. That includes the portable ZIP: the binaries are identical, but the pre-release
+      # one also carries the channel.txt marker, so a portable copy keeps its settings
+      # separate from a released install exactly as an installed one does.
       $wantsDev = '${{ parameters.channel }}' -eq 'dev'
       $installers = Get-ChildItem -Path $env:ARTIFACTS -Recurse -Filter '*.msi' |
           Where-Object { $_.Name -notlike '*-frameworkdependent*' } |
           Where-Object { ($_.Name -like '*-dev*') -eq $wantsDev }
       $portable = Get-ChildItem -Path $env:ARTIFACTS -Recurse -Filter '*-portable.zip' |
-          Where-Object { $_.Name -notlike '*-frameworkdependent*' }
+          Where-Object { $_.Name -notlike '*-frameworkdependent*' } |
+          Where-Object { ($_.Name -like '*-dev-portable.zip') -eq $wantsDev }
 
       $assets = @($installers) + @($portable)
       if (-not $assets) {

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ selected with the `Channel` and `Scope` preprocessor variables:
 | `SQLBI.Whiteboard.<version>.x64-dev.msi` | `Program Files\SQLBI\Whiteboard Dev` |
 | `SQLBI.Whiteboard.<version>.x64-dev-userinstaller.msi` | `%LOCALAPPDATA%\Programs\SQLBI\Whiteboard Dev`, no elevation |
 | `SQLBI.Whiteboard.<version>.x64-portable.zip` | runs without installing |
+| `SQLBI.Whiteboard.<version>.x64-dev-portable.zip` | runs without installing, as the pre-release channel |
 
 ### Channels
 
@@ -72,9 +73,10 @@ installed. They differ in three ways:
   and carries its own `UpgradeCode`, so it never upgrades or replaces a released install.
 - Only the released channel registers the `.wboard` file type. Uninstalling a pre-release
   build therefore cannot leave the association broken.
-- The pre-release installer places a `channel.txt` beside the executable. `AppChannel` reads
-  it at startup to append `(Dev)` to the window title and to keep settings in
-  `%APPDATA%\SQLBI\Whiteboard Dev`, so the two copies cannot overwrite each other's settings.
+- The pre-release installer places a `channel.txt` beside the executable, and the pre-release
+  portable ZIP carries the same file. `AppChannel` reads it at startup to append `(Dev)` to
+  the window title and to keep settings in `%APPDATA%\SQLBI\Whiteboard Dev`, so the two
+  copies cannot overwrite each other's settings.
 
 Because the channel is detected at run time rather than compiled in, one build of the
 application serves both, and a tested binary can be promoted without being rebuilt.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -97,10 +97,12 @@ Three consequences were chosen deliberately:
 - **Dev does not register `.wboard`.** If both channels claimed it the last install would
   win, and uninstalling dev would delete the association outright, breaking the released
   copy. Boards always open in the released build; dev is launched explicitly.
-- **Settings are separated** through a `channel.txt` the dev installer places beside the
-  executable. Without this the two copies silently overwrite each other's settings on every
-  save — the settings parser ignores the `Version` field, so this fails quietly rather than
-  loudly.
+- **Settings are separated** through a `channel.txt` placed beside the executable by the dev
+  installer, and carried inside the dev portable ZIP. Without this the two copies silently
+  overwrite each other's settings on every save — the settings parser ignores the `Version`
+  field, so this fails quietly rather than loudly. The portable ZIP originally shipped
+  without the marker in both channels, which reintroduced exactly this collision for anyone
+  running a portable pre-release (issue 17).
 - **The channel is detected at run time, not compiled in.** One set of binaries therefore
   serves both channels, all four installers come from a single publish, and a tested build
   can be promoted without being rebuilt (decision 9).

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -34,6 +34,7 @@ Set-StrictMode -Version Latest
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $project = Join-Path $repoRoot 'src/SQLBI.Whiteboard/SQLBI.Whiteboard.csproj'
 $installerRoot = Join-Path $repoRoot 'installer/wix'
+$assetsFolder = Join-Path $installerRoot 'assets'
 $skipPublish = -not [string]::IsNullOrWhiteSpace($PublishFolder)
 $publishFolder = if ($skipPublish) { $PublishFolder } else { Join-Path $repoRoot 'artifacts/publish' }
 $outputFolder = if ([string]::IsNullOrWhiteSpace($OutputFolder)) {
@@ -96,7 +97,6 @@ try {
     # so every value is expanded into a quoted string first.
     $sourceFile = Join-Path $installerRoot 'SQLBI.Whiteboard.wxs'
     $localizationFile = Join-Path $installerRoot 'SQLBI.Whiteboard.en-us.wxl'
-    $assetsFolder = Join-Path $installerRoot 'assets'
 
     # Both channels are built from one publish, so the released installers are produced by
     # the same run that produced the pre-release ones and can be promoted without rebuilding.
@@ -128,12 +128,38 @@ finally {
     Pop-Location
 }
 
-Write-Host '==> Portable ZIP' -ForegroundColor Cyan
-Compress-Archive `
-    -Path (Join-Path $publishFolder '*') `
-    -DestinationPath (Join-Path $outputFolder "$artifactName-portable.zip") `
-    -CompressionLevel Optimal `
-    -Force
+# One portable ZIP per channel, differing only by the channel marker, exactly as the
+# installers do. Without this a portable pre-release would report itself as the released
+# channel and write to the released channel's settings folder, which is the collision
+# channel.txt exists to prevent.
+foreach ($channel in ($Variants | ForEach-Object { $_.Split('/')[0] } | Sort-Object -Unique)) {
+    $channelSuffix = if ($channel -eq 'dev') { '-dev' } else { '' }
+    $zipPath = Join-Path $outputFolder "$artifactName$channelSuffix-portable.zip"
+
+    Write-Host "==> Portable ZIP ($channel)" -ForegroundColor Cyan
+    Compress-Archive `
+        -Path (Join-Path $publishFolder '*') `
+        -DestinationPath $zipPath `
+        -CompressionLevel Optimal `
+        -Force
+
+    # The same file the installer ships, so the two can never disagree about a channel name.
+    # The released channel has no marker: its absence is what identifies it.
+    $marker = Join-Path $assetsFolder "channel-$channel.txt"
+    if (Test-Path $marker) {
+        # Staged and added afterwards rather than copied into the publish folder, which is
+        # shared between channels and, in the pipeline, already signed.
+        $staging = Join-Path $outputFolder ".marker-$channel"
+        New-Item -ItemType Directory -Path $staging -Force | Out-Null
+        try {
+            Copy-Item $marker (Join-Path $staging 'channel.txt') -Force
+            Compress-Archive -Path (Join-Path $staging 'channel.txt') -DestinationPath $zipPath -Update
+        }
+        finally {
+            Remove-Item $staging -Recurse -Force
+        }
+    }
+}
 
 Write-Host ''
 Write-Host 'Artifacts:' -ForegroundColor Green


### PR DESCRIPTION
Fixes #17.

The portable ZIP shipped in both channels as one file with no `channel.txt`, because that
marker is placed by the installer rather than being part of the publish output. A portable
pre-release therefore reported itself as the released channel and wrote to
`%APPDATA%\SQLBI\Whiteboard` — the settings collision `channel.txt` exists to prevent, and one
that fails silently because the settings parser ignores the `Version` field.

`scripts/build-installer.ps1` now produces one portable ZIP per channel it is building,
differing only by the marker, exactly as the installers do:

| Asset | Contents |
| --- | --- |
| `…x64-portable.zip` | as before |
| `…x64-dev-portable.zip` | plus `channel.txt` |

The dev ZIP reuses `installer/wix/assets/channel-dev.txt` — the very file the installer ships
— so the two cannot drift apart on the channel name. The marker is staged and added to the
archive afterwards rather than copied into the publish folder, which is shared between
channels and, in the pipeline, already signed.

`collect-release-assets.yml` now selects the portable ZIP by channel the way it already
selected the MSIs, so each release carries the ZIP that matches its installers.

### Verified

Inspected the archives rather than trusting the file names:

```
…-portable.zip          no channel.txt (released channel)   20 root entries
…-dev-portable.zip      channel.txt = 'Dev'                 21 root entries
```

`SQLBI.Whiteboard.exe` is at the root of both, so the marker sits beside it where
`AppChannel` reads it from `AppContext.BaseDirectory`.

Also confirmed the asset selection yields exactly three assets per channel with the correct
ZIP in each, and that the staging folder leaves nothing behind in the output directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5PF5wmsRMAxyuXvxPr5Gx