### PR TITLE
Track the pen hover dot in air

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SQLBI.Whiteboard/MainWindow.xaml
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml
@@ -18,7 +18,10 @@
         PreviewDrop="Window_PreviewDrop"
         PreviewKeyDown="Window_PreviewKeyDown"
         PreviewKeyUp="Window_PreviewKeyUp"
-        PreviewStylusDown="Window_PreviewStylusDown">
+        PreviewStylusDown="Window_PreviewStylusDown"
+        PreviewStylusInRange="Window_PreviewStylusInRange"
+        PreviewStylusOutOfRange="Window_PreviewStylusOutOfRange"
+        PreviewStylusInAirMove="Window_PreviewStylusInAirMove">
     <Grid x:Name="RootGrid">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -155,6 +158,7 @@
                        Stylus.IsTouchFeedbackEnabled="False"
                        PreviewStylusDown="InkSurface_PreviewStylusDown"
                        PreviewStylusMove="InkSurface_PreviewStylusMove"
+                       PreviewStylusInAirMove="InkSurface_PreviewStylusInAirMove"
                        PreviewStylusUp="InkSurface_PreviewStylusUp"
                        PreviewStylusButtonDown="InkSurface_PreviewStylusButtonDown"
                        PreviewStylusButtonUp="InkSurface_PreviewStylusButtonUp"

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -101,6 +101,8 @@ public partial class MainWindow : Window
     private ResizeMode _resizeModeBeforeFullScreen;
     private Rect _windowBoundsBeforeFullScreen;
     private readonly string? _initialBoardPath;
+    private readonly DispatcherTimer _hoverWatch;
+    private long _lastHoverTimestamp;
 
     public MainWindow()
         : this(null)
@@ -121,6 +123,12 @@ public partial class MainWindow : Window
             Interval = TimeSpan.FromMilliseconds(75),
         };
         _textHighlightTimer.Tick += TextHighlightTimer_Tick;
+        _hoverWatch = new DispatcherTimer(DispatcherPriority.Input)
+        {
+            Interval = TimeSpan.FromMilliseconds(50),
+        };
+        _hoverWatch.Tick += HoverWatch_Tick;
+        InkSurface.HoverTracker.Hovered += HoverTracker_Hovered;
         SourceInitialized += MainWindow_SourceInitialized;
         Loaded += MainWindow_Loaded;
         _document.Changed += Document_Changed;
@@ -365,11 +373,12 @@ public partial class MainWindow : Window
         }
         else
         {
-            UsePenCursor();
-            ShowPointerDot(e.GetPosition(RootGrid));
+            UpdateHoverPointerDot(e);
         }
-
     }
+
+    private void InkSurface_PreviewStylusInAirMove(object sender, StylusEventArgs e) =>
+        UpdateHoverPointerDot(e);
 
     private void InkSurface_PreviewStylusUp(object sender, StylusEventArgs e)
     {
@@ -427,10 +436,13 @@ public partial class MainWindow : Window
             InkSurface.Cursor = SelectCursorAt(hoverScreen);
             HidePointerDot();
         }
+        else if (e.StylusDevice.InAir)
+        {
+            UpdateHoverPointerDot(e);
+        }
         else
         {
-            UsePenCursor();
-            ShowPointerDot(e.GetPosition(RootGrid));
+            HidePointerDot();
         }
         Debug.WriteLine("[WpfInk] stylus-up reached WPF");
     }
@@ -462,7 +474,7 @@ public partial class MainWindow : Window
         UsePenCursor();
         if (!_penInContact)
         {
-            ShowPointerDot(e.GetPosition(RootGrid));
+            UpdateHoverPointerDot(e);
         }
     }
 
@@ -3592,12 +3604,93 @@ public partial class MainWindow : Window
         DisposeAllLiveViewPresenters();
     }
 
+    private void Window_PreviewStylusInRange(object sender, StylusEventArgs e)
+    {
+        if (!_penInContact)
+        {
+            UpdateHoverPointerDot(e);
+        }
+    }
+
+    private void Window_PreviewStylusOutOfRange(object sender, StylusEventArgs e)
+    {
+        if (!IsTouchStylus(e))
+        {
+            HidePointerDot();
+        }
+    }
+
+    private void Window_PreviewStylusInAirMove(object sender, StylusEventArgs e) =>
+        UpdateHoverPointerDot(e);
+
+    private void HoverTracker_Hovered(Point inkSurfacePoint)
+    {
+        if (_penInContact)
+        {
+            return;
+        }
+
+        UpdateHoverPointerDotAt(InkSurface.TranslatePoint(inkSurfacePoint, RootGrid), overBoard: true);
+    }
+
+    private void HoverWatch_Tick(object? sender, EventArgs e)
+    {
+        if (Stopwatch.GetElapsedTime(_lastHoverTimestamp).TotalMilliseconds > 120)
+        {
+            HidePointerDot();
+            _hoverWatch.Stop();
+        }
+    }
+
     private void UsePenCursor()
     {
         InkSurface.Cursor = EffectiveTool is BoardTool.Select
             ? Cursors.Arrow
             : Cursors.None;
     }
+
+    // Contact packets arrive as StylusMove; hover is StylusInAirMove. Wacom
+    // Cintiqs also fire OutOfRange when the pen leaves detection, which is
+    // not the same as leaving the InkCanvas hit-test bounds.
+    private void UpdateHoverPointerDot(StylusEventArgs e)
+    {
+        if (IsTouchStylus(e) ||
+            e.StylusDevice.Inverted ||
+            !e.StylusDevice.InAir)
+        {
+            HidePointerDot();
+            return;
+        }
+
+        var rootPosition = e.GetPosition(RootGrid);
+        var boardPosition = e.GetPosition(BoardViewport);
+        UpdateHoverPointerDotAt(rootPosition, IsWithin(boardPosition, BoardViewport));
+    }
+
+    private void UpdateHoverPointerDotAt(Point rootPosition, bool overBoard)
+    {
+        if (_penInContact ||
+            EffectiveTool is BoardTool.Select or BoardTool.Laser ||
+            !overBoard)
+        {
+            HidePointerDot();
+            return;
+        }
+
+        UsePenCursor();
+        ShowPointerDot(rootPosition);
+        _lastHoverTimestamp = Stopwatch.GetTimestamp();
+        if (!_hoverWatch.IsEnabled)
+        {
+            _hoverWatch.Start();
+        }
+    }
+
+    private static bool IsWithin(Point position, FrameworkElement element) =>
+        position.X >= 0 &&
+        position.Y >= 0 &&
+        position.X <= element.ActualWidth &&
+        position.Y <= element.ActualHeight;
 
     private void ShowPointerDot(Point position)
     {
@@ -3612,7 +3705,11 @@ public partial class MainWindow : Window
         PointerDot.Visibility = Visibility.Visible;
     }
 
-    private void HidePointerDot() => PointerDot.Visibility = Visibility.Collapsed;
+    private void HidePointerDot()
+    {
+        PointerDot.Visibility = Visibility.Collapsed;
+        _hoverWatch.Stop();
+    }
 
     private void ShowError(string context, Exception exception)
     {

--- a/src/SQLBI.Whiteboard/PenOnlyInkCanvas.cs
+++ b/src/SQLBI.Whiteboard/PenOnlyInkCanvas.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Input.StylusPlugIns;
 using System.Windows.Media;
+using System.Windows.Threading;
 using SQLBI.Whiteboard.Core.Model;
 
 namespace SQLBI.Whiteboard;
@@ -14,6 +15,8 @@ public sealed class PenOnlyInkCanvas : InkCanvas
 
     public LaserSamplePlugIn LaserSamples { get; } = new();
 
+    public HoverTrackerPlugIn HoverTracker { get; } = new();
+
     public PenOnlyInkCanvas()
     {
         var touchTabletIds = Tablet.TabletDevices
@@ -23,6 +26,7 @@ public sealed class PenOnlyInkCanvas : InkCanvas
         _penOnlyRenderer = new PenOnlyDynamicRenderer(touchTabletIds);
         DynamicRenderer = _penOnlyRenderer;
         StylusPlugIns.Add(LaserSamples);
+        StylusPlugIns.Add(HoverTracker);
     }
 
     public void RegisterTouchTablet(int tabletDeviceId) =>
@@ -92,6 +96,67 @@ public sealed class LaserSamplePlugIn : StylusPlugIn
             var point = points[index];
             _samples.Enqueue((point.X, point.Y, Math.Clamp(point.PressureFactor, 0.02f, 1f)));
         }
+    }
+}
+
+public sealed class HoverTrackerPlugIn : StylusPlugIn
+{
+    private readonly object _gate = new();
+    private Point _latest;
+    private bool _queued;
+    private bool _contact;
+
+    public Action<Point>? Hovered { get; set; }
+
+    protected override void OnStylusDown(RawStylusInput rawStylusInput) => _contact = true;
+
+    protected override void OnStylusUp(RawStylusInput rawStylusInput)
+    {
+        _contact = false;
+        Enqueue(rawStylusInput);
+    }
+
+    protected override void OnStylusMove(RawStylusInput rawStylusInput)
+    {
+        if (!_contact)
+        {
+            Enqueue(rawStylusInput);
+        }
+    }
+
+    private void Enqueue(RawStylusInput rawStylusInput)
+    {
+        var points = rawStylusInput.GetStylusPoints();
+        if (points.Count == 0)
+        {
+            return;
+        }
+
+        var point = points[^1];
+        var latest = new Point(point.X, point.Y);
+        lock (_gate)
+        {
+            _latest = latest;
+            if (_queued)
+            {
+                return;
+            }
+
+            _queued = true;
+        }
+
+        var dispatcher = Element?.Dispatcher;
+        dispatcher?.BeginInvoke(() =>
+        {
+            Point consumed;
+            lock (_gate)
+            {
+                _queued = false;
+                consumed = _latest;
+            }
+
+            Hovered?.Invoke(consumed);
+        }, DispatcherPriority.Input);
     }
 }
 


### PR DESCRIPTION
The red hover dot only appeared after the pen touched the board, then stayed at the last lift point while the pen moved in range. Contact is StylusMove; hover is StylusInAirMove. The stylus plugin also forwards in-air packets so Wacom hover works before the first contact, and the dot is hidden on OutOfRange or when packets stop.

VersionPrefix is 0.4.1.