### PR TITLE
Import dropped files at the pointer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ How the project is developed and shipped is documented separately:
 - Basic palm rejection: touch navigation is suspended when the pen makes contact
 - Mouse-wheel zoom and middle-button or temporary Space-key panning
 - Whole-stroke erasing
-- PNG, JPEG, BMP, and GIF import, clipboard bitmap paste, and Explorer drag-and-drop
+- PNG, JPEG, BMP, and GIF import, clipboard bitmap paste, and Explorer drag-and-drop of images and text files
 - Image selection, movement, resizing, and deletion
 - Text containers created by pasting plain text, with display and in-place edit modes
 - Plain-text, DAX, and SQL Server language modes, with live syntax highlighting and local F6 formatting
@@ -190,7 +190,7 @@ Imported images, LiveViews, and text objects act as containers. A completed stro
 
 Paste plain text to create a text container and enter edit mode immediately. Text reflows while its edit-mode resize grip changes the width, and the height grows automatically when necessary. Choose **DAX** or **SQL Server** in the title-bar language selector for syntax highlighting in both edit and display modes. A language-aware title identifies a defined DAX or SQL object when possible. Press **F6** to apply the corresponding local formatter. SQL Server mode targets SQL Server 2025 T-SQL, preserves `GO` batch separators, and leaves invalid scripts unchanged. Press **Ctrl+Enter** to commit or **Escape** to restore the previous text, language, and dimensions. In display mode, resizing preserves the aspect ratio and scales the complete text visual without reflowing it.
 
-Image files can be dropped directly from File Explorer. Their initial center is the board position at which they were dropped.
+Image files, and `.txt`, `.dax`, and `.sql` files, can be dropped directly from File Explorer. Their initial center is the board position at which they were dropped. DAX and SQL files open in the matching language mode. Markdown import is a later format; dropping a `.md` file does nothing yet.
 
 ## Architecture
 

--- a/TODO.md
+++ b/TODO.md
@@ -35,14 +35,11 @@ trail timing, and the toolbar options. New settings are catalog entries rather t
 layout. The menu is still always visible; hide-on-demand is a later UI pass, not a missing
 piece of this item.
 
-### 2. Drag and drop import
+### 2. Drag and drop import — done
 
-Dropping a file onto the canvas should import it as a container placed where the pointer was
-released, rather than at a default position. Images already arrive through the clipboard, so
-this is mostly hit-testing the drop point into camera space and reusing the existing import
-path.
-
-Small and self-contained, and it becomes the natural entry point for the format below.
+A drop on the window imports at the release point in camera space. Images become image
+containers; `.txt`, `.dax`, and `.sql` become text containers in the matching language.
+The classifier is the hook for the import format below — `.md` is still unsupported.
 
 ### 3. An import file format
 

--- a/src/SQLBI.Whiteboard.Core/Import/DroppedFileImport.cs
+++ b/src/SQLBI.Whiteboard.Core/Import/DroppedFileImport.cs
@@ -1,0 +1,71 @@
+using SQLBI.Whiteboard.Core.Model;
+
+namespace SQLBI.Whiteboard.Core.Import;
+
+public enum DroppedFileKind
+{
+    Unsupported = 0,
+    Image = 1,
+    Text = 2,
+}
+
+public static class DroppedFileImport
+{
+    public const int MaximumTextBytes = 1_000_000;
+
+    private static readonly HashSet<string> ImageExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".bmp",
+        ".gif",
+    };
+
+    private static readonly HashSet<string> TextExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".txt",
+        ".sql",
+        ".dax",
+    };
+
+    public static DroppedFileKind Classify(string? path)
+    {
+        var extension = Path.GetExtension(path);
+        if (string.IsNullOrEmpty(extension))
+        {
+            return DroppedFileKind.Unsupported;
+        }
+
+        if (ImageExtensions.Contains(extension))
+        {
+            return DroppedFileKind.Image;
+        }
+
+        if (TextExtensions.Contains(extension))
+        {
+            return DroppedFileKind.Text;
+        }
+
+        return DroppedFileKind.Unsupported;
+    }
+
+    public static bool CanImport(string? path) => Classify(path) != DroppedFileKind.Unsupported;
+
+    public static bool CanImportAny(IEnumerable<string> paths)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+        return paths.Any(CanImport);
+    }
+
+    public static string LanguageIdFor(string? path)
+    {
+        var extension = Path.GetExtension(path);
+        return extension?.ToLowerInvariant() switch
+        {
+            ".dax" => TextLanguageIds.Dax,
+            ".sql" => TextLanguageIds.SqlServer,
+            _ => TextLanguageIds.Plain,
+        };
+    }
+}

--- a/src/SQLBI.Whiteboard/MainWindow.xaml
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml
@@ -13,6 +13,9 @@
         Background="White"
         Deactivated="Window_Deactivated"
         Closing="Window_Closing"
+        AllowDrop="True"
+        PreviewDragOver="Window_PreviewDragOver"
+        PreviewDrop="Window_PreviewDrop"
         PreviewKeyDown="Window_PreviewKeyDown"
         PreviewKeyUp="Window_PreviewKeyUp"
         PreviewStylusDown="Window_PreviewStylusDown">
@@ -144,7 +147,6 @@
                        EditingMode="Ink"
                        EditingModeInverted="None"
                        UseCustomCursor="True"
-                       AllowDrop="True"
                        Focusable="True"
                        IsManipulationEnabled="False"
                        Stylus.IsPressAndHoldEnabled="False"
@@ -163,9 +165,7 @@
                        PreviewMouseUp="InkSurface_PreviewMouseUp"
                        PreviewMouseWheel="InkSurface_PreviewMouseWheel"
                        LostMouseCapture="InkSurface_LostMouseCapture"
-                       StrokeCollected="InkSurface_StrokeCollected"
-                       DragOver="InkSurface_DragOver"
-                       Drop="InkSurface_Drop" />
+                       StrokeCollected="InkSurface_StrokeCollected" />
 
             <Canvas x:Name="LiveViewActionLayer"
                     Panel.ZIndex="20"

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using ICSharpCode.AvalonEdit.Document;
 using Microsoft.Win32;
 using SQLBI.Whiteboard.Core.Commands;
 using SQLBI.Whiteboard.Core.Geometry;
+using SQLBI.Whiteboard.Core.Import;
 using SQLBI.Whiteboard.Core.Model;
 using SQLBI.Whiteboard.Core.Persistence;
 using SQLBI.Whiteboard.Core.Settings;
@@ -25,16 +26,6 @@ namespace SQLBI.Whiteboard;
 
 public partial class MainWindow : Window
 {
-    private static readonly HashSet<string> ImageFileExtensions =
-        new(StringComparer.OrdinalIgnoreCase)
-        {
-            ".png",
-            ".jpg",
-            ".jpeg",
-            ".bmp",
-            ".gif",
-        };
-
     private enum BoardTool
     {
         Pen,
@@ -2783,7 +2774,12 @@ public partial class MainWindow : Window
         UpdateLiveViewActionOverlay();
     }
 
-    private void AddText(string text, PointD? worldCenter = null)
+    private void AddText(
+        string text,
+        PointD? worldCenter = null,
+        bool beginEdit = true,
+        string? title = null,
+        string? languageId = null)
     {
         if (string.IsNullOrEmpty(text))
         {
@@ -2808,14 +2804,18 @@ public partial class MainWindow : Window
                 center.Y - (height / 2),
                 width,
                 height),
-            "Text",
-            text);
+            string.IsNullOrWhiteSpace(title) ? "Text" : title,
+            text,
+            LanguageId: TextLanguageIds.Normalize(languageId));
 
         _history.Execute(new AddObjectCommand(textObject), _document);
         _selectedObjectId = textObject.Id;
         SceneSurface.SelectedObjectId = textObject.Id;
         SetActiveTool(BoardTool.Select);
-        BeginTextEdit(textObject);
+        if (beginEdit)
+        {
+            BeginTextEdit(textObject);
+        }
     }
 
     private async Task AddLiveViewAsync()
@@ -3288,51 +3288,77 @@ public partial class MainWindow : Window
         }
     }
 
-    private void InkSurface_DragOver(object sender, DragEventArgs e)
+    private void Window_PreviewDragOver(object sender, DragEventArgs e)
     {
-        if (e.Data.GetDataPresent(DataFormats.FileDrop))
-        {
-            e.Effects = DragDropEffects.Copy;
-        }
-        else
-        {
-            e.Effects = DragDropEffects.None;
-        }
-
+        e.Effects = e.Data.GetDataPresent(DataFormats.FileDrop) &&
+                    e.Data.GetData(DataFormats.FileDrop) is string[] paths &&
+                    DroppedFileImport.CanImportAny(paths)
+            ? DragDropEffects.Copy
+            : DragDropEffects.None;
         e.Handled = true;
     }
 
-    private async void InkSurface_Drop(object sender, DragEventArgs e)
+    private async void Window_PreviewDrop(object sender, DragEventArgs e)
     {
+        e.Handled = true;
         if (e.Data.GetData(DataFormats.FileDrop) is not string[] paths)
         {
             return;
         }
 
         var dropCenter = _camera.ScreenToWorld(ToPointD(e.GetPosition(InkSurface)));
+        await ImportDroppedFilesAsync(paths, dropCenter);
+    }
+
+    private async Task ImportDroppedFilesAsync(string[] paths, PointD worldCenter)
+    {
         var imported = 0;
         try
         {
-            foreach (var path in paths.Where(path =>
-                         ImageFileExtensions.Contains(Path.GetExtension(path))))
+            foreach (var path in paths)
             {
-                var bytes = await File.ReadAllBytesAsync(path);
-                var offset = new PointD(imported * 24, imported * 24);
-                AddImage(
-                    bytes,
-                    Path.GetFileName(path),
-                    ContentTypeFor(path),
-                    dropCenter + offset);
+                var kind = DroppedFileImport.Classify(path);
+                if (kind == DroppedFileKind.Unsupported)
+                {
+                    continue;
+                }
+
+                var center = worldCenter + new PointD(imported * 24, imported * 24);
+                switch (kind)
+                {
+                    case DroppedFileKind.Image:
+                        AddImage(
+                            await File.ReadAllBytesAsync(path),
+                            Path.GetFileName(path),
+                            ContentTypeFor(path),
+                            center);
+                        break;
+                    case DroppedFileKind.Text:
+                        if (new FileInfo(path).Length > DroppedFileImport.MaximumTextBytes)
+                        {
+                            ShowError(
+                                "Could not drop file",
+                                new InvalidOperationException(
+                                    $"{Path.GetFileName(path)} is too large to import as text."));
+                            continue;
+                        }
+
+                        AddText(
+                            await File.ReadAllTextAsync(path),
+                            center,
+                            beginEdit: false,
+                            title: Path.GetFileNameWithoutExtension(path),
+                            languageId: DroppedFileImport.LanguageIdFor(path));
+                        break;
+                }
+
                 imported++;
             }
-
         }
         catch (Exception exception)
         {
-            ShowError("Could not drop image", exception);
+            ShowError("Could not drop file", exception);
         }
-
-        e.Handled = true;
     }
 
     private void Window_PreviewKeyDown(object sender, KeyEventArgs e)

--- a/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
+++ b/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
@@ -2,6 +2,7 @@ using System.IO.Compression;
 using System.Text;
 using SQLBI.Whiteboard.Core.Commands;
 using SQLBI.Whiteboard.Core.Geometry;
+using SQLBI.Whiteboard.Core.Import;
 using SQLBI.Whiteboard.Core.Model;
 using SQLBI.Whiteboard.Core.Persistence;
 using SQLBI.Whiteboard.Core.Settings;
@@ -46,6 +47,26 @@ AssertNear(
     originalLiveViewBounds.Width * originalLiveViewBounds.Height,
     reconnectedLiveViewBounds.Width * reconnectedLiveViewBounds.Height,
     "Changing a LiveView aspect ratio must preserve its visual area.");
+
+Assert(
+    DroppedFileImport.Classify(@"C:\board\shot.PNG") == DroppedFileKind.Image &&
+    DroppedFileImport.Classify("notes.txt") == DroppedFileKind.Text &&
+    DroppedFileImport.Classify("measure.dax") == DroppedFileKind.Text &&
+    DroppedFileImport.Classify("query.sql") == DroppedFileKind.Text &&
+    DroppedFileImport.Classify("board.wboard") == DroppedFileKind.Unsupported &&
+    DroppedFileImport.Classify("notes.md") == DroppedFileKind.Unsupported,
+    "Drop import should accept images and text now, and leave markdown and boards for later.");
+Assert(
+    DroppedFileImport.CanImportAny(["skip.bin", "photo.jpg"]),
+    "A mixed drop should be accepted when any file can be imported.");
+Assert(
+    !DroppedFileImport.CanImportAny(["notes.md", "board.wboard"]),
+    "A drop of only later formats should not show a copy cursor yet.");
+Assert(
+    DroppedFileImport.LanguageIdFor("measure.dax") == TextLanguageIds.Dax &&
+    DroppedFileImport.LanguageIdFor("query.sql") == TextLanguageIds.SqlServer &&
+    DroppedFileImport.LanguageIdFor("notes.txt") == TextLanguageIds.Plain,
+    "Dropped text files should pick a language from the extension.");
 
 var document = new BoardDocument();
 Assert(document.ContentBounds is null, "An empty document should not have content bounds.");


### PR DESCRIPTION
A drop on the window imports at the release point in camera space. Images become image containers; .txt, .dax, and .sql become text containers in the matching language. The classifier is the hook for the later import format — .md is still unsupported.

VersionPrefix is 0.4.0 so the pre-release from this merge includes it.