### PR TITLE
Add the .wimport Markdown import format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ and per-user, selected by the `Channel` and `Scope` preprocessor variables. Chan
 identity, install folder, or the file association affects all four.
 
 **The pre-release channel must stay a separate product,** with its own `UpgradeCode`, and
-must not register `.wboard`. Decision 7 explains what breaks otherwise.
+must not register `.wboard` or `.wimport`. Decision 7 explains what breaks otherwise.
 
 **The channel is detected at run time,** never compiled in, so one publish serves both
 channels and a tested build can be promoted without rebuilding.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>0.4.1</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ How the project is developed and shipped is documented separately:
 - Basic palm rejection: touch navigation is suspended when the pen makes contact
 - Mouse-wheel zoom and middle-button or temporary Space-key panning
 - Whole-stroke erasing
-- PNG, JPEG, BMP, and GIF import, clipboard bitmap paste, and Explorer drag-and-drop of images and text files
+- PNG, JPEG, BMP, and GIF import, clipboard bitmap paste, and Explorer drag-and-drop of images, text files, and `.wimport` recipes
 - Image selection, movement, resizing, and deletion
 - Text containers created by pasting plain text, with display and in-place edit modes
 - Plain-text, DAX, and SQL Server language modes, with live syntax highlighting and local F6 formatting
@@ -24,6 +24,7 @@ How the project is developed and shipped is documented separately:
 - Double-click a container to center it and fit it to the canvas
 - Undo and redo for strokes, erasing, containers, text edits, and transformations
 - Versioned ZIP-based `.wboard` documents with embedded image assets
+- Markdown `.wimport` recipes that build image and text containers from headings
 - An intentionally small floating toolbar
 - Preferences for the startup monitor, full-screen start, laser trail, and toolbar layout
 
@@ -72,8 +73,8 @@ installed. They differ in three ways:
 
 - The pre-release channel installs under `Whiteboard Dev`, is named **SQLBI Whiteboard (Dev)**,
   and carries its own `UpgradeCode`, so it never upgrades or replaces a released install.
-- Only the released channel registers the `.wboard` file type. Uninstalling a pre-release
-  build therefore cannot leave the association broken.
+- Only the released channel registers the `.wboard` and `.wimport` file types. Uninstalling a
+  pre-release build therefore cannot leave those associations broken.
 - The pre-release installer places a `channel.txt` beside the executable, and the pre-release
   portable ZIP carries the same file. `AppChannel` reads it at startup to append `(Dev)` to
   the window title and to keep settings in `%APPDATA%\SQLBI\Whiteboard Dev`, so the two
@@ -190,7 +191,27 @@ Imported images, LiveViews, and text objects act as containers. A completed stro
 
 Paste plain text to create a text container and enter edit mode immediately. Text reflows while its edit-mode resize grip changes the width, and the height grows automatically when necessary. Choose **DAX** or **SQL Server** in the title-bar language selector for syntax highlighting in both edit and display modes. A language-aware title identifies a defined DAX or SQL object when possible. Press **F6** to apply the corresponding local formatter. SQL Server mode targets SQL Server 2025 T-SQL, preserves `GO` batch separators, and leaves invalid scripts unchanged. Press **Ctrl+Enter** to commit or **Escape** to restore the previous text, language, and dimensions. In display mode, resizing preserves the aspect ratio and scales the complete text visual without reflowing it.
 
-Image files, and `.txt`, `.dax`, and `.sql` files, can be dropped directly from File Explorer. Their initial center is the board position at which they were dropped. DAX and SQL files open in the matching language mode. Markdown import is a later format; dropping a `.md` file does nothing yet.
+Image files, and `.txt`, `.dax`, and `.sql` files, can be dropped directly from File Explorer. Their initial center is the board position at which they were dropped. DAX and SQL files open in the matching language mode.
+
+### `.wimport` recipes
+
+A `.wimport` file is Markdown that builds containers on a board. It is import-only: there is no export, and saving always writes a `.wboard`.
+
+- `#` is an optional title (not a container).
+- `##` starts one container. The heading is the title.
+- An image (`![](path)`), a `dax` / `sql` fence, a link to `.dax` / `.sql` / an image file, or leftover prose chooses the container kind.
+- A thematic break (`---`) starts a new row. Items otherwise flow left to right and wrap.
+- Paths are local and relative to the `.wimport` file. Missing files are skipped and listed in a dialog.
+
+Drop a `.wimport` onto an open board to add its containers, with the pointer as the group’s top-left. **File → Import…** does the same at the top-left of the view. **File → Open** or double-click (released installer) starts a new untitled board from the recipe.
+
+The full contract for authors and agents is [docs/wimport.md](docs/wimport.md). A sample lives at `docs/samples/contoso-workshop.wimport`. In VS Code, associate the extension with Markdown to use the built-in preview:
+
+```json
+"files.associations": { "*.wimport": "markdown" }
+```
+
+Plain `.md` files are not imported.
 
 ## Architecture
 

--- a/TODO.md
+++ b/TODO.md
@@ -41,15 +41,12 @@ A drop on the window imports at the release point in camera space. Images become
 containers; `.txt`, `.dax`, and `.sql` become text containers in the matching language.
 The classifier is the hook for the import format below — `.md` is still unsupported.
 
-### 3. An import file format
+### 3. An import file format — done
 
-A plain-text format — Markdown is the obvious candidate — that builds a new whiteboard from
-images and text. This makes boards authorable outside the application and generatable by a
-script or an agent, instead of only by drawing.
-
-Two decisions to settle before writing code: which subset of Markdown maps to containers, and
-how positions are expressed when the source has none. Once the format exists, drag and drop
-carries it too.
+`.wimport` is Markdown that builds containers: `##` is one container, `---` starts a new row,
+images and DAX/SQL are inferred from the body or a local link. Drop adds to the current board;
+Open / double-click (released channel) starts a new board that saves as `.wboard`. There is no
+export. Languages are a table so later fences (Python, C#, …) do not need a new matcher.
 
 ### 4. A rendered preview inside the `.wboard` archive
 
@@ -92,7 +89,8 @@ The site is a download page today. It needs real documentation: the tool set, co
 LiveView, the DAX and SQL Server text containers, the import format, and the keyboard and pen
 shortcuts. The README already carries most of this content, so the open question is whether the
 site renders from those files or keeps its own copy — decide that before writing the pages
-twice.
+twice. The `.wimport` contract for authors and agents is already written in
+[docs/wimport.md](docs/wimport.md); publish that file rather than rewriting it.
 
 ### 9. Microsoft Store
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -94,9 +94,10 @@ A dev build installs alongside a released one rather than replacing it: its own
 
 Three consequences were chosen deliberately:
 
-- **Dev does not register `.wboard`.** If both channels claimed it the last install would
-  win, and uninstalling dev would delete the association outright, breaking the released
-  copy. Boards always open in the released build; dev is launched explicitly.
+- **Dev does not register `.wboard` or `.wimport`.** If both channels claimed them the last
+  install would win, and uninstalling dev would delete the association outright, breaking
+  the released copy. Boards and import recipes always open in the released build; dev is
+  launched explicitly.
 - **Settings are separated** through a `channel.txt` placed beside the executable by the dev
   installer, and carried inside the dev portable ZIP. Without this the two copies silently
   overwrite each other's settings on every save — the settings parser ignores the `Version`

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -35,7 +35,7 @@ Two download channels, and they are separate products so both can be installed a
 | Product name | SQLBI Whiteboard | SQLBI Whiteboard (Dev) |
 | Install folder | `…\SQLBI\Whiteboard` | `…\SQLBI\Whiteboard Dev` |
 | Settings | `%APPDATA%\SQLBI\Whiteboard` | `%APPDATA%\SQLBI\Whiteboard Dev` |
-| Registers `.wboard` | yes | no |
+| Registers `.wboard` and `.wimport` | yes | no |
 | Marker file | none | `channel.txt` beside the executable |
 | Published as | GitHub Release | GitHub prerelease |
 

--- a/docs/samples/contoso-workshop.wimport
+++ b/docs/samples/contoso-workshop.wimport
@@ -1,0 +1,28 @@
+# Contoso workshop
+
+This introductory paragraph is only for the Markdown preview. SQLBI Whiteboard
+ignores it.
+
+## Talking points
+- Grain is daily
+- Currency is EUR
+
+## Total Sales
+```dax
+Total Sales := SUM(Sales[Amount])
+```
+
+---
+
+## Test picture
+![demo](../../src/SQLBI.Whiteboard/Assets/SQLBI.Whiteboard.png)
+
+## Warehouse query
+```sql
+SELECT TOP (10)
+    CustomerKey,
+    SUM(SalesAmount) AS SalesAmount
+FROM FactInternetSales
+GROUP BY CustomerKey
+ORDER BY SalesAmount DESC;
+```

--- a/docs/wimport.md
+++ b/docs/wimport.md
@@ -1,0 +1,144 @@
+# `.wimport` format for authors and agents
+
+Read this file before writing a `.wimport`. It is the contract SQLBI Whiteboard implements.
+The site documentation (TODO item 8) should publish this same file rather than a second copy.
+
+A `.wimport` file is a Markdown **recipe**. Whiteboard imports it as image and text
+containers. It is not a board file. There is no export back to `.wimport`. After import the
+user rearranges, draws, and saves a `.wboard`.
+
+The file must be valid CommonMark so it previews in VS Code and GitHub without a custom
+renderer. Associate the extension if the editor does not treat it as Markdown:
+
+```json
+"files.associations": { "*.wimport": "markdown" }
+```
+
+## Produce this
+
+- Extension: `.wimport` (not `.md`, not `.imp`).
+- Encoding: UTF-8.
+- Paths: local and relative to the `.wimport` file. No `http://` or `https://`.
+- One idea per `##` heading. One container per heading.
+
+## Heading grammar
+
+| Line | Meaning |
+| --- | --- |
+| `# Title` | Optional board title. At most one. Not a container. Ignored if it appears after the first `##`. |
+| `## Title` | Starts a container. The heading text is the container title. |
+| `###` and deeper | Stay inside the current container body. They do not start a new object. |
+| `---`, `***`, or `___` on its own line | Thematic break. Starts a **new row** of containers. Not a container. |
+| Any other line before the first `##` | Documentation for the preview. Not imported. |
+
+An empty `##` heading is titled `Text`.
+
+## How the body becomes a container
+
+Recognizers run in this order. The first match wins. Extra material after the match is
+ignored.
+
+1. **Markdown image** — `![optional alt](relative/path.png)`
+   - Image container.
+   - Title is the `##` heading. If the heading is empty, the alt text is used, then the file
+     name.
+   - Allowed extensions: `.png`, `.jpg`, `.jpeg`, `.bmp`, `.gif`.
+2. **Fenced code** whose info-string is a registered language
+   - Text container. Contents of the fence. Language from the tag.
+3. **Markdown link** to an image extension — `[label](relative/path.png)`
+   - Same as an image.
+4. **Markdown link** to a registered language extension — `[label](relative/path.dax)`
+   - Text container. File contents. Language from the extension.
+5. **Any remaining text**
+   - Text container. The Markdown source is stored as **plain text**. Whiteboard does not
+     render Markdown.
+6. **Empty body**
+   - The heading is skipped.
+
+Do not put an image and a measure under the same `##`. Use two headings.
+
+A fenced block whose tag is unknown (for example `python` today) is **not** a language
+container. The whole body, fence included, becomes plain text.
+
+### Languages shipped today
+
+| Language | Fence info-string | File extensions |
+| --- | --- | --- |
+| DAX | `dax` | `.dax` |
+| SQL Server | `sql`, `tsql` | `.sql` |
+
+Further languages (Python, C#, TypeScript, …) will be extra rows in this table. Do not invent
+fence tags Whiteboard does not list here: they import as plain text.
+
+Linked text files larger than 1 000 000 bytes are skipped and reported as missing.
+
+## Layout
+
+Whiteboard measures each container, then packs them **left to right**. A thematic break
+starts a new row even if the current row is not full. Without a break, a row wraps when the
+next item would exceed about 2400 world units.
+
+On drop, the group’s **top-left** is the pointer. On Open or File → Import, the group’s
+top-left is the top-left of the visible view.
+
+Do not put coordinates in the file. There is no `pos:`, no YAML front matter, and no HTML
+comment layout.
+
+## How the file is opened
+
+| Action | Result |
+| --- | --- |
+| Drop onto an open board | Containers are **added**. Pointer is the group top-left. Undo is one step. |
+| File → Import… | Containers are **added** at the visible top-left. |
+| File → Open, or double-click | **New untitled board**, then import. Save / Save As writes `.wboard` only. The `.wimport` path is used only to resolve relative links. |
+
+Missing or unreadable linked files are skipped. Whiteboard then shows a dialog listing the
+resolved paths, which can be copied.
+
+## Template
+
+```markdown
+# Optional board title
+
+Optional notes for the Markdown preview. Not imported.
+
+## Container title for an image
+![short alt](./images/diagram.png)
+
+## Container title for notes
+- Bullet one
+- Bullet two
+
+---
+
+## Container title for embedded DAX
+```dax
+Total Sales := SUM(Sales[Amount])
+```
+
+## Container title for linked SQL
+[Top customers](./sql/top-customers.sql)
+```
+
+A complete sample is `docs/samples/contoso-workshop.wimport`.
+
+## Checklist before you finish
+
+- File name ends in `.wimport`.
+- Every container is a `##` heading with exactly one payload.
+- Images and linked code exist next to the file, using relative paths.
+- Image files are png/jpeg/bmp/gif. Code files you link are `.dax` or `.sql`, or the code is
+  embedded in a `dax` / `sql` / `tsql` fence.
+- Row breaks are a thematic break on its own line, not a fake heading.
+- You did not use `http://`, YAML, or explicit positions.
+- Opening the file in a Markdown preview still reads as a normal document.
+
+## Do not
+
+- Write a `.md` and expect Whiteboard to import it.
+- Ask Whiteboard to save or export `.wimport`.
+- Embed bitmap bytes. Images are always a link to a file.
+- Mix two payloads in one `##` section.
+- Use HTML, YAML front matter, or custom XML.
+- Reference network URLs.
+- Generate ink, LiveViews, or a `.wboard` ZIP. Those are not this format.

--- a/installer/wix/SQLBI.Whiteboard.en-us.wxl
+++ b/installer/wix/SQLBI.Whiteboard.en-us.wxl
@@ -7,6 +7,7 @@
   <String Id="SupportedWindowsVersionMessage" Value="SQLBI Whiteboard requires Windows 10 version 2004 (build 19041) or later." />
   <String Id="LaunchApplication" Value="Launch SQLBI Whiteboard" />
   <String Id="BoardFileTypeDescription" Value="SQLBI Whiteboard board" />
+  <String Id="ImportFileTypeDescription" Value="SQLBI Whiteboard import" />
   <String Id="BoardOpenVerb" Value="Open" />
 
 </WixLocalization>

--- a/installer/wix/SQLBI.Whiteboard.wxs
+++ b/installer/wix/SQLBI.Whiteboard.wxs
@@ -21,12 +21,15 @@
   <?define AppUrlInfoAbout = "https://whiteboard.sqlbi.com" ?>
   <?define BoardExtension = "wboard" ?>
   <?define BoardProgId = "SQLBI.Whiteboard.Board" ?>
+  <?define ImportExtension = "wimport" ?>
+  <?define ImportProgId = "SQLBI.Whiteboard.Import" ?>
 
   <!--
     The pre-release channel is a separate product: its own UpgradeCodes, name, install
     folder and settings, so a tester can keep a released copy installed alongside it.
-    It deliberately does not claim the .wboard file type, which stays with the released
-    channel; uninstalling a pre-release therefore cannot break that association.
+    It deliberately does not claim the .wboard or .wimport file types, which stay with
+    the released channel; uninstalling a pre-release therefore cannot break those
+    associations.
   -->
   <?if $(var.Channel) = dev ?>
     <?define ChannelName = "Dev" ?>
@@ -172,6 +175,18 @@
               Description="!(loc.BoardFileTypeDescription)"
               Icon="DocumentIcon">
             <Extension Id="$(var.BoardExtension)" ContentType="application/vnd.sqlbi.whiteboard">
+              <Verb
+                  Id="open"
+                  Command="!(loc.BoardOpenVerb)"
+                  TargetFile="MainExecutable"
+                  Argument="&quot;%1&quot;" />
+            </Extension>
+          </ProgId>
+          <ProgId
+              Id="$(var.ImportProgId)"
+              Description="!(loc.ImportFileTypeDescription)"
+              Icon="DocumentIcon">
+            <Extension Id="$(var.ImportExtension)" ContentType="application/vnd.sqlbi.whiteboard-import">
               <Verb
                   Id="open"
                   Command="!(loc.BoardOpenVerb)"

--- a/src/SQLBI.Whiteboard.Core/Commands/CommandHistory.cs
+++ b/src/SQLBI.Whiteboard.Core/Commands/CommandHistory.cs
@@ -71,6 +71,37 @@ public sealed record AddObjectCommand(BoardObject Item) : IBoardCommand
     public void Undo(BoardDocument document) => document.RemoveObject(Item.Id);
 }
 
+public sealed record AddImportCommand(
+    IReadOnlyList<BoardObject> Objects,
+    IReadOnlyList<BoardAsset> Assets) : IBoardCommand
+{
+    public void Execute(BoardDocument document)
+    {
+        foreach (var asset in Assets)
+        {
+            document.AddAsset(asset);
+        }
+
+        foreach (var item in Objects)
+        {
+            document.AddObject(item);
+        }
+    }
+
+    public void Undo(BoardDocument document)
+    {
+        foreach (var item in Objects)
+        {
+            document.RemoveObject(item.Id);
+        }
+
+        foreach (var asset in Assets)
+        {
+            document.RemoveAsset(asset.Id);
+        }
+    }
+}
+
 public sealed record RemoveObjectsCommand(IReadOnlyList<BoardObject> Items) : IBoardCommand
 {
     public void Execute(BoardDocument document)

--- a/src/SQLBI.Whiteboard.Core/Import/DroppedFileImport.cs
+++ b/src/SQLBI.Whiteboard.Core/Import/DroppedFileImport.cs
@@ -1,5 +1,3 @@
-using SQLBI.Whiteboard.Core.Model;
-
 namespace SQLBI.Whiteboard.Core.Import;
 
 public enum DroppedFileKind
@@ -7,42 +5,40 @@ public enum DroppedFileKind
     Unsupported = 0,
     Image = 1,
     Text = 2,
+    Import = 3,
 }
 
 public static class DroppedFileImport
 {
     public const int MaximumTextBytes = 1_000_000;
+    public const string ImportExtension = ".wimport";
 
-    private static readonly HashSet<string> ImageExtensions = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ".png",
-        ".jpg",
-        ".jpeg",
-        ".bmp",
-        ".gif",
-    };
-
-    private static readonly HashSet<string> TextExtensions = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> PlainTextExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
         ".txt",
-        ".sql",
-        ".dax",
     };
 
-    public static DroppedFileKind Classify(string? path)
+    public static DroppedFileKind Classify(string? path, ImportCatalog? catalog = null)
     {
+        catalog ??= ImportCatalog.Default;
         var extension = Path.GetExtension(path);
         if (string.IsNullOrEmpty(extension))
         {
             return DroppedFileKind.Unsupported;
         }
 
-        if (ImageExtensions.Contains(extension))
+        if (string.Equals(extension, ImportExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            return DroppedFileKind.Import;
+        }
+
+        if (catalog.IsImageExtension(extension))
         {
             return DroppedFileKind.Image;
         }
 
-        if (TextExtensions.Contains(extension))
+        if (catalog.LanguageForExtension(extension) is not null ||
+            PlainTextExtensions.Contains(extension))
         {
             return DroppedFileKind.Text;
         }
@@ -58,14 +54,6 @@ public static class DroppedFileImport
         return paths.Any(CanImport);
     }
 
-    public static string LanguageIdFor(string? path)
-    {
-        var extension = Path.GetExtension(path);
-        return extension?.ToLowerInvariant() switch
-        {
-            ".dax" => TextLanguageIds.Dax,
-            ".sql" => TextLanguageIds.SqlServer,
-            _ => TextLanguageIds.Plain,
-        };
-    }
+    public static string LanguageIdFor(string? path, ImportCatalog? catalog = null) =>
+        (catalog ?? ImportCatalog.Default).LanguageIdForPath(path);
 }

--- a/src/SQLBI.Whiteboard.Core/Import/ImportCatalog.cs
+++ b/src/SQLBI.Whiteboard.Core/Import/ImportCatalog.cs
@@ -1,0 +1,88 @@
+using SQLBI.Whiteboard.Core.Model;
+
+namespace SQLBI.Whiteboard.Core.Import;
+
+public sealed class ImportLanguage
+{
+    public required string Id { get; init; }
+
+    public required IReadOnlyList<string> FenceTags { get; init; }
+
+    public required IReadOnlyList<string> Extensions { get; init; }
+}
+
+public sealed class ImportCatalog
+{
+    public static ImportCatalog Default { get; } = new(
+        [
+            new ImportLanguage
+            {
+                Id = TextLanguageIds.Dax,
+                FenceTags = ["dax"],
+                Extensions = [".dax"],
+            },
+            new ImportLanguage
+            {
+                Id = TextLanguageIds.SqlServer,
+                FenceTags = ["sql", "tsql"],
+                Extensions = [".sql"],
+            },
+        ],
+        [".png", ".jpg", ".jpeg", ".bmp", ".gif"]);
+
+    public ImportCatalog(
+        IReadOnlyList<ImportLanguage> languages,
+        IReadOnlyList<string> imageExtensions)
+    {
+        ArgumentNullException.ThrowIfNull(languages);
+        ArgumentNullException.ThrowIfNull(imageExtensions);
+        Languages = languages;
+        ImageExtensions = imageExtensions;
+    }
+
+    public IReadOnlyList<ImportLanguage> Languages { get; }
+
+    public IReadOnlyList<string> ImageExtensions { get; }
+
+    public ImportCatalog WithLanguage(ImportLanguage language)
+    {
+        ArgumentNullException.ThrowIfNull(language);
+        return new ImportCatalog([.. Languages, language], ImageExtensions);
+    }
+
+    public bool IsImageExtension(string? extension) =>
+        !string.IsNullOrEmpty(extension) &&
+        ImageExtensions.Any(known =>
+            string.Equals(known, extension, StringComparison.OrdinalIgnoreCase));
+
+    public ImportLanguage? LanguageForFence(string? tag)
+    {
+        if (string.IsNullOrWhiteSpace(tag))
+        {
+            return null;
+        }
+
+        var normalized = tag.Trim();
+        return Languages.FirstOrDefault(language =>
+            language.FenceTags.Any(fence =>
+                string.Equals(fence, normalized, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    public ImportLanguage? LanguageForExtension(string? extension)
+    {
+        if (string.IsNullOrEmpty(extension))
+        {
+            return null;
+        }
+
+        return Languages.FirstOrDefault(language =>
+            language.Extensions.Any(known =>
+                string.Equals(known, extension, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    public string LanguageIdForPath(string? path)
+    {
+        var language = LanguageForExtension(Path.GetExtension(path));
+        return language?.Id ?? TextLanguageIds.Plain;
+    }
+}

--- a/src/SQLBI.Whiteboard.Core/Import/ImportDocument.cs
+++ b/src/SQLBI.Whiteboard.Core/Import/ImportDocument.cs
@@ -1,0 +1,355 @@
+using System.Text.RegularExpressions;
+using SQLBI.Whiteboard.Core.Model;
+
+namespace SQLBI.Whiteboard.Core.Import;
+
+public enum ImportItemKind
+{
+    Image = 0,
+    Text = 1,
+}
+
+public sealed record ImportItem
+{
+    public required string Title { get; init; }
+
+    public required ImportItemKind Kind { get; init; }
+
+    public string LanguageId { get; init; } = TextLanguageIds.Plain;
+
+    public string? Text { get; init; }
+
+    public string? SourcePath { get; init; }
+
+    public bool StartNewRow { get; init; }
+
+    public byte[]? ImageBytes { get; init; }
+
+    public string? ImageFileName { get; init; }
+}
+
+public sealed class ImportDocument
+{
+    private static readonly Regex ImagePattern = new(
+        @"!\[(?<alt>[^\]]*)\]\((?<path><[^>]+>|[^)\s]+)\)",
+        RegexOptions.CultureInvariant);
+
+    private static readonly Regex LinkPattern = new(
+        @"(?<!!)\[(?<text>[^\]]*)\]\((?<path><[^>]+>|[^)\s]+)\)",
+        RegexOptions.CultureInvariant);
+
+    public ImportDocument(
+        string? title,
+        IReadOnlyList<ImportItem> items,
+        IReadOnlyList<string> missingFiles)
+    {
+        Title = title;
+        Items = items;
+        MissingFiles = missingFiles;
+    }
+
+    public string? Title { get; }
+
+    public IReadOnlyList<ImportItem> Items { get; }
+
+    public IReadOnlyList<string> MissingFiles { get; }
+
+    public static ImportDocument Parse(string markdown, ImportCatalog? catalog = null)
+    {
+        catalog ??= ImportCatalog.Default;
+        var sections = SplitSections(markdown ?? string.Empty);
+        var items = new List<ImportItem>();
+        foreach (var section in sections)
+        {
+            if (Recognize(section, catalog) is { } item)
+            {
+                items.Add(item);
+            }
+        }
+
+        return new ImportDocument(
+            ReadBoardTitle(markdown ?? string.Empty),
+            items,
+            []);
+    }
+
+    public ImportDocument Resolve(string baseDirectory, ImportCatalog? catalog = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(baseDirectory);
+        catalog ??= ImportCatalog.Default;
+        var items = new List<ImportItem>();
+        var missing = new List<string>();
+        foreach (var item in Items)
+        {
+            if (item.SourcePath is null)
+            {
+                items.Add(item);
+                continue;
+            }
+
+            if (IsRemote(item.SourcePath))
+            {
+                missing.Add(item.SourcePath);
+                continue;
+            }
+
+            var fullPath = Path.GetFullPath(Path.Combine(baseDirectory, item.SourcePath));
+            if (!File.Exists(fullPath))
+            {
+                missing.Add(fullPath);
+                continue;
+            }
+
+            if (item.Kind == ImportItemKind.Image)
+            {
+                items.Add(item with
+                {
+                    ImageBytes = File.ReadAllBytes(fullPath),
+                    ImageFileName = Path.GetFileName(fullPath),
+                    SourcePath = fullPath,
+                });
+                continue;
+            }
+
+            var info = new FileInfo(fullPath);
+            if (info.Length > DroppedFileImport.MaximumTextBytes)
+            {
+                missing.Add(fullPath);
+                continue;
+            }
+
+            items.Add(item with
+            {
+                Text = File.ReadAllText(fullPath),
+                SourcePath = fullPath,
+            });
+        }
+
+        return new ImportDocument(Title, items, missing);
+    }
+
+    private static string? ReadBoardTitle(string markdown)
+    {
+        using var reader = new StringReader(markdown);
+        while (reader.ReadLine() is { } line)
+        {
+            if (line.StartsWith("##", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            if (line.StartsWith("# ", StringComparison.Ordinal))
+            {
+                var title = line[2..].Trim();
+                return title.Length == 0 ? null : title;
+            }
+        }
+
+        return null;
+    }
+
+    private static List<Section> SplitSections(string markdown)
+    {
+        var sections = new List<Section>();
+        string? title = null;
+        var body = new List<string>();
+        var pendingNewRow = false;
+        var started = false;
+
+        void Flush()
+        {
+            if (!started || title is null)
+            {
+                body.Clear();
+                return;
+            }
+
+            sections.Add(new Section(title, string.Join("\n", body).Trim(), pendingNewRow));
+            pendingNewRow = false;
+            body.Clear();
+        }
+
+        using var reader = new StringReader(markdown);
+        while (reader.ReadLine() is { } line)
+        {
+            if (IsThematicBreak(line))
+            {
+                Flush();
+                started = false;
+                title = null;
+                pendingNewRow = true;
+                continue;
+            }
+
+            if (line.StartsWith("## ", StringComparison.Ordinal) &&
+                !line.StartsWith("###", StringComparison.Ordinal))
+            {
+                Flush();
+                started = true;
+                title = line[3..].Trim();
+                if (title.Length == 0)
+                {
+                    title = "Text";
+                }
+
+                continue;
+            }
+
+            if (started)
+            {
+                body.Add(line);
+            }
+        }
+
+        Flush();
+        return sections;
+    }
+
+    private static ImportItem? Recognize(Section section, ImportCatalog catalog)
+    {
+        if (ImagePattern.Match(section.Body) is { Success: true } image)
+        {
+            var path = NormalizeLinkTarget(image.Groups["path"].Value);
+            var title = section.Title == "Text"
+                ? NullIfEmpty(image.Groups["alt"].Value) ??
+                  Path.GetFileNameWithoutExtension(path) ??
+                  "Image"
+                : section.Title;
+            return new ImportItem
+            {
+                Title = title,
+                Kind = ImportItemKind.Image,
+                SourcePath = path,
+                StartNewRow = section.StartNewRow,
+            };
+        }
+
+        if (TryFindFence(section.Body, out var fenceTag, out var fenceBody) &&
+            catalog.LanguageForFence(fenceTag) is { } fencedLanguage)
+        {
+            return new ImportItem
+            {
+                Title = section.Title,
+                Kind = ImportItemKind.Text,
+                LanguageId = fencedLanguage.Id,
+                Text = fenceBody,
+                StartNewRow = section.StartNewRow,
+            };
+        }
+
+        foreach (Match link in LinkPattern.Matches(section.Body))
+        {
+            var path = NormalizeLinkTarget(link.Groups["path"].Value);
+            var extension = Path.GetExtension(path);
+            if (catalog.IsImageExtension(extension))
+            {
+                return new ImportItem
+                {
+                    Title = section.Title,
+                    Kind = ImportItemKind.Image,
+                    SourcePath = path,
+                    StartNewRow = section.StartNewRow,
+                };
+            }
+
+            if (catalog.LanguageForExtension(extension) is { } language)
+            {
+                return new ImportItem
+                {
+                    Title = section.Title,
+                    Kind = ImportItemKind.Text,
+                    LanguageId = language.Id,
+                    SourcePath = path,
+                    StartNewRow = section.StartNewRow,
+                };
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(section.Body))
+        {
+            return null;
+        }
+
+        return new ImportItem
+        {
+            Title = section.Title,
+            Kind = ImportItemKind.Text,
+            LanguageId = TextLanguageIds.Plain,
+            Text = section.Body.Trim(),
+            StartNewRow = section.StartNewRow,
+        };
+    }
+
+    private static bool TryFindFence(string body, out string tag, out string contents)
+    {
+        tag = string.Empty;
+        contents = string.Empty;
+        using var reader = new StringReader(body);
+        string? line;
+        string? opening = null;
+        string? fenceTag = null;
+        var inner = new List<string>();
+        while ((line = reader.ReadLine()) is not null)
+        {
+            var trimmed = line.TrimStart();
+            if (opening is null)
+            {
+                if (!trimmed.StartsWith("```", StringComparison.Ordinal) &&
+                    !trimmed.StartsWith("~~~", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                opening = trimmed[..3];
+                fenceTag = trimmed[3..].Trim();
+                var space = fenceTag.IndexOfAny([' ', '\t']);
+                if (space >= 0)
+                {
+                    fenceTag = fenceTag[..space];
+                }
+
+                continue;
+            }
+
+            if (trimmed.StartsWith(opening, StringComparison.Ordinal))
+            {
+                tag = fenceTag ?? string.Empty;
+                contents = string.Join("\n", inner).Trim();
+                return true;
+            }
+
+            inner.Add(line);
+        }
+
+        return false;
+    }
+
+    private static bool IsThematicBreak(string line)
+    {
+        var compact = string.Concat(line.Where(character => !char.IsWhiteSpace(character)));
+        return compact.Length >= 3 &&
+               compact.Distinct().Count() == 1 &&
+               compact[0] is '-' or '*' or '_';
+    }
+
+    private static string NormalizeLinkTarget(string raw)
+    {
+        var path = raw.Trim();
+        if (path.Length >= 2 && path[0] == '<' && path[^1] == '>')
+        {
+            path = path[1..^1].Trim();
+        }
+
+        var hash = path.IndexOf('#', StringComparison.Ordinal);
+        return hash >= 0 ? path[..hash] : path;
+    }
+
+    private static bool IsRemote(string path) =>
+        path.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+        path.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private sealed record Section(string Title, string Body, bool StartNewRow);
+}

--- a/src/SQLBI.Whiteboard.Core/Import/ImportLayout.cs
+++ b/src/SQLBI.Whiteboard.Core/Import/ImportLayout.cs
@@ -1,0 +1,53 @@
+using SQLBI.Whiteboard.Core.Geometry;
+
+namespace SQLBI.Whiteboard.Core.Import;
+
+public static class ImportLayout
+{
+    public const double MaxRowWidth = 2400;
+    public const double Gap = 32;
+    public const double MaxImageWidth = 900;
+    public const double MaxImageHeight = 700;
+
+    public static IReadOnlyList<RectD> Place(
+        IReadOnlyList<(double Width, double Height, bool StartNewRow)> items,
+        PointD originTopLeft)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        var placed = new RectD[items.Count];
+        var x = originTopLeft.X;
+        var y = originTopLeft.Y;
+        var rowHeight = 0d;
+        var rowOccupied = false;
+        for (var index = 0; index < items.Count; index++)
+        {
+            var (width, height, startNewRow) = items[index];
+            width = Math.Max(1, width);
+            height = Math.Max(1, height);
+            var wrap = startNewRow ||
+                       (rowOccupied && x + width > originTopLeft.X + MaxRowWidth);
+            if (wrap)
+            {
+                x = originTopLeft.X;
+                y += rowHeight + Gap;
+                rowHeight = 0;
+                rowOccupied = false;
+            }
+
+            placed[index] = new RectD(x, y, width, height);
+            x += width + Gap;
+            rowHeight = Math.Max(rowHeight, height);
+            rowOccupied = true;
+        }
+
+        return placed;
+    }
+
+    public static (double Width, double Height) ImageSize(double naturalWidth, double naturalHeight)
+    {
+        var width = Math.Max(1, naturalWidth);
+        var height = Math.Max(1, naturalHeight);
+        var scale = Math.Min(1, Math.Min(MaxImageWidth / width, MaxImageHeight / height));
+        return (width * scale, height * scale);
+    }
+}

--- a/src/SQLBI.Whiteboard.Core/Model/BoardDocument.cs
+++ b/src/SQLBI.Whiteboard.Core/Model/BoardDocument.cs
@@ -102,6 +102,17 @@ public sealed class BoardDocument
         Changed?.Invoke(this, EventArgs.Empty);
     }
 
+    public bool RemoveAsset(string id)
+    {
+        var removed = _assets.Remove(id);
+        if (removed)
+        {
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+
+        return removed;
+    }
+
     public IEnumerable<BoardObject> Query(RectD worldBounds) =>
         _objects.Where(item => item.Bounds.Intersects(worldBounds));
 

--- a/src/SQLBI.Whiteboard/App.xaml.cs
+++ b/src/SQLBI.Whiteboard/App.xaml.cs
@@ -15,7 +15,7 @@ public partial class App : Application
 
     /// <summary>
     /// Returns the first existing file passed on the command line, as supplied by the
-    /// shell when a <c>.wboard</c> document is opened from Explorer.
+    /// shell when a <c>.wboard</c> or <c>.wimport</c> file is opened from Explorer.
     /// </summary>
     private static string? FindBoardPath(string[] args)
     {

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -163,7 +163,7 @@ public partial class MainWindow : Window
         Loaded -= MainWindow_Loaded;
         if (_initialBoardPath is not null)
         {
-            await LoadBoardAsync(_initialBoardPath);
+            await OpenPathAsync(_initialBoardPath, confirmDiscard: false);
         }
     }
 
@@ -2640,13 +2640,7 @@ public partial class MainWindow : Window
     private void NewMenuItem_Click(object sender, RoutedEventArgs e)
     {
         CommitTextEdit();
-        if ((_document.Objects.Count > 0 || _document.Assets.Count > 0) &&
-            MessageBox.Show(
-                this,
-                "Create a new whiteboard? Any unsaved changes will be lost.",
-                "New whiteboard",
-                MessageBoxButton.YesNo,
-                MessageBoxImage.Warning) != MessageBoxResult.Yes)
+        if (!ConfirmDiscardUnsaved("Create a new whiteboard? Any unsaved changes will be lost."))
         {
             return;
         }
@@ -2655,6 +2649,15 @@ public partial class MainWindow : Window
         _currentBoardPath = null;
         ResetBoardView();
     }
+
+    private bool ConfirmDiscardUnsaved(string message) =>
+        _document.Objects.Count == 0 && _document.Assets.Count == 0 ||
+        MessageBox.Show(
+            this,
+            message,
+            "SQLBI Whiteboard",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Warning) == MessageBoxResult.Yes;
 
     private async void SaveAsMenuItem_Click(object sender, RoutedEventArgs e) =>
         await SaveBoardAsync(saveAs: true);
@@ -2700,12 +2703,19 @@ public partial class MainWindow : Window
     {
         var dialog = new OpenFileDialog
         {
-            Title = "Import image",
-            Filter = "Images|*.png;*.jpg;*.jpeg;*.bmp;*.gif",
+            Title = "Import",
+            Filter =
+                "Importable files|*.wimport;*.png;*.jpg;*.jpeg;*.bmp;*.gif|Whiteboard import|*.wimport|Images|*.png;*.jpg;*.jpeg;*.bmp;*.gif",
             Multiselect = false,
         };
         if (dialog.ShowDialog(this) != true)
         {
+            return;
+        }
+
+        if (DroppedFileImport.Classify(dialog.FileName) == DroppedFileKind.Import)
+        {
+            await ImportRecipeAsync(dialog.FileName, VisibleTopLeft(), replaceDocument: false);
             return;
         }
 
@@ -3181,8 +3191,9 @@ public partial class MainWindow : Window
         CommitTextEdit();
         var dialog = new OpenFileDialog
         {
-            Title = "Open board",
-            Filter = "Whiteboard document|*.wboard",
+            Title = "Open",
+            Filter =
+                "Whiteboard|*.wboard;*.wimport|Whiteboard document|*.wboard|Whiteboard import|*.wimport",
             Multiselect = false,
         };
         if (dialog.ShowDialog(this) != true)
@@ -3190,7 +3201,30 @@ public partial class MainWindow : Window
             return;
         }
 
-        await LoadBoardAsync(dialog.FileName);
+        await OpenPathAsync(dialog.FileName, confirmDiscard: true);
+    }
+
+    private async Task OpenPathAsync(string filePath, bool confirmDiscard)
+    {
+        if (DroppedFileImport.Classify(filePath) == DroppedFileKind.Import)
+        {
+            if (confirmDiscard &&
+                !ConfirmDiscardUnsaved("Open this import? Any unsaved changes will be lost."))
+            {
+                return;
+            }
+
+            await ImportRecipeAsync(filePath, VisibleTopLeft(), replaceDocument: true);
+            return;
+        }
+
+        if (confirmDiscard &&
+            !ConfirmDiscardUnsaved("Open this board? Any unsaved changes will be lost."))
+        {
+            return;
+        }
+
+        await LoadBoardAsync(filePath);
     }
 
     private async Task LoadBoardAsync(string filePath)
@@ -3318,11 +3352,11 @@ public partial class MainWindow : Window
             return;
         }
 
-        var dropCenter = _camera.ScreenToWorld(ToPointD(e.GetPosition(InkSurface)));
-        await ImportDroppedFilesAsync(paths, dropCenter);
+        var dropPoint = _camera.ScreenToWorld(ToPointD(e.GetPosition(InkSurface)));
+        await ImportDroppedFilesAsync(paths, dropPoint);
     }
 
-    private async Task ImportDroppedFilesAsync(string[] paths, PointD worldCenter)
+    private async Task ImportDroppedFilesAsync(string[] paths, PointD worldPoint)
     {
         var imported = 0;
         try
@@ -3335,7 +3369,14 @@ public partial class MainWindow : Window
                     continue;
                 }
 
-                var center = worldCenter + new PointD(imported * 24, imported * 24);
+                if (kind == DroppedFileKind.Import)
+                {
+                    await ImportRecipeAsync(path, worldPoint, replaceDocument: false);
+                    imported++;
+                    continue;
+                }
+
+                var center = worldPoint + new PointD(imported * 24, imported * 24);
                 switch (kind)
                 {
                     case DroppedFileKind.Image:
@@ -3372,6 +3413,155 @@ public partial class MainWindow : Window
             ShowError("Could not drop file", exception);
         }
     }
+
+    private async Task ImportRecipeAsync(
+        string filePath,
+        PointD originTopLeft,
+        bool replaceDocument)
+    {
+        try
+        {
+            var markdown = await File.ReadAllTextAsync(filePath);
+            var baseDirectory = Path.GetDirectoryName(filePath);
+            if (string.IsNullOrWhiteSpace(baseDirectory))
+            {
+                baseDirectory = Environment.CurrentDirectory;
+            }
+
+            var imported = ImportDocument.Parse(markdown).Resolve(baseDirectory);
+            if (replaceDocument)
+            {
+                ReplaceDocument(new BoardDocument());
+                _currentBoardPath = null;
+                ResetBoardView();
+                originTopLeft = VisibleTopLeft();
+            }
+
+            ApplyImport(imported, originTopLeft, recordUndo: !replaceDocument);
+            if (imported.MissingFiles.Count > 0)
+            {
+                new MissingFilesWindow(imported.MissingFiles)
+                {
+                    Owner = this,
+                }.ShowDialog();
+            }
+        }
+        catch (Exception exception)
+        {
+            ShowError("Could not import whiteboard", exception);
+        }
+    }
+
+    private void ApplyImport(ImportDocument imported, PointD originTopLeft, bool recordUndo)
+    {
+        if (imported.Items.Count == 0)
+        {
+            return;
+        }
+
+        var dpi = VisualTreeHelper.GetDpi(SceneSurface).PixelsPerDip;
+        var sizes = new List<(double Width, double Height, bool StartNewRow)>(imported.Items.Count);
+        var decoded = new List<(ImportItem Item, byte[]? Bytes, double Width, double Height)>(
+            imported.Items.Count);
+        foreach (var item in imported.Items)
+        {
+            if (item.Kind == ImportItemKind.Image)
+            {
+                if (item.ImageBytes is null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var bitmap = WpfImageCodec.Decode(item.ImageBytes);
+                    var (width, height) = ImportLayout.ImageSize(bitmap.PixelWidth, bitmap.PixelHeight);
+                    sizes.Add((width, height, item.StartNewRow));
+                    decoded.Add((item, item.ImageBytes, width, height));
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                var text = item.Text ?? string.Empty;
+                if (text.Length == 0)
+                {
+                    continue;
+                }
+
+                var width = Math.Min(
+                    TextContainerVisual.DefaultWidth,
+                    Math.Max(320, _camera.VisibleWorldBounds.Width * 0.7));
+                var height = TextContainerVisual.MeasureDesiredHeight(text, width, 1, dpi);
+                sizes.Add((width, height, item.StartNewRow));
+                decoded.Add((item, null, width, height));
+            }
+        }
+
+        if (decoded.Count == 0)
+        {
+            return;
+        }
+
+        var rects = ImportLayout.Place(sizes, originTopLeft);
+        var objects = new List<BoardObject>(decoded.Count);
+        var assets = new List<BoardAsset>();
+        for (var index = 0; index < decoded.Count; index++)
+        {
+            var (item, bytes, _, _) = decoded[index];
+            var bounds = rects[index];
+            if (item.Kind == ImportItemKind.Image && bytes is not null)
+            {
+                var assetId = Guid.NewGuid().ToString("N");
+                assets.Add(new BoardAsset(
+                    assetId,
+                    item.ImageFileName ?? "image.png",
+                    ContentTypeFor(item.ImageFileName ?? item.SourcePath ?? "image.png"),
+                    bytes));
+                objects.Add(new ImageBoardObject(
+                    Guid.NewGuid(),
+                    _document.NextZIndex + objects.Count,
+                    bounds,
+                    assetId));
+            }
+            else
+            {
+                objects.Add(new TextBoardObject(
+                    Guid.NewGuid(),
+                    _document.NextZIndex + objects.Count,
+                    bounds,
+                    item.Title,
+                    item.Text ?? string.Empty,
+                    LanguageId: TextLanguageIds.Normalize(item.LanguageId)));
+            }
+        }
+
+        var command = new AddImportCommand(objects, assets);
+        if (recordUndo)
+        {
+            _history.Execute(command, _document);
+        }
+        else
+        {
+            command.Execute(_document);
+            _history.Clear();
+        }
+
+        SceneSurface.InvalidateAssets();
+        if (objects.Count > 0)
+        {
+            _selectedObjectId = objects[^1].Id;
+            SceneSurface.SelectedObjectId = _selectedObjectId;
+            SetActiveTool(BoardTool.Select);
+        }
+
+        UpdateLiveViewActionOverlay();
+    }
+
+    private PointD VisibleTopLeft() => _camera.ScreenToWorld(new PointD(0, 0));
 
     private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
     {

--- a/src/SQLBI.Whiteboard/MissingFilesWindow.xaml
+++ b/src/SQLBI.Whiteboard/MissingFilesWindow.xaml
@@ -1,0 +1,44 @@
+<Window x:Class="SQLBI.Whiteboard.MissingFilesWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Could not import some files"
+        Width="560"
+        Height="320"
+        MinWidth="420"
+        MinHeight="240"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        Background="{DynamicResource ToolbarBackgroundBrush}">
+    <DockPanel Margin="20">
+        <TextBlock DockPanel.Dock="Top"
+                   FontFamily="Segoe UI"
+                   FontSize="13"
+                   Foreground="#FF1F2937"
+                   TextWrapping="Wrap"
+                   Text="These files were missing or unreadable and were skipped." />
+        <StackPanel DockPanel.Dock="Bottom"
+                    Margin="0,16,0,0"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right">
+            <Button MinWidth="88"
+                    MinHeight="30"
+                    Margin="0,0,8,0"
+                    Content="Copy paths"
+                    Click="CopyButton_Click" />
+            <Button MinWidth="88"
+                    MinHeight="30"
+                    IsDefault="True"
+                    Content="Close"
+                    Click="CloseButton_Click" />
+        </StackPanel>
+        <TextBox x:Name="PathsBox"
+                 Margin="0,12,0,0"
+                 IsReadOnly="True"
+                 TextWrapping="NoWrap"
+                 AcceptsReturn="True"
+                 VerticalScrollBarVisibility="Auto"
+                 HorizontalScrollBarVisibility="Auto"
+                 FontFamily="Consolas"
+                 FontSize="12" />
+    </DockPanel>
+</Window>

--- a/src/SQLBI.Whiteboard/MissingFilesWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MissingFilesWindow.xaml.cs
@@ -1,0 +1,23 @@
+using System.Windows;
+
+namespace SQLBI.Whiteboard;
+
+public partial class MissingFilesWindow : Window
+{
+    public MissingFilesWindow(IEnumerable<string> paths)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+        InitializeComponent();
+        PathsBox.Text = string.Join(Environment.NewLine, paths);
+    }
+
+    private void CopyButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (PathsBox.Text.Length > 0)
+        {
+            Clipboard.SetText(PathsBox.Text);
+        }
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
+++ b/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
@@ -53,9 +53,10 @@ Assert(
     DroppedFileImport.Classify("notes.txt") == DroppedFileKind.Text &&
     DroppedFileImport.Classify("measure.dax") == DroppedFileKind.Text &&
     DroppedFileImport.Classify("query.sql") == DroppedFileKind.Text &&
+    DroppedFileImport.Classify("lesson.wimport") == DroppedFileKind.Import &&
     DroppedFileImport.Classify("board.wboard") == DroppedFileKind.Unsupported &&
     DroppedFileImport.Classify("notes.md") == DroppedFileKind.Unsupported,
-    "Drop import should accept images and text now, and leave markdown and boards for later.");
+    "Drop import should accept images, text, and .wimport, and leave markdown and boards for later.");
 Assert(
     DroppedFileImport.CanImportAny(["skip.bin", "photo.jpg"]),
     "A mixed drop should be accepted when any file can be imported.");
@@ -67,6 +68,135 @@ Assert(
     DroppedFileImport.LanguageIdFor("query.sql") == TextLanguageIds.SqlServer &&
     DroppedFileImport.LanguageIdFor("notes.txt") == TextLanguageIds.Plain,
     "Dropped text files should pick a language from the extension.");
+
+var parsedImport = ImportDocument.Parse(
+    """
+    # Contoso workshop
+
+    This intro is ignored.
+
+    ## Sales model
+    ![Sales model](./images/model.png)
+
+    ## Talking points
+    - Grain is daily
+
+    ---
+
+    ## Total Sales
+    ```dax
+    Total Sales := SUM(Sales[Amount])
+    ```
+
+    ## Warehouse query
+    [top customers](./sql/top-customers.sql)
+
+    ## Unknown fence
+    ```python
+    print("hi")
+    ```
+    """);
+Assert(
+    parsedImport.Title == "Contoso workshop" &&
+    parsedImport.Items.Count == 5,
+    "A .wimport file should yield one item per ## heading.");
+Assert(
+    parsedImport.Items[0] is
+    {
+        Kind: ImportItemKind.Image,
+        SourcePath: "./images/model.png",
+        Title: "Sales model",
+        StartNewRow: false,
+    },
+    "A Markdown image should become an image item.");
+Assert(
+    parsedImport.Items[1] is { Kind: ImportItemKind.Text, LanguageId: TextLanguageIds.Plain } &&
+    parsedImport.Items[1].Text!.Contains("Grain is daily", StringComparison.Ordinal),
+    "Notes should import as plain Markdown source.");
+Assert(
+    parsedImport.Items[2] is
+    {
+        Kind: ImportItemKind.Text,
+        LanguageId: TextLanguageIds.Dax,
+        StartNewRow: true,
+        Text: "Total Sales := SUM(Sales[Amount])",
+    },
+    "A thematic break should force the next container onto a new row.");
+Assert(
+    parsedImport.Items[3] is
+    {
+        Kind: ImportItemKind.Text,
+        LanguageId: TextLanguageIds.SqlServer,
+        SourcePath: "./sql/top-customers.sql",
+    },
+    "A link to a .sql file should become a SQL text item.");
+Assert(
+    parsedImport.Items[4] is { LanguageId: TextLanguageIds.Plain } &&
+    parsedImport.Items[4].Text!.Contains("print", StringComparison.Ordinal),
+    "An unknown fence should fall through to plain text.");
+
+var pythonCatalog = ImportCatalog.Default.WithLanguage(
+    new ImportLanguage
+    {
+        Id = "python",
+        FenceTags = ["python", "py"],
+        Extensions = [".py"],
+    });
+var pythonFromFence = ImportDocument.Parse(
+    """
+    ## Script
+    ```python
+    print("hi")
+    ```
+    """,
+    pythonCatalog);
+var pythonFromLink = ImportDocument.Parse(
+    """
+    ## Script
+    [script](./util.py)
+    """,
+    pythonCatalog);
+Assert(
+    pythonFromFence.Items is [{ LanguageId: "python", Text: "print(\"hi\")" }] &&
+    pythonFromLink.Items is [{ LanguageId: "python", SourcePath: "./util.py" }],
+    "A new language row should be picked up by fence and by link without matcher changes.");
+
+var importFolder = Path.Combine(Path.GetTempPath(), "wimport-" + Guid.NewGuid().ToString("N"));
+Directory.CreateDirectory(importFolder);
+File.WriteAllText(Path.Combine(importFolder, "ok.dax"), "x := 1");
+var resolvedImport = ImportDocument.Parse(
+    """
+    ## Present
+    [ok](./ok.dax)
+
+    ## Missing
+    ![](./missing.png)
+    """).Resolve(importFolder);
+Assert(
+    resolvedImport.Items is [{ LanguageId: TextLanguageIds.Dax, Text: "x := 1" }] &&
+    resolvedImport.MissingFiles.Count == 1 &&
+    resolvedImport.MissingFiles[0].EndsWith("missing.png", StringComparison.OrdinalIgnoreCase),
+    "Resolve should load linked files and list missing paths without aborting.");
+Directory.Delete(importFolder, recursive: true);
+
+var placed = ImportLayout.Place(
+    [
+        (400, 200, false),
+        (400, 180, false),
+        (400, 200, true),
+        (ImportLayout.MaxRowWidth, 100, false),
+        (500, 100, false),
+    ],
+    new PointD(10, 20));
+Assert(
+    placed[0].X == 10 && placed[0].Y == 20 &&
+    placed[1].X == 10 + 400 + ImportLayout.Gap && placed[1].Y == 20 &&
+    placed[2].X == 10 && placed[2].Y > placed[0].Bottom &&
+    placed[4].Y > placed[3].Y,
+    "Flow layout should pack left to right, honour a forced row, and wrap on max width.");
+Assert(
+    ImportLayout.ImageSize(1800, 1400) is { Width: 900, Height: 700 },
+    "Imported images should use the same 900 by 700 cap as a dropped image.");
 
 var document = new BoardDocument();
 Assert(document.ContentBounds is null, "An empty document should not have content bounds.");


### PR DESCRIPTION
A .wimport file is a Markdown recipe that builds image and text containers. Drop adds them to the current board with the pointer as the group top-left. File Open or a double-click starts a new untitled board; Save As writes .wboard only. The released channel registers the extension.

Languages are a table so later fences do not need a new matcher. The author and agent contract is docs/wimport.md.

VersionPrefix is 0.5.0.