### PR TITLE
Add a searchable preferences dialog

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>0.2.1</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ How the project is developed and shipped is documented separately:
 - Undo and redo for strokes, erasing, containers, text edits, and transformations
 - Versioned ZIP-based `.wboard` documents with embedded image assets
 - An intentionally small floating toolbar
+- Preferences for the startup monitor, full-screen start, laser trail, and toolbar layout
 
 ## Build and run
 
@@ -177,9 +178,11 @@ Use **Copy settings** after finding a useful combination so the exact values can
 | Escape | Cancel the active text edit |
 | Ctrl+S / Ctrl+O | Save / open a board |
 | Delete | Delete the selected container and its linked strokes |
+| Tools > Preferences... | Searchable settings: startup monitor, full screen, laser trail, toolbar |
 | Tools > Add LiveView | Capture an application window or display as a container |
 | Tools > Freeze selected LiveView | Freeze or resume the selected live feed |
 | Tools > Reconnect selected LiveView | Select a new capture target for the existing container |
+| F11 | Toggle full screen; Escape leaves it when a text container is not being edited |
 
 With the mouse, selection is automatic: click a container to move it, or drag the circular bottom-right handle to resize it while preserving its aspect ratio. Double-click a container to center it and fit it to the canvas. Releasing the mouse returns to the previously selected drawing tool.
 

--- a/TODO.md
+++ b/TODO.md
@@ -28,15 +28,12 @@ Ordered by dependency first and effort second, so an item can be picked up as so
 above it are done. The feature work comes before the material that describes it, because a
 teaser and a documentation page written against a moving UI have to be redone.
 
-### 1. Configuration dialog
+### 1. Configuration dialog — done
 
-Settings are spread between defaults in code and whatever `AppSettingsStore` already persists,
-with no way to change them from the application. One dialog should own them: the monitor to
-open on, whether to start full screen, the laser pointer decay time, and the existing options
-now set only in code.
-
-First because it depends on nothing and because it gives every later preference somewhere to
-go. Without it, each new option is another constant to recompile.
+`Tools > Preferences...` is a searchable catalog: startup monitor, start full screen, laser
+trail timing, and the toolbar options. New settings are catalog entries rather than a new
+layout. The menu is still always visible; hide-on-demand is a later UI pass, not a missing
+piece of this item.
 
 ### 2. Drag and drop import
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO
 
-Outstanding work, roughly in the order it should be done. Items are written to be picked up
-cold: each says what to change and why it matters.
+Outstanding work, in the order it should be started. Items are written to be picked up cold:
+each says what to change and why it matters.
 
 Background reading, in this order:
 
@@ -10,41 +10,133 @@ Background reading, in this order:
 - [docs/decisions.md](docs/decisions.md) — why it is built that way. Each entry says whether it
   is implemented or only agreed.
 
-The delivery chain is working end to end: a merge to `main` builds, signs, and publishes a
-pre-release to GitHub Releases, and one approval promotes that same build to a release.
-<https://whiteboard.sqlbi.com> resolves its download links at load time and needs no edit per
-release.
+## Where the project stands
 
-## Before the first stable release
+0.2.1 is released. The delivery chain works end to end: a merge to `main` builds, signs, and
+publishes a pre-release to GitHub Releases, and one approval promotes that same build to a
+release. <https://whiteboard.sqlbi.com> resolves its download links at load time and needs no
+edit per release. The .NET 10 upgrade has been checked on real pen hardware, and the installers
+have been exercised on a real machine.
 
-### Re-check ink on real hardware after the .NET 10 upgrade
+Shipping is therefore no longer the problem. The 0.2.x releases exist to get builds into hands
+and to keep the pipeline exercised; **1.0 is the launch** — the version the site, the teaser,
+and the Store listing are written for. Everything below is what 1.0 needs.
 
-All seven projects now target .NET 10 and both CI definitions install the 10.0.x SDK. The
-solution builds with no warnings, the core smoke tests pass, all four installer variants
-package, and the published build starts.
+## The road to 1.0
 
-What that does not cover is the part that matters most: WPF ink and `RenderTargetBitmap`
-behaviour on a real pen display. Run the Wacom Cintiq Pro checks at the end of
-[README.md](README.md) before shipping.
+Ordered by dependency first and effort second, so an item can be picked up as soon as the ones
+above it are done. The feature work comes before the material that describes it, because a
+teaser and a documentation page written against a moving UI have to be redone.
 
-### Decide the first version number
+### 1. Configuration dialog
 
-`VersionPrefix` in `Directory.Build.props` reads `0.2.0`, bumped for the .NET 10 upgrade but
-still a development number. Changing that line is what starts a release (decision 8).
+Settings are spread between defaults in code and whatever `AppSettingsStore` already persists,
+with no way to change them from the application. One dialog should own them: the monitor to
+open on, whether to start full screen, the laser pointer decay time, and the existing options
+now set only in code.
 
-### Verify the installers on a real machine
+First because it depends on nothing and because it gives every later preference somewhere to
+go. Without it, each new option is another constant to recompile.
 
-Nothing in this list has been exercised on an installed build. The checklist is at the end of
-[docs/release-management.md](docs/release-management.md): signature verification, install,
-upgrade and uninstall for both scopes, the `.wboard` association, released and pre-release
-side by side, and a clean machine to confirm SmartScreen stays quiet.
+### 2. Drag and drop import
 
-### Promote the first release
+Dropping a file onto the canvas should import it as a container placed where the pointer was
+released, rather than at a default position. Images already arrive through the clipboard, so
+this is mostly hit-testing the drop point into camera space and reusing the existing import
+path.
 
-Approve the Release stage on a run whose version you intend to ship. Releasing the same
-version twice fails on the existing tag, which is the intended guard.
+Small and self-contained, and it becomes the natural entry point for the format below.
 
-## Distribution
+### 3. An import file format
+
+A plain-text format — Markdown is the obvious candidate — that builds a new whiteboard from
+images and text. This makes boards authorable outside the application and generatable by a
+script or an agent, instead of only by drawing.
+
+Two decisions to settle before writing code: which subset of Markdown maps to containers, and
+how positions are expressed when the source has none. Once the format exists, drag and drop
+carries it too.
+
+### 4. A rendered preview inside the `.wboard` archive
+
+Both previews below need a picture of the board without opening the application. Rendering one
+on demand means a full WPF load inside a shell extension, which is exactly what a thumbnail
+provider must not do. Writing a rendered bitmap into the archive on save makes both previews
+cheap.
+
+This is a file-format change, so it lands before its two consumers rather than being retrofitted
+around them. Boards saved by earlier versions carry no preview and have to degrade to the
+document icon.
+
+### 5. Preview of `.wboard` files in Explorer
+
+The association exists, but a `.wboard` file shows only the document icon. A thumbnail provider
+reading the embedded preview makes a folder of boards browsable. Note this adds the project's
+first shell extension, which the installer has to register and the uninstaller has to remove
+cleanly.
+
+### 6. Preview of `.wboard` files in VS Code
+
+The same preview in an editor: an extension that opens a `.wboard` file as an image rather than
+as an archive. Useful wherever boards live in a repository next to the material they document.
+Cheaper than the Explorer provider once the archive carries the bitmap, and shipped through the
+marketplace rather than through the installer.
+
+### 7. Video teaser
+
+A short recording that shows what the application does. Nothing about the product is obvious
+from a screenshot: ink following a pen, containers carrying their strokes, and LiveView all need
+motion to read. It is also the asset the landing page, the Store listing, and any announcement
+all need, so it sits on the critical path for all three.
+
+Here rather than earlier because it should show the 1.0 UI, including the configuration dialog
+and drag and drop.
+
+### 8. Documentation on whiteboard.sqlbi.com
+
+The site is a download page today. It needs real documentation: the tool set, containers,
+LiveView, the DAX and SQL Server text containers, the import format, and the keyboard and pen
+shortcuts. The README already carries most of this content, so the open question is whether the
+site renders from those files or keeps its own copy — decide that before writing the pages
+twice.
+
+### 9. Microsoft Store
+
+The largest remaining piece and the one with the longest lead time. It depends on none of the
+feature work above, so the packaging can start in parallel at any point; only the listing has to
+wait for the teaser and for screenshots of the finished UI.
+
+1. **Build an MSIX.** None exists; only MSIs are produced. `Bravo.Installer.Msix` in the Bravo
+   repository is the template. The application is already MSIX-clean: settings live in
+   `%APPDATA%`, the only registry use is a read, and nothing writes to the install folder. The
+   Explorer thumbnail provider is the one thing that changes this — an MSIX registers a shell
+   extension through its manifest rather than through installer custom actions, so items 5 and 9
+   have to agree on how the extension is declared.
+2. **Give the MSIX its own version derivation.** Store versions must end in `.0`, and the
+   current four-part scheme never produces that — the last part is seconds since midnight
+   divided by two.
+3. **Do the first submission by hand.** Listing text, screenshots, age rating, and privacy
+   details are one-time work no pipeline performs.
+4. **Then automate it** with the Microsoft Store Developer CLI or the Partner Center submission
+   API, as a stage that runs *in parallel* with the web release. Certification takes hours to
+   days and must never gate a download that is otherwise ready.
+
+Note the Store signs the package itself, so the SQLBI certificate is not involved. Store
+availability is also uneven on managed corporate machines, which is why the MSI channel stays
+the primary route rather than a fallback (decision 10).
+
+### 10. Finger mode
+
+Touch input as an alternative to the pen, for machines without one. Last because it is the only
+item here that may reasonably ship after 1.0: the interaction model assumes a pen and a separate
+pointing device, and finger drawing has to answer what pan and zoom do instead. That is a design
+question rather than an implementation one, and answering it badly under launch pressure is
+worse than shipping 1.0 as pen-first and adding touch in 1.1.
+
+## Distribution plumbing
+
+Independent of 1.0 and of each other. Neither blocks the launch, and both are cheaper to do
+before it than during it.
 
 ### Publish release manifests
 
@@ -57,82 +149,6 @@ instead of each deriving the same facts differently.
 `winget-releaser` opens a pull request against `microsoft/winget-pkgs` when a release is
 published. Only possible because the repository is public and the assets are unauthenticated.
 
-### Microsoft Store
-
-The largest remaining piece, and independent of everything above.
-
-1. **Build an MSIX.** None exists; only MSIs are produced. `Bravo.Installer.Msix` in the Bravo
-   repository is the template. The application is already MSIX-clean: settings live in
-   `%APPDATA%`, the only registry use is a read, and nothing writes to the install folder.
-2. **Give the MSIX its own version derivation.** Store versions must end in `.0`, and the
-   current four-part scheme never produces that — the last part is seconds since midnight
-   divided by two.
-3. **Do the first submission by hand.** Listing text, screenshots, age rating, and privacy
-   details are one-time work no pipeline performs.
-4. **Then automate it** with the Microsoft Store Developer CLI or the Partner Center
-   submission API, as a stage that runs *in parallel* with the web release. Certification takes
-   hours to days and must never gate a download that is otherwise ready.
-
-Note the Store signs the package itself, so the SQLBI certificate is not involved. Store
-availability is also uneven on managed corporate machines, which is why the MSI channel stays
-the primary route rather than a fallback (decision 10).
-
-## Product work
-
-Features and material not yet built, listed independently of the release plumbing above.
-
-### Documentation on whiteboard.sqlbi.com
-
-The site is a download page today. It needs real documentation: the tool set, containers,
-LiveView, the DAX and SQL Server text containers, and the keyboard and pen shortcuts. The
-README already carries most of this content, so the open question is whether the site renders
-from those files or keeps its own copy.
-
-### Video teaser
-
-A short recording that shows what the application does. Nothing about the product is obvious
-from a screenshot: ink following a pen, containers carrying their strokes, and LiveView all
-need motion to read. It is also the asset the landing page, the Store listing, and any
-announcement all need.
-
-### Configuration dialog
-
-Settings are spread between defaults in code and whatever `AppSettingsStore` already persists,
-with no way to change them from the application. One dialog should own them: the monitor to
-open on, whether to start full screen, the laser pointer decay time, and the existing options
-now set only in code.
-
-### Preview of `.wboard` files in Explorer
-
-The association exists, but a `.wboard` file shows only the document icon. A thumbnail
-provider that renders the board would make a folder of boards browsable. The archive would
-need to carry a rendered preview for this to be cheap, which is a file-format decision as much
-as a shell-extension one.
-
-### Preview of `.wboard` files in VS Code
-
-The same preview in an editor: an extension that opens a `.wboard` file as an image rather
-than as an archive. Useful wherever boards live in a repository next to the material they
-document.
-
-### An import file format
-
-A plain-text format — Markdown is the obvious candidate — that builds a new whiteboard from
-images and text. This makes boards authorable outside the application and generatable by a
-script or an agent, instead of only by drawing.
-
-### Drag and drop import
-
-Dropping a file onto the canvas should import it as a container placed where the pointer was
-released, rather than at a default position. This applies to images and to the import format
-above.
-
-### Finger mode
-
-Touch input as an alternative to the pen, for machines without one. Timing is open, and it may
-be better after the first stable release: the interaction model assumes a pen and a separate
-pointing device, and finger drawing has to answer what pan and zoom do instead.
-
 ## Deferred, deliberately
 
 - **arm64.** Not built. Worth adding if Surface devices matter for a pen application.
@@ -141,4 +157,4 @@ pointing device, and finger drawing has to answer what pan and zoom do instead.
   change the SVG and rerun `scripts/build-assets.ps1`.
 - **Landing page copy.** The tagline and feature list on `site/index.html` were drafted from
   the README and have not had an editorial pass. They are the first thing anyone reads about
-  the product.
+  the product, and the documentation work above supersedes them if it lands first.

--- a/TODO.md
+++ b/TODO.md
@@ -77,11 +77,65 @@ Note the Store signs the package itself, so the SQLBI certificate is not involve
 availability is also uneven on managed corporate machines, which is why the MSI channel stays
 the primary route rather than a fallback (decision 10).
 
+## Product work
+
+Features and material not yet built, listed independently of the release plumbing above.
+
+### Documentation on whiteboard.sqlbi.com
+
+The site is a download page today. It needs real documentation: the tool set, containers,
+LiveView, the DAX and SQL Server text containers, and the keyboard and pen shortcuts. The
+README already carries most of this content, so the open question is whether the site renders
+from those files or keeps its own copy.
+
+### Video teaser
+
+A short recording that shows what the application does. Nothing about the product is obvious
+from a screenshot: ink following a pen, containers carrying their strokes, and LiveView all
+need motion to read. It is also the asset the landing page, the Store listing, and any
+announcement all need.
+
+### Configuration dialog
+
+Settings are spread between defaults in code and whatever `AppSettingsStore` already persists,
+with no way to change them from the application. One dialog should own them: the monitor to
+open on, whether to start full screen, the laser pointer decay time, and the existing options
+now set only in code.
+
+### Preview of `.wboard` files in Explorer
+
+The association exists, but a `.wboard` file shows only the document icon. A thumbnail
+provider that renders the board would make a folder of boards browsable. The archive would
+need to carry a rendered preview for this to be cheap, which is a file-format decision as much
+as a shell-extension one.
+
+### Preview of `.wboard` files in VS Code
+
+The same preview in an editor: an extension that opens a `.wboard` file as an image rather
+than as an archive. Useful wherever boards live in a repository next to the material they
+document.
+
+### An import file format
+
+A plain-text format — Markdown is the obvious candidate — that builds a new whiteboard from
+images and text. This makes boards authorable outside the application and generatable by a
+script or an agent, instead of only by drawing.
+
+### Drag and drop import
+
+Dropping a file onto the canvas should import it as a container placed where the pointer was
+released, rather than at a default position. This applies to images and to the import format
+above.
+
+### Finger mode
+
+Touch input as an alternative to the pen, for machines without one. Timing is open, and it may
+be better after the first stable release: the interaction model assumes a pen and a separate
+pointing device, and finger drawing has to answer what pan and zoom do instead.
+
 ## Deferred, deliberately
 
 - **arm64.** Not built. Worth adding if Surface devices matter for a pen application.
-- **Telemetry.** Bravo's installer custom action and opt-in checkboxes were not ported
-  (decision 14). Port only if the data is actually wanted.
 - **The brand mark.** The icon is the Fluent whiteboard glyph in SQLBI colours: in-family and
   deliberate, but not distinctive (decision 12). Replacing it touches no installer plumbing —
   change the SVG and rerun `scripts/build-assets.ps1`.

--- a/src/SQLBI.Whiteboard.Core/Settings/AppSettings.cs
+++ b/src/SQLBI.Whiteboard.Core/Settings/AppSettings.cs
@@ -36,6 +36,17 @@ public enum CalligraphyAccess
     DualPalette = 2,
 }
 
+public enum StartupMonitorKind
+{
+    /// <summary>
+    /// Current default: a Wacom/Cintiq if one is attached, otherwise
+    /// the monitor Windows selected for the window.
+    /// </summary>
+    WacomIfPresent = 0,
+    Primary = 1,
+    Named = 2,
+}
+
 public sealed class AppSettings
 {
     public int Version { get; set; } = AppSettingsSerializer.CurrentVersion;
@@ -43,6 +54,12 @@ public sealed class AppSettings
     public ToolbarPlacement ToolbarPlacement { get; set; } = ToolbarPlacement.TopRight;
 
     public CalligraphyAccess CalligraphyAccess { get; set; } = CalligraphyAccess.DualPalette;
+
+    public StartupMonitorKind StartupMonitor { get; set; } = StartupMonitorKind.WacomIfPresent;
+
+    public string? StartupMonitorName { get; set; }
+
+    public bool StartFullScreen { get; set; }
 
     public InkToolSettings Pen { get; set; } = InkToolSettings.From(InkPalettes.DefaultPen);
 
@@ -57,7 +74,7 @@ public sealed class AppSettings
 
 public static class AppSettingsSerializer
 {
-    public const int CurrentVersion = 6;
+    public const int CurrentVersion = 7;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -123,6 +140,28 @@ public static class AppSettingsSerializer
         if (!Enum.IsDefined(settings.CalligraphyAccess))
         {
             settings.CalligraphyAccess = CalligraphyAccess.DualPalette;
+        }
+
+        if (!Enum.IsDefined(settings.StartupMonitor))
+        {
+            settings.StartupMonitor = StartupMonitorKind.WacomIfPresent;
+        }
+
+        if (settings.StartupMonitor == StartupMonitorKind.Named)
+        {
+            if (string.IsNullOrWhiteSpace(settings.StartupMonitorName))
+            {
+                settings.StartupMonitor = StartupMonitorKind.WacomIfPresent;
+                settings.StartupMonitorName = null;
+            }
+            else
+            {
+                settings.StartupMonitorName = settings.StartupMonitorName.Trim();
+            }
+        }
+        else
+        {
+            settings.StartupMonitorName = null;
         }
 
         settings.Pen = InkPalettes.Normalize(settings.Pen, PenKind.Pen);

--- a/src/SQLBI.Whiteboard/App.xaml
+++ b/src/SQLBI.Whiteboard/App.xaml
@@ -5,6 +5,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/Toolbar.xaml" />
+                <ResourceDictionary Source="Themes/Settings.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -149,7 +149,14 @@ public partial class MainWindow : Window
 
     private void MainWindow_SourceInitialized(object? sender, EventArgs e)
     {
-        MonitorStartupPlacement.PlaceMaximizedOnWacom(this);
+        MonitorStartupPlacement.PlaceMaximized(
+            this,
+            _settings.StartupMonitor,
+            _settings.StartupMonitorName);
+        if (_settings.StartFullScreen)
+        {
+            EnterFullScreen();
+        }
     }
 
     private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
@@ -2405,13 +2412,17 @@ public partial class MainWindow : Window
         }
     }
 
+    private void ApplyPreferences()
+    {
+        ApplyToolbarPlacement();
+        ApplyCalligraphyAccess();
+        ApplyLaserSettings();
+        PersistSettings();
+    }
+
     private void PreferencesMenuItem_Click(object sender, RoutedEventArgs e)
     {
-        var dialog = new PreferencesWindow(
-            _settings.ToolbarPlacement,
-            _settings.CalligraphyAccess,
-            SetToolbarPlacement,
-            SetCalligraphyAccess)
+        var dialog = new PreferencesWindow(_settings, ApplyPreferences)
         {
             Owner = this,
         };

--- a/src/SQLBI.Whiteboard/MonitorStartupPlacement.cs
+++ b/src/SQLBI.Whiteboard/MonitorStartupPlacement.cs
@@ -4,33 +4,52 @@ using System.Text;
 using System.Windows;
 using System.Windows.Interop;
 using Microsoft.Win32;
+using SQLBI.Whiteboard.Core.Settings;
 
 namespace SQLBI.Whiteboard;
+
+internal sealed record DisplayMonitor(string DeviceName, string? FriendlyName, bool IsPrimary)
+{
+    public string DisplayName =>
+        string.IsNullOrWhiteSpace(FriendlyName) ? DeviceName : FriendlyName;
+}
 
 internal static class MonitorStartupPlacement
 {
     private const uint EddGetDeviceInterfaceName = 0x00000001;
     private const uint MonitorDefaultToNearest = 0x00000002;
+    private const uint MonitorInfoPrimary = 0x00000001;
     private const uint SwpNoZOrder = 0x0004;
     private const uint SwpNoActivate = 0x0010;
     private const uint SwpFrameChanged = 0x0020;
 
-    public static void PlaceMaximizedOnWacom(Window window)
+    public static IReadOnlyList<DisplayMonitor> Enumerate() =>
+        EnumerateMonitors()
+            .Select(monitor => new DisplayMonitor(
+                monitor.DeviceName,
+                monitor.MonitorName,
+                monitor.IsPrimary))
+            .ToArray();
+
+    public static void PlaceMaximized(
+        Window window,
+        StartupMonitorKind kind,
+        string? name)
     {
         ArgumentNullException.ThrowIfNull(window);
 
-        var target = EnumerateMonitors().FirstOrDefault(monitor =>
-            IsWacomMonitorName(monitor.MonitorName));
+        var monitors = EnumerateMonitors();
+        var target = FindTarget(monitors, kind, name);
         if (target is null)
         {
             Debug.WriteLine(
-                "[Startup] No Wacom/Cintiq monitor name was found; maximizing on the Windows-selected monitor.");
+                "[Startup] No matching monitor was found; maximizing on the Windows-selected monitor.");
             window.WindowState = WindowState.Maximized;
             return;
         }
 
         Debug.WriteLine(
-            $"[Startup] Using {target.MonitorName} on {target.DeviceName}.");
+            $"[Startup] Using {target.MonitorName ?? target.DeviceName} on {target.DeviceName}.");
         var windowHandle = new WindowInteropHelper(window).Handle;
         var area = target.WorkingArea;
         SetWindowPos(
@@ -43,6 +62,27 @@ internal static class MonitorStartupPlacement
             SwpNoZOrder | SwpNoActivate);
         window.WindowState = WindowState.Maximized;
     }
+
+    private static MonitorDescriptor? FindTarget(
+        IReadOnlyList<MonitorDescriptor> monitors,
+        StartupMonitorKind kind,
+        string? name) =>
+        kind switch
+        {
+            StartupMonitorKind.Primary =>
+                monitors.FirstOrDefault(monitor => monitor.IsPrimary),
+            StartupMonitorKind.Named when !string.IsNullOrWhiteSpace(name) =>
+                monitors.FirstOrDefault(monitor =>
+                    string.Equals(
+                        string.IsNullOrWhiteSpace(monitor.MonitorName)
+                            ? monitor.DeviceName
+                            : monitor.MonitorName,
+                        name,
+                        StringComparison.OrdinalIgnoreCase)),
+            StartupMonitorKind.WacomIfPresent =>
+                monitors.FirstOrDefault(monitor => IsWacomMonitorName(monitor.MonitorName)),
+            _ => null,
+        };
 
     public static void FillCurrentMonitor(Window window)
     {
@@ -94,6 +134,7 @@ internal static class MonitorStartupPlacement
                     monitors.Add(new MonitorDescriptor(
                         monitorInfo.DeviceName,
                         ReadMonitorName(monitorInfo.DeviceName),
+                        (monitorInfo.Flags & MonitorInfoPrimary) != 0,
                         monitorInfo.WorkingArea));
                 }
 
@@ -214,6 +255,7 @@ internal static class MonitorStartupPlacement
     private sealed record MonitorDescriptor(
         string DeviceName,
         string? MonitorName,
+        bool IsPrimary,
         NativeRectangle WorkingArea);
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/src/SQLBI.Whiteboard/PreferencesWindow.xaml
+++ b/src/SQLBI.Whiteboard/PreferencesWindow.xaml
@@ -2,76 +2,56 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Preferences"
-        Width="420"
-        Height="340"
-        MinWidth="360"
-        MinHeight="300"
+        Width="720"
+        Height="560"
+        MinWidth="560"
+        MinHeight="400"
         WindowStartupLocation="CenterOwner"
-        ResizeMode="NoResize"
+        ResizeMode="CanResize"
         ShowInTaskbar="False"
-        Background="#FFF9F9F9">
+        Background="{DynamicResource ToolbarBackgroundBrush}"
+        Stylus.IsPressAndHoldEnabled="False"
+        PreviewKeyDown="Window_PreviewKeyDown"
+        Loaded="Window_Loaded">
     <Grid Margin="20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <TextBlock Grid.Row="0"
-                   Margin="0,0,0,8"
-                   FontSize="13"
-                   Text="Toolbar position" />
-        <ComboBox x:Name="PlacementCombo"
-                  Grid.Row="1"
-                  MinHeight="32"
-                  SelectionChanged="PlacementCombo_SelectionChanged">
-            <ComboBoxItem Tag="TopRight"
-                          Content="Top right" />
-            <ComboBoxItem Tag="TopLeft"
-                          Content="Top left" />
-            <ComboBoxItem Tag="BottomRight"
-                          Content="Bottom right" />
-            <ComboBoxItem Tag="BottomLeft"
-                          Content="Bottom left" />
-            <ComboBoxItem Tag="BottomCenter"
-                          Content="Bottom center" />
-        </ComboBox>
-        <TextBlock Grid.Row="2"
-                   Margin="0,8,0,16"
-                   TextWrapping="Wrap"
-                   Foreground="#FF4B5563"
-                   Text="Top right keeps the toolbar under a typical presenter picture-in-picture during recording." />
+        <Border Style="{StaticResource SettingsSearchHost}">
+            <Grid>
+                <TextBlock x:Name="SearchPlaceholder"
+                           Style="{StaticResource SettingsPlaceholder}"
+                           Text="Search settings" />
+                <TextBox x:Name="SearchBox"
+                         Style="{StaticResource SettingsSearchBox}"
+                         TextChanged="SearchBox_TextChanged" />
+            </Grid>
+        </Border>
 
-        <TextBlock Grid.Row="3"
-                   Margin="0,0,0,8"
-                   FontSize="13"
-                   Text="Toolbar layout" />
-        <ComboBox x:Name="CalligraphyCombo"
-                  Grid.Row="4"
-                  MinHeight="32"
-                  SelectionChanged="CalligraphyCombo_SelectionChanged">
-            <ComboBoxItem Tag="DualPalette"
-                          Content="Dual palette (pen and highlighter together)" />
-            <ComboBoxItem Tag="Chevron"
-                          Content="Chevron on the Pen button" />
-            <ComboBoxItem Tag="SizeRow"
-                          Content="Icons beside the size chips" />
-        </ComboBox>
-        <TextBlock Grid.Row="5"
-                   Margin="0,8,0,0"
-                   TextWrapping="Wrap"
-                   Foreground="#FF4B5563"
-                   Text="Dual palette keeps both tools’ colors and sizes visible. The other layouts use a compact bar and a single-tool panel." />
-        <Button Grid.Row="6"
-                HorizontalAlignment="Right"
-                MinWidth="88"
-                MinHeight="30"
-                IsDefault="True"
-                Content="Close"
-                Click="CloseButton_Click" />
+        <Grid Grid.Row="1"
+              Margin="0,16,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="180"
+                                  MinWidth="140" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel x:Name="CategoryHost"
+                        Margin="0,0,16,0" />
+
+            <ScrollViewer Grid.Column="1"
+                          HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto">
+                <StackPanel x:Name="SettingsHost" />
+            </ScrollViewer>
+
+            <TextBlock x:Name="EmptyState"
+                       Grid.Column="1"
+                       Style="{StaticResource SettingsEmpty}"
+                       Text="No settings match."
+                       Visibility="Collapsed" />
+        </Grid>
     </Grid>
 </Window>

--- a/src/SQLBI.Whiteboard/PreferencesWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/PreferencesWindow.xaml.cs
@@ -1,46 +1,133 @@
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
 using SQLBI.Whiteboard.Core.Settings;
 
 namespace SQLBI.Whiteboard;
 
 public partial class PreferencesWindow : Window
 {
-    private readonly Action<ToolbarPlacement> _applyPlacement;
-    private readonly Action<CalligraphyAccess> _applyCalligraphyAccess;
+    private readonly AppSettings _settings;
+    private readonly Action _applied;
+    private readonly IReadOnlyList<DisplayMonitor> _monitors;
+    private string? _selectedCategory;
     private bool _suppressChange;
 
-    public PreferencesWindow(
-        ToolbarPlacement currentPlacement,
-        CalligraphyAccess currentCalligraphyAccess,
-        Action<ToolbarPlacement> applyPlacement,
-        Action<CalligraphyAccess> applyCalligraphyAccess)
+    public PreferencesWindow(AppSettings settings, Action applied)
     {
-        ArgumentNullException.ThrowIfNull(applyPlacement);
-        ArgumentNullException.ThrowIfNull(applyCalligraphyAccess);
-        _applyPlacement = applyPlacement;
-        _applyCalligraphyAccess = applyCalligraphyAccess;
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(applied);
+        _settings = settings;
+        _applied = applied;
+        _monitors = MonitorStartupPlacement.Enumerate();
         InitializeComponent();
-        SelectCombo(PlacementCombo, currentPlacement.ToString());
-        SelectCombo(CalligraphyCombo, currentCalligraphyAccess.ToString());
+        Rebuild();
     }
 
-    private void SelectCombo(ComboBox combo, string tag)
+    private void Window_Loaded(object sender, RoutedEventArgs e) => SearchBox.Focus();
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
     {
+        if (e.Key != Key.Escape)
+        {
+            return;
+        }
+
+        Close();
+        e.Handled = true;
+    }
+
+    private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        SearchPlaceholder.Visibility = string.IsNullOrEmpty(SearchBox.Text)
+            ? Visibility.Visible
+            : Visibility.Collapsed;
+        Rebuild();
+    }
+
+    private void Rebuild()
+    {
+        var query = SearchBox.Text;
+        var matching = SettingsCatalog.Filter(query, category: null);
+        var visibleCategories = SettingsCatalog.CategoriesFor(matching);
+        if (_selectedCategory is not null &&
+            !visibleCategories.Contains(_selectedCategory, StringComparer.Ordinal))
+        {
+            _selectedCategory = null;
+        }
+
+        var visible = SettingsCatalog.Filter(query, _selectedCategory);
+        RebuildCategories(visibleCategories);
+        RebuildSettings(visible);
+    }
+
+    private void RebuildCategories(IReadOnlyList<string> categories)
+    {
+        CategoryHost.Children.Clear();
+        foreach (var category in categories)
+        {
+            var button = new ToggleButton
+            {
+                Style = (Style)FindResource("SettingsCategoryButton"),
+                Content = category,
+                Tag = category,
+                IsChecked = category == _selectedCategory,
+            };
+            button.Click += CategoryButton_Click;
+            CategoryHost.Children.Add(button);
+        }
+    }
+
+    private void CategoryButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not ToggleButton { Tag: string category })
+        {
+            return;
+        }
+
+        _selectedCategory = category == _selectedCategory ? null : category;
+        Rebuild();
+    }
+
+    private void RebuildSettings(IReadOnlyList<SettingDescriptor> settings)
+    {
+        SettingsHost.Children.Clear();
+        var empty = settings.Count == 0;
+        EmptyState.Visibility = empty ? Visibility.Visible : Visibility.Collapsed;
+        if (empty)
+        {
+            return;
+        }
+
+        var showHeadings = DistinctCategoryCount(settings) > 1;
+        string? lastCategory = null;
+        var firstHeading = true;
         _suppressChange = true;
         try
         {
-            foreach (var item in combo.Items.OfType<ComboBoxItem>())
+            foreach (var setting in settings)
             {
-                if (item.Tag is string name &&
-                    string.Equals(name, tag, StringComparison.Ordinal))
+                if (showHeadings && setting.Category != lastCategory)
                 {
-                    combo.SelectedItem = item;
-                    return;
-                }
-            }
+                    var heading = new TextBlock
+                    {
+                        Style = (Style)FindResource("SettingsHeading"),
+                        Text = setting.Category.ToUpperInvariant(),
+                    };
+                    if (firstHeading)
+                    {
+                        heading.Margin = new Thickness(4, 0, 4, 4);
+                        firstHeading = false;
+                    }
 
-            combo.SelectedIndex = 0;
+                    SettingsHost.Children.Add(heading);
+                    lastCategory = setting.Category;
+                }
+
+                SettingsHost.Children.Add(CreateRow(setting));
+            }
         }
         finally
         {
@@ -48,29 +135,330 @@ public partial class PreferencesWindow : Window
         }
     }
 
-    private void PlacementCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    private Border CreateRow(SettingDescriptor setting)
+    {
+        var editor = CreateEditor(setting);
+        var copy = new StackPanel();
+        copy.Children.Add(new TextBlock
+        {
+            Style = (Style)FindResource("SettingsTitle"),
+            Text = setting.Title,
+        });
+        copy.Children.Add(new TextBlock
+        {
+            Style = (Style)FindResource("SettingsDescription"),
+            Text = setting.Description,
+        });
+
+        var body = new Grid();
+        if (setting.Editor == SettingEditorKind.DoubleRange)
+        {
+            body.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            body.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            body.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            body.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            var slider = (Slider)editor;
+            var value = new TextBlock
+            {
+                Style = (Style)FindResource("SettingsValueLabel"),
+                Text = FormatSeconds(slider.Value),
+            };
+            slider.ValueChanged += (_, _) => value.Text = FormatSeconds(slider.Value);
+            Grid.SetColumn(value, 1);
+            Grid.SetRow(slider, 1);
+            Grid.SetColumnSpan(slider, 2);
+            body.Children.Add(copy);
+            body.Children.Add(value);
+            body.Children.Add(slider);
+        }
+        else
+        {
+            body.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            body.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            Grid.SetColumn(editor, 1);
+            editor.Margin = new Thickness(16, 0, 0, 0);
+            editor.VerticalAlignment = VerticalAlignment.Center;
+            body.Children.Add(copy);
+            body.Children.Add(editor);
+        }
+
+        return new Border
+        {
+            Style = (Style)FindResource("SettingsRow"),
+            Child = body,
+        };
+    }
+
+    private FrameworkElement CreateEditor(SettingDescriptor setting) =>
+        setting.Editor switch
+        {
+            SettingEditorKind.BooleanSwitch => CreateSwitch(setting),
+            SettingEditorKind.DoubleRange => CreateSlider(setting),
+            SettingEditorKind.MonitorChoice => CreateMonitorCombo(),
+            _ => CreateEnumCombo(setting),
+        };
+
+    private ToggleButton CreateSwitch(SettingDescriptor setting)
+    {
+        var button = new ToggleButton
+        {
+            Style = (Style)FindResource("SettingsSwitch"),
+            IsChecked = setting.Id == SettingsCatalog.Ids.StartFullScreen && _settings.StartFullScreen,
+        };
+        button.Checked += (_, _) => SetBoolean(setting, true);
+        button.Unchecked += (_, _) => SetBoolean(setting, false);
+        return button;
+    }
+
+    private Slider CreateSlider(SettingDescriptor setting)
+    {
+        var value = setting.Id == SettingsCatalog.Ids.LaserFadeSeconds
+            ? _settings.Laser.FadeSeconds
+            : _settings.Laser.HoldSeconds;
+        var slider = new Slider
+        {
+            Style = (Style)FindResource("SettingsSlider"),
+            Minimum = setting.Minimum,
+            Maximum = setting.Maximum,
+            SmallChange = setting.Id == SettingsCatalog.Ids.LaserFadeSeconds ? 0.05 : 0.25,
+            LargeChange = setting.Id == SettingsCatalog.Ids.LaserFadeSeconds ? 0.5 : 1,
+            TickFrequency = setting.Id == SettingsCatalog.Ids.LaserFadeSeconds ? 0.05 : 0.25,
+            IsSnapToTickEnabled = true,
+            Value = value,
+        };
+        slider.ValueChanged += (_, _) => SetRange(setting, slider.Value);
+        return slider;
+    }
+
+    private ComboBox CreateEnumCombo(SettingDescriptor setting)
+    {
+        var combo = new ComboBox
+        {
+            Style = (Style)FindResource("SettingsComboBox"),
+        };
+        foreach (var choice in setting.Choices)
+        {
+            combo.Items.Add(choice);
+        }
+
+        combo.SelectedItem = setting.Choices.FirstOrDefault(choice =>
+            choice.Id == CurrentEnumId(setting));
+        combo.SelectionChanged += (_, _) =>
+        {
+            if (combo.SelectedItem is SettingChoice choice)
+            {
+                SetEnum(setting, choice.Id);
+            }
+        };
+        return combo;
+    }
+
+    private ComboBox CreateMonitorCombo()
+    {
+        var combo = new ComboBox
+        {
+            Style = (Style)FindResource("SettingsComboBox"),
+        };
+        foreach (var item in BuildMonitorItems())
+        {
+            combo.Items.Add(item);
+        }
+
+        SelectMonitorItem(combo);
+        combo.SelectionChanged += MonitorCombo_SelectionChanged;
+        return combo;
+    }
+
+    private List<MonitorChoiceItem> BuildMonitorItems()
+    {
+        var items = new List<MonitorChoiceItem>
+        {
+            new()
+            {
+                Kind = StartupMonitorKind.WacomIfPresent,
+                Title = "Wacom / Cintiq if present",
+            },
+            new()
+            {
+                Kind = StartupMonitorKind.Primary,
+                Title = "Primary monitor",
+            },
+        };
+
+        if (_monitors.Count > 0)
+        {
+            items.Add(new() { IsSeparator = true, Title = string.Empty });
+            foreach (var monitor in _monitors)
+            {
+                items.Add(new()
+                {
+                    Kind = StartupMonitorKind.Named,
+                    Name = monitor.DisplayName,
+                    Title = monitor.DisplayName,
+                });
+            }
+        }
+
+        if (_settings.StartupMonitor == StartupMonitorKind.Named &&
+            !string.IsNullOrWhiteSpace(_settings.StartupMonitorName) &&
+            !_monitors.Any(monitor =>
+                string.Equals(
+                    monitor.DisplayName,
+                    _settings.StartupMonitorName,
+                    StringComparison.OrdinalIgnoreCase)))
+        {
+            items.Add(new()
+            {
+                Kind = StartupMonitorKind.Named,
+                Name = _settings.StartupMonitorName,
+                Title = $"{_settings.StartupMonitorName} (not connected)",
+                IsAvailable = false,
+            });
+        }
+
+        return items;
+    }
+
+    private void SelectMonitorItem(ComboBox combo)
+    {
+        foreach (var choice in combo.Items.OfType<MonitorChoiceItem>())
+        {
+            var selected = choice.Kind == _settings.StartupMonitor &&
+                           (choice.Kind != StartupMonitorKind.Named ||
+                            string.Equals(
+                                choice.Name,
+                                _settings.StartupMonitorName,
+                                StringComparison.OrdinalIgnoreCase));
+            if (selected)
+            {
+                combo.SelectedItem = choice;
+                return;
+            }
+        }
+
+        combo.SelectedIndex = 0;
+    }
+
+    private void MonitorCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_suppressChange ||
-            PlacementCombo.SelectedItem is not ComboBoxItem { Tag: string name } ||
-            !Enum.TryParse<ToolbarPlacement>(name, out var placement))
+            sender is not ComboBox combo ||
+            combo.SelectedItem is not MonitorChoiceItem choice ||
+            !choice.IsAvailable ||
+            choice.IsSeparator)
         {
             return;
         }
 
-        _applyPlacement(placement);
+        _settings.StartupMonitor = choice.Kind;
+        _settings.StartupMonitorName = choice.Kind == StartupMonitorKind.Named ? choice.Name : null;
+        NotifyApplied();
     }
 
-    private void CalligraphyCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    private string CurrentEnumId(SettingDescriptor setting) =>
+        setting.Id switch
+        {
+            SettingsCatalog.Ids.LaserHoldMode => _settings.Laser.HoldMode.ToString(),
+            SettingsCatalog.Ids.ToolbarPlacement => _settings.ToolbarPlacement.ToString(),
+            SettingsCatalog.Ids.ToolbarLayout => _settings.CalligraphyAccess.ToString(),
+            _ => string.Empty,
+        };
+
+    private void SetBoolean(SettingDescriptor setting, bool value)
     {
-        if (_suppressChange ||
-            CalligraphyCombo.SelectedItem is not ComboBoxItem { Tag: string name } ||
-            !Enum.TryParse<CalligraphyAccess>(name, out var access))
+        if (_suppressChange || setting.Id != SettingsCatalog.Ids.StartFullScreen)
         {
             return;
         }
 
-        _applyCalligraphyAccess(access);
+        _settings.StartFullScreen = value;
+        NotifyApplied();
     }
 
-    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+    private void SetRange(SettingDescriptor setting, double value)
+    {
+        if (_suppressChange)
+        {
+            return;
+        }
+
+        if (setting.Id == SettingsCatalog.Ids.LaserFadeSeconds)
+        {
+            _settings.Laser.FadeSeconds = value;
+        }
+        else
+        {
+            _settings.Laser.HoldSeconds = value;
+        }
+
+        _settings.Laser = LaserSettings.Normalize(_settings.Laser);
+        NotifyApplied();
+    }
+
+    private void SetEnum(SettingDescriptor setting, string id)
+    {
+        if (_suppressChange)
+        {
+            return;
+        }
+
+        switch (setting.Id)
+        {
+            case SettingsCatalog.Ids.LaserHoldMode
+                when Enum.TryParse<LaserHoldMode>(id, out var holdMode):
+                _settings.Laser.HoldMode = holdMode;
+                break;
+            case SettingsCatalog.Ids.ToolbarPlacement
+                when Enum.TryParse<ToolbarPlacement>(id, out var placement):
+                _settings.ToolbarPlacement = placement;
+                break;
+            case SettingsCatalog.Ids.ToolbarLayout
+                when Enum.TryParse<CalligraphyAccess>(id, out var access):
+                _settings.CalligraphyAccess = access;
+                break;
+            default:
+                return;
+        }
+
+        NotifyApplied();
+    }
+
+    private void NotifyApplied()
+    {
+        if (!_suppressChange)
+        {
+            _applied();
+        }
+    }
+
+    private static int DistinctCategoryCount(IReadOnlyList<SettingDescriptor> settings)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var setting in settings)
+        {
+            seen.Add(setting.Category);
+        }
+
+        return seen.Count;
+    }
+
+    private static string FormatSeconds(double value)
+    {
+        var rounded = Math.Round(value, 2, MidpointRounding.AwayFromZero);
+        var text = rounded.ToString(rounded == Math.Truncate(rounded) ? "0" : "0.##", CultureInfo.CurrentCulture);
+        return $"{text} s";
+    }
+
+    private sealed class MonitorChoiceItem
+    {
+        public StartupMonitorKind Kind { get; init; }
+
+        public string? Name { get; init; }
+
+        public required string Title { get; init; }
+
+        public bool IsSeparator { get; init; }
+
+        public bool IsAvailable { get; init; } = true;
+    }
 }

--- a/src/SQLBI.Whiteboard/SettingsCatalog.cs
+++ b/src/SQLBI.Whiteboard/SettingsCatalog.cs
@@ -1,0 +1,190 @@
+using SQLBI.Whiteboard.Core.Settings;
+
+namespace SQLBI.Whiteboard;
+
+internal enum SettingEditorKind
+{
+    EnumChoice,
+    BooleanSwitch,
+    DoubleRange,
+    MonitorChoice,
+}
+
+internal sealed class SettingChoice
+{
+    public required string Id { get; init; }
+
+    public required string Title { get; init; }
+
+    public bool IsSeparator { get; init; }
+
+    public bool IsAvailable { get; init; } = true;
+}
+
+internal sealed class SettingDescriptor
+{
+    public required string Id { get; init; }
+
+    public required string Category { get; init; }
+
+    public required string Title { get; init; }
+
+    public required string Description { get; init; }
+
+    public required string[] Keywords { get; init; }
+
+    public required SettingEditorKind Editor { get; init; }
+
+    public IReadOnlyList<SettingChoice> Choices { get; init; } = [];
+
+    public double Minimum { get; init; }
+
+    public double Maximum { get; init; }
+}
+
+internal static class SettingsCatalog
+{
+    public static class Ids
+    {
+        public const string StartupMonitor = "startup.monitor";
+        public const string StartFullScreen = "startup.fullscreen";
+        public const string LaserHoldSeconds = "laser.holdSeconds";
+        public const string LaserFadeSeconds = "laser.fadeSeconds";
+        public const string LaserHoldMode = "laser.holdMode";
+        public const string ToolbarPlacement = "toolbar.placement";
+        public const string ToolbarLayout = "toolbar.layout";
+    }
+
+    public const string Startup = "Startup";
+    public const string Laser = "Laser pointer";
+    public const string Toolbar = "Toolbar";
+
+    public static IReadOnlyList<string> Categories { get; } = [Startup, Laser, Toolbar];
+
+    public static IReadOnlyList<SettingDescriptor> All { get; } =
+    [
+        new()
+        {
+            Id = Ids.StartupMonitor,
+            Category = Startup,
+            Title = "Open on",
+            Description = "Which display the window uses at launch.",
+            Keywords = ["monitor", "display", "cintiq", "wacom", "screen"],
+            Editor = SettingEditorKind.MonitorChoice,
+        },
+        new()
+        {
+            Id = Ids.StartFullScreen,
+            Category = Startup,
+            Title = "Start full screen",
+            Description = "Hide the menu and title bar the next time the application starts. F11 still toggles this session.",
+            Keywords = ["fullscreen", "full screen", "f11", "maximize"],
+            Editor = SettingEditorKind.BooleanSwitch,
+        },
+        new()
+        {
+            Id = Ids.LaserHoldSeconds,
+            Category = Laser,
+            Title = "Trail duration",
+            Description = "How long the laser stays fully visible after you lift.",
+            Keywords = ["laser", "decay", "hold", "trail", "duration"],
+            Editor = SettingEditorKind.DoubleRange,
+            Minimum = LaserSettings.MinimumHoldSeconds,
+            Maximum = LaserSettings.MaximumHoldSeconds,
+        },
+        new()
+        {
+            Id = Ids.LaserFadeSeconds,
+            Category = Laser,
+            Title = "Fade duration",
+            Description = "How long the trail takes to disappear after the hold.",
+            Keywords = ["laser", "fade", "decay", "trail"],
+            Editor = SettingEditorKind.DoubleRange,
+            Minimum = LaserSettings.MinimumFadeSeconds,
+            Maximum = LaserSettings.MaximumFadeSeconds,
+        },
+        new()
+        {
+            Id = Ids.LaserHoldMode,
+            Category = Laser,
+            Title = "Hold",
+            Description = "Whether a new stroke keeps the previous trail alive or starts its own timer.",
+            Keywords = ["laser", "hold", "shared", "stroke"],
+            Editor = SettingEditorKind.EnumChoice,
+            Choices =
+            [
+                new() { Id = nameof(LaserHoldMode.Shared), Title = "Shared across strokes" },
+                new() { Id = nameof(LaserHoldMode.PerStroke), Title = "Each stroke separately" },
+            ],
+        },
+        new()
+        {
+            Id = Ids.ToolbarPlacement,
+            Category = Toolbar,
+            Title = "Position",
+            Description = "Top right keeps the toolbar under a typical presenter picture-in-picture during recording.",
+            Keywords = ["toolbar", "position", "placement", "pip"],
+            Editor = SettingEditorKind.EnumChoice,
+            Choices =
+            [
+                new() { Id = nameof(ToolbarPlacement.TopRight), Title = "Top right" },
+                new() { Id = nameof(ToolbarPlacement.TopLeft), Title = "Top left" },
+                new() { Id = nameof(ToolbarPlacement.BottomRight), Title = "Bottom right" },
+                new() { Id = nameof(ToolbarPlacement.BottomLeft), Title = "Bottom left" },
+                new() { Id = nameof(ToolbarPlacement.BottomCenter), Title = "Bottom center" },
+            ],
+        },
+        new()
+        {
+            Id = Ids.ToolbarLayout,
+            Category = Toolbar,
+            Title = "Layout",
+            Description = "Dual palette keeps both tools’ colors and sizes visible. The other layouts use a compact bar and a single-tool panel.",
+            Keywords = ["toolbar", "layout", "calligraphy", "palette", "chevron"],
+            Editor = SettingEditorKind.EnumChoice,
+            Choices =
+            [
+                new() { Id = nameof(CalligraphyAccess.DualPalette), Title = "Dual palette" },
+                new() { Id = nameof(CalligraphyAccess.Chevron), Title = "Chevron on the Pen button" },
+                new() { Id = nameof(CalligraphyAccess.SizeRow), Title = "Icons beside the size chips" },
+            ],
+        },
+    ];
+
+    public static IReadOnlyList<SettingDescriptor> Filter(string? query, string? category)
+    {
+        IEnumerable<SettingDescriptor> items = All;
+        if (!string.IsNullOrWhiteSpace(category))
+        {
+            items = items.Where(setting => setting.Category == category);
+        }
+
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            items = items.Where(setting => Matches(setting, query));
+        }
+
+        return items.ToArray();
+    }
+
+    public static IReadOnlyList<string> CategoriesFor(IReadOnlyList<SettingDescriptor> items) =>
+        Categories.Where(category => items.Any(item => item.Category == category)).ToArray();
+
+    public static bool Matches(SettingDescriptor setting, string query)
+    {
+        ArgumentNullException.ThrowIfNull(setting);
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return true;
+        }
+
+        var term = query.Trim();
+        return Contains(setting.Title, term) ||
+               Contains(setting.Description, term) ||
+               Contains(setting.Category, term) ||
+               setting.Keywords.Any(keyword => Contains(keyword, term));
+    }
+
+    private static bool Contains(string value, string term) =>
+        value.Contains(term, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/SQLBI.Whiteboard/Themes/Settings.xaml
+++ b/src/SQLBI.Whiteboard/Themes/Settings.xaml
@@ -1,0 +1,529 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="SettingsTextBrush"
+                     Color="#FF1F2937" />
+    <SolidColorBrush x:Key="SettingsHintBrush"
+                     Color="#FF4B5563" />
+    <SolidColorBrush x:Key="SettingsEditorBrush"
+                     Color="#FFFFFFFF" />
+    <SolidColorBrush x:Key="SettingsSwitchOffBrush"
+                     Color="#22000000" />
+
+    <Style x:Key="SettingsSearchHost"
+           TargetType="Border">
+        <Setter Property="Background"
+                Value="{DynamicResource SettingsEditorBrush}" />
+        <Setter Property="BorderBrush"
+                Value="{DynamicResource ToolbarBorderBrush}" />
+        <Setter Property="BorderThickness"
+                Value="1" />
+        <Setter Property="CornerRadius"
+                Value="8" />
+        <Setter Property="Padding"
+                Value="10,6" />
+        <Setter Property="MinHeight"
+                Value="36" />
+    </Style>
+
+    <Style x:Key="SettingsSearchBox"
+           TargetType="TextBox">
+        <Setter Property="FontFamily"
+                Value="Segoe UI" />
+        <Setter Property="FontSize"
+                Value="13" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource SettingsTextBrush}" />
+        <Setter Property="CaretBrush"
+                Value="{DynamicResource SettingsTextBrush}" />
+        <Setter Property="Background"
+                Value="Transparent" />
+        <Setter Property="BorderThickness"
+                Value="0" />
+        <Setter Property="Padding"
+                Value="0" />
+        <Setter Property="VerticalContentAlignment"
+                Value="Center" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <ScrollViewer x:Name="PART_ContentHost"
+                                  Margin="0"
+                                  VerticalAlignment="Center" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="SettingsPlaceholder"
+           TargetType="TextBlock">
+        <Setter Property="FontFamily"
+                Value="Segoe UI" />
+        <Setter Property="FontSize"
+                Value="13" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource SettingsHintBrush}" />
+        <Setter Property="IsHitTestVisible"
+                Value="False" />
+        <Setter Property="VerticalAlignment"
+                Value="Center" />
+    </Style>
+
+    <Style x:Key="SettingsCategoryButton"
+           TargetType="ToggleButton">
+        <Setter Property="MinHeight"
+                Value="32" />
+        <Setter Property="Padding"
+                Value="10,6" />
+        <Setter Property="Margin"
+                Value="0,0,0,4" />
+        <Setter Property="HorizontalAlignment"
+                Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment"
+                Value="Left" />
+        <Setter Property="FontFamily"
+                Value="Segoe UI" />
+        <Setter Property="FontSize"
+                Value="13" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource SettingsTextBrush}" />
+        <Setter Property="Background"
+                Value="Transparent" />
+        <Setter Property="BorderThickness"
+                Value="0" />
+        <Setter Property="Focusable"
+                Value="True" />
+        <Setter Property="Stylus.IsPressAndHoldEnabled"
+                Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToggleButton">
+                    <Border x:Name="Root"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="8"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver"
+                                 Value="True">
+                            <Setter TargetName="Root"
+                                    Property="Background"
+                                    Value="{DynamicResource ToolbarHoverBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked"
+                                 Value="True">
+                            <Setter TargetName="Root"
+                                    Property="Background"
+                                    Value="{DynamicResource ToolbarSelectedBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="SettingsHeading"
+           TargetType="TextBlock">
+        <Setter Property="FontFamily"
+                Value="Segoe UI" />
+        <Setter Property="FontSize"
+                Value="11" />
+        <Setter Property="FontWeight"
+                Value="SemiBold" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource SettingsHintBrush}" />
+        <Setter Property="Margin"
+                Value="4,16,4,4" />
+    </Style>
+
+    <Style x:Key="SettingsRow"
+           TargetType="Border">
+        <Setter Property="Padding"
+                Value="12" />
+        <Setter Property="CornerRadius"
+                Value="8" />
+        <Setter Property="Background"
+                Value="Transparent" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver"
+                     Value="True">
+                <Setter Property="Background"
+                        Value="{DynamicResource ToolbarHoverBrush}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="SettingsTitle"
+           TargetType="TextBlock">
+        <Setter Property="FontFamily"
+                Value="Segoe UI" />
+        <Setter Property="FontSize"
+                Value="13" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource SettingsTextBrush}" />
+        <Setter Property="TextWrapping"
+                Value="Wrap" />
+    </Style>
+
+    <Style x:Key="SettingsDescription"
+           TargetType="TextBlock">
+        <Setter Property="FontFamily"
+                Value="Segoe UI" />
+        <Setter Property="FontSize"
+                Value="12" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource SettingsHintBrush}" />
+        <Setter Property="TextWrapping"
+                Value="Wrap" />
+        <Setter Property="Margin"
+                Value="0,4,0,0" />
+    </Style>
+
+    <Style x:Key="SettingsEmpty"
+           TargetType="TextBlock">
+        <Setter Property="FontFamily"
+                Value="Segoe UI" />
+        <Setter Property="FontSize"
+                Value="13" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource SettingsHintBrush}" />
+        <Setter Property="HorizontalAlignment"
+                Value="Left" />
+        <Setter Property="VerticalAlignment"
+                Value="Top" />
+        <Setter Property="Margin"
+                Value="12,8,0,0" />
+    </Style>
+
+    <Style x:Key="SettingsValueLabel"
+           TargetType="TextBlock">
+        <Setter Property="FontFamily"
+                Value="Segoe UI" />
+        <Setter Property="FontSize"
+                Value="12" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource SettingsHintBrush}" />
+        <Setter Property="VerticalAlignment"
+                Value="Center" />
+        <Setter Property="MinWidth"
+                Value="48" />
+        <Setter Property="TextAlignment"
+                Value="Right" />
+    </Style>
+
+    <Style x:Key="SettingsSwitch"
+           TargetType="ToggleButton">
+        <Setter Property="Width"
+                Value="40" />
+        <Setter Property="Height"
+                Value="22" />
+        <Setter Property="Background"
+                Value="Transparent" />
+        <Setter Property="BorderThickness"
+                Value="0" />
+        <Setter Property="Focusable"
+                Value="True" />
+        <Setter Property="Stylus.IsPressAndHoldEnabled"
+                Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToggleButton">
+                    <Grid Width="40"
+                          Height="22">
+                        <Border x:Name="Track"
+                                Background="{DynamicResource SettingsSwitchOffBrush}"
+                                CornerRadius="11" />
+                        <Ellipse x:Name="Thumb"
+                                 Width="16"
+                                 Height="16"
+                                 HorizontalAlignment="Left"
+                                 Margin="3,0,0,0"
+                                 Fill="White">
+                            <Ellipse.Effect>
+                                <DropShadowEffect BlurRadius="4"
+                                                  ShadowDepth="1"
+                                                  Opacity="0.2"
+                                                  Color="Black" />
+                            </Ellipse.Effect>
+                        </Ellipse>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked"
+                                 Value="True">
+                            <Setter TargetName="Track"
+                                    Property="Background"
+                                    Value="{DynamicResource ToolbarAccentBrush}" />
+                            <Setter TargetName="Thumb"
+                                    Property="HorizontalAlignment"
+                                    Value="Right" />
+                            <Setter TargetName="Thumb"
+                                    Property="Margin"
+                                    Value="0,0,3,0" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <DataTemplate x:Key="SettingsChoiceItemTemplate">
+        <Grid MinHeight="18">
+            <TextBlock x:Name="Label"
+                       VerticalAlignment="Center"
+                       Text="{Binding Title}"
+                       TextTrimming="CharacterEllipsis" />
+            <Border x:Name="Rule"
+                    Height="1"
+                    VerticalAlignment="Center"
+                    Background="{DynamicResource ToolbarBorderBrush}"
+                    Visibility="Collapsed" />
+        </Grid>
+        <DataTemplate.Triggers>
+            <DataTrigger Binding="{Binding IsSeparator}"
+                         Value="True">
+                <Setter TargetName="Label"
+                        Property="Visibility"
+                        Value="Collapsed" />
+                <Setter TargetName="Rule"
+                        Property="Visibility"
+                        Value="Visible" />
+            </DataTrigger>
+        </DataTemplate.Triggers>
+    </DataTemplate>
+
+    <Style x:Key="SettingsComboBoxItem"
+           TargetType="ComboBoxItem">
+        <Setter Property="Padding"
+                Value="10,6" />
+        <Setter Property="FontFamily"
+                Value="Segoe UI" />
+        <Setter Property="FontSize"
+                Value="13" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource SettingsTextBrush}" />
+        <Setter Property="HorizontalContentAlignment"
+                Value="Left" />
+        <Setter Property="Stylus.IsPressAndHoldEnabled"
+                Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBoxItem">
+                    <Border x:Name="Root"
+                            Margin="4,2"
+                            Padding="{TemplateBinding Padding}"
+                            CornerRadius="6"
+                            Background="Transparent">
+                        <ContentPresenter />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsHighlighted"
+                                 Value="True">
+                            <Setter TargetName="Root"
+                                    Property="Background"
+                                    Value="{DynamicResource ToolbarHoverBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsSelected"
+                                 Value="True">
+                            <Setter TargetName="Root"
+                                    Property="Background"
+                                    Value="{DynamicResource ToolbarSelectedBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                 Value="False">
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource SettingsHintBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding IsAvailable}"
+                         Value="False">
+                <Setter Property="IsEnabled"
+                        Value="False" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding IsSeparator}"
+                         Value="True">
+                <Setter Property="IsEnabled"
+                        Value="False" />
+                <Setter Property="Focusable"
+                        Value="False" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="SettingsComboBox"
+           TargetType="ComboBox">
+        <Setter Property="MinHeight"
+                Value="32" />
+        <Setter Property="MinWidth"
+                Value="200" />
+        <Setter Property="MaxWidth"
+                Value="280" />
+        <Setter Property="Padding"
+                Value="10,4,28,4" />
+        <Setter Property="FontFamily"
+                Value="Segoe UI" />
+        <Setter Property="FontSize"
+                Value="13" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource SettingsTextBrush}" />
+        <Setter Property="Background"
+                Value="{DynamicResource SettingsEditorBrush}" />
+        <Setter Property="BorderBrush"
+                Value="{DynamicResource ToolbarBorderBrush}" />
+        <Setter Property="BorderThickness"
+                Value="1" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+                Value="Disabled" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility"
+                Value="Auto" />
+        <Setter Property="ItemTemplate"
+                Value="{StaticResource SettingsChoiceItemTemplate}" />
+        <Setter Property="ItemContainerStyle"
+                Value="{StaticResource SettingsComboBoxItem}" />
+        <Setter Property="Stylus.IsPressAndHoldEnabled"
+                Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBox">
+                    <Grid>
+                        <Border x:Name="Chrome"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="8" />
+                        <ToggleButton x:Name="ToggleButton"
+                                      Background="Transparent"
+                                      BorderThickness="0"
+                                      Focusable="False"
+                                      ClickMode="Press"
+                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
+                            <ToggleButton.Template>
+                                <ControlTemplate TargetType="ToggleButton">
+                                    <Border Background="Transparent" />
+                                </ControlTemplate>
+                            </ToggleButton.Template>
+                        </ToggleButton>
+                        <ContentPresenter Margin="{TemplateBinding Padding}"
+                                          VerticalAlignment="Center"
+                                          HorizontalAlignment="Left"
+                                          Content="{Binding SelectionBoxItem, RelativeSource={RelativeSource TemplatedParent}}"
+                                          ContentTemplate="{Binding SelectionBoxItemTemplate, RelativeSource={RelativeSource TemplatedParent}}"
+                                          ContentTemplateSelector="{Binding ItemTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}"
+                                          IsHitTestVisible="False" />
+                        <Path Width="8"
+                              Height="5"
+                              Margin="0,0,10,0"
+                              HorizontalAlignment="Right"
+                              VerticalAlignment="Center"
+                              Data="M 0,0 L 4,5 L 8,0"
+                              Fill="{DynamicResource ToolbarIconBrush}"
+                              Stretch="Uniform"
+                              IsHitTestVisible="False" />
+                        <Popup x:Name="Popup"
+                               AllowsTransparency="True"
+                               Focusable="False"
+                               IsOpen="{TemplateBinding IsDropDownOpen}"
+                               Placement="Bottom"
+                               PopupAnimation="Fade">
+                            <Border Margin="0,4,0,8"
+                                    MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                                    Background="{DynamicResource SettingsEditorBrush}"
+                                    BorderBrush="{DynamicResource ToolbarBorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="8">
+                                <Border.Effect>
+                                    <DropShadowEffect BlurRadius="18"
+                                                      ShadowDepth="1"
+                                                      Direction="270"
+                                                      Opacity="0.16"
+                                                      Color="Black" />
+                                </Border.Effect>
+                                <ScrollViewer MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                              Margin="0,4">
+                                    <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsKeyboardFocusWithin"
+                                 Value="True">
+                            <Setter TargetName="Chrome"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource ToolbarAccentBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="SettingsSlider"
+           TargetType="Slider">
+        <Setter Property="Minimum"
+                Value="0" />
+        <Setter Property="Maximum"
+                Value="1" />
+        <Setter Property="IsMoveToPointEnabled"
+                Value="True" />
+        <Setter Property="Stylus.IsPressAndHoldEnabled"
+                Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Slider">
+                    <Grid Margin="0,10,0,4">
+                        <Border Height="4"
+                                VerticalAlignment="Center"
+                                Background="{DynamicResource SettingsSwitchOffBrush}"
+                                CornerRadius="2" />
+                        <Track x:Name="PART_Track">
+                            <Track.DecreaseRepeatButton>
+                                <RepeatButton Command="{x:Static Slider.DecreaseLarge}"
+                                              Focusable="False">
+                                    <RepeatButton.Template>
+                                        <ControlTemplate TargetType="RepeatButton">
+                                            <Border Background="Transparent" />
+                                        </ControlTemplate>
+                                    </RepeatButton.Template>
+                                </RepeatButton>
+                            </Track.DecreaseRepeatButton>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton Command="{x:Static Slider.IncreaseLarge}"
+                                              Focusable="False">
+                                    <RepeatButton.Template>
+                                        <ControlTemplate TargetType="RepeatButton">
+                                            <Border Background="Transparent" />
+                                        </ControlTemplate>
+                                    </RepeatButton.Template>
+                                </RepeatButton>
+                            </Track.IncreaseRepeatButton>
+                            <Track.Thumb>
+                                <Thumb Width="16"
+                                       Height="16">
+                                    <Thumb.Template>
+                                        <ControlTemplate TargetType="Thumb">
+                                            <Ellipse Fill="White"
+                                                     Stroke="{DynamicResource ToolbarAccentBrush}"
+                                                     StrokeThickness="2">
+                                                <Ellipse.Effect>
+                                                    <DropShadowEffect BlurRadius="4"
+                                                                      ShadowDepth="1"
+                                                                      Opacity="0.2"
+                                                                      Color="Black" />
+                                                </Ellipse.Effect>
+                                            </Ellipse>
+                                        </ControlTemplate>
+                                    </Thumb.Template>
+                                </Thumb>
+                            </Track.Thumb>
+                        </Track>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/SQLBI.Whiteboard/Themes/Toolbar.xaml
+++ b/src/SQLBI.Whiteboard/Themes/Toolbar.xaml
@@ -10,6 +10,8 @@
                      Color="#14000000" />
     <SolidColorBrush x:Key="ToolbarSelectedBrush"
                      Color="#1A2563EB" />
+    <SolidColorBrush x:Key="ToolbarAccentBrush"
+                     Color="#FF2563EB" />
     <SolidColorBrush x:Key="ToolbarSeparatorBrush"
                      Color="#22000000" />
 

--- a/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
+++ b/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
@@ -465,6 +465,40 @@ Assert(
         "{ \"pen\": { \"argb\": 1, \"thickness\": 99 } }").Pen.Argb ==
     InkPalettes.DefaultPen.Argb,
     "Saved ink that is no longer in the palette should fall back to the tool default.");
+Assert(
+    defaultSettings.StartupMonitor == StartupMonitorKind.WacomIfPresent &&
+    defaultSettings.StartupMonitorName is null &&
+    !defaultSettings.StartFullScreen,
+    "Missing settings should default to Wacom-if-present and a windowed start.");
+Assert(
+    AppSettingsSerializer.Parse("{ \"startupMonitor\": \"Sideways\" }").StartupMonitor ==
+    StartupMonitorKind.WacomIfPresent,
+    "Unknown startup monitors should fall back to Wacom-if-present.");
+Assert(
+    AppSettingsSerializer.Parse(
+        "{ \"startupMonitor\": \"Named\" }").StartupMonitor ==
+    StartupMonitorKind.WacomIfPresent,
+    "A named startup monitor without a name should fall back to Wacom-if-present.");
+Assert(
+    AppSettingsSerializer.Parse(
+        "{ \"startupMonitor\": \"Primary\", \"startupMonitorName\": \"Cintiq Pro 27\" }") is
+    {
+        StartupMonitor: StartupMonitorKind.Primary,
+        StartupMonitorName: null,
+    },
+    "A primary startup monitor should drop a leftover display name.");
+var namedStartup = AppSettingsSerializer.Parse(
+    AppSettingsSerializer.Format(new AppSettings
+    {
+        StartupMonitor = StartupMonitorKind.Named,
+        StartupMonitorName = "  Cintiq Pro 27  ",
+        StartFullScreen = true,
+    }));
+Assert(
+    namedStartup.StartupMonitor == StartupMonitorKind.Named &&
+    namedStartup.StartupMonitorName == "Cintiq Pro 27" &&
+    namedStartup.StartFullScreen,
+    "Settings JSON should round-trip a named startup monitor and full-screen start.");
 
 var daxSource = """
 Tricky :=


### PR DESCRIPTION
Settings that lived only as defaults or JSON now have a home, so later preferences do not become another constant to recompile.

Tools > Preferences... is a searchable catalog in the same visual language as the tool palette. It owns:

- which monitor to open on (Wacom/Cintiq if present, primary, or a named display)
- whether to start full screen
- laser trail duration, fade, and hold mode
- the existing toolbar position and layout

Startup choices persist immediately and apply on the next launch. Laser and toolbar changes apply at once. The menu is unchanged.

VersionPrefix is 0.3.0 so the pre-release published from this merge is the first build that includes the dialog.