### PR TITLE
Keep the colour picker within the presenter picture-in-picture

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.2.1</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SQLBI.Whiteboard/Themes/Toolbar.xaml
+++ b/src/SQLBI.Whiteboard/Themes/Toolbar.xaml
@@ -78,14 +78,21 @@
                 Value="Pen or calligraphy" />
     </Style>
 
+    <!--
+        These sizes set the width of the whole tool palette. Six pen swatches drive the shared
+        colour column, and the highlighter row - that column plus three tool buttons - is the
+        widest thing in the palette. At 32 with a 3 margin the palette overflowed a presenter
+        picture-in-picture in the top-right corner, which is the placement the default toolbar
+        position exists to hide under. Enlarging these again brings that back.
+    -->
     <Style x:Key="ColorSwatchButton"
            TargetType="{x:Type ToggleButton}">
         <Setter Property="Width"
-                Value="32" />
+                Value="28" />
         <Setter Property="Height"
-                Value="32" />
+                Value="28" />
         <Setter Property="Margin"
-                Value="3" />
+                Value="1" />
         <Setter Property="Focusable"
                 Value="False" />
         <Setter Property="ClickMode"
@@ -97,7 +104,11 @@
                         <Ellipse x:Name="Ring"
                                  Stroke="Transparent"
                                  StrokeThickness="2" />
-                        <Ellipse Margin="4"
+                        <!--
+                            Inset from 4 to 3 alongside the smaller button, so the visible
+                            colour only loses 2 units rather than 4.
+                        -->
+                        <Ellipse Margin="3"
                                  Fill="{TemplateBinding Background}"
                                  Stroke="#33000000"
                                  StrokeThickness="1" />


### PR DESCRIPTION
The tool palette was wider than a typical presenter picture-in-picture, so it stuck out to
the left of it during recording — the opposite of what the default `TopRight` placement
exists to achieve.

### Where the width came from

Not the row you would guess. The palette is sized by the **highlighter** row: the colour
column carries `SharedSizeGroup="DualColors"`, so it is sized by the *pen's* six swatches,
and the highlighter row pairs that column with three tool buttons rather than two.

Every contributing value is a fixed `Width`/`Margin`, so the width is exact:

| | Colour column | + 3 tool buttons | Palette |
| --- | --- | --- | --- |
| Before | 228 | 126 | **376** |
| After | 180 | 126 | **328** |

### The change

The colour swatch goes from 32 with a 3 margin to 28 with a 1 margin — footprint 38 → 30.
The template's inner inset also tightens from 4 to 3, so the visible colour circle only drops
from 24 to 22 rather than to 20.

All six colours are kept; nothing was removed from the palette.

### How much was needed

Measured from the screenshot: the palette's left border sits at x=182 and the
picture-in-picture begins at x≈206.5, an overflow of ~24.5 screenshot pixels. Calibrating the
scale against two independent references — the 6-unit palette padding, and the swatch circle
diameter — gives 0.65–0.70, so **35–38 units** had to go. This recovers 48, leaving 10–13 units
of slack.

### Verification

The before/after figures are not arithmetic: both versions of `Toolbar.xaml` were parsed and
measured through WPF's own layout engine, which also confirmed the unchanged constants
(`ToolbarIconButton` 42, `SizeChipButton` 60).

Build is clean and the core smoke tests pass.

**Not visually confirmed.** Three attempts to launch the application and capture the palette
produced a window whose toolbar never appeared, despite settings reading `TopRight` +
`DualPalette`. It renders correctly on the reporter's machine, so this is worth an eyeball
before shipping — particularly the judgement call on a 28-unit hit target, down from 32.

If it is still a hair wide, the next 12 units are free: drop the swatch margin to 0, since the
template's inset already provides visual separation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5PF5wmsRMAxyuXvxPr5Gx