### PR TITLE
Show the hover dot for the laser pointer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.5.1</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -350,11 +350,15 @@ public partial class MainWindow : Window
         }
         else if (EffectiveTool == BoardTool.Laser)
         {
-            HidePointerDot();
             InkSurface.Cursor = Cursors.None;
-            if (_stylusAction != PointerAction.Laser)
+            if (_stylusAction == PointerAction.Laser || _penInContact)
+            {
+                HidePointerDot();
+            }
+            else
             {
                 LaserTrail.HideHead();
+                UpdateHoverPointerDot(e);
             }
         }
         else if (EffectiveTool == BoardTool.Select)
@@ -424,10 +428,17 @@ public partial class MainWindow : Window
         _penInContact = false;
         if (EffectiveTool == BoardTool.Laser)
         {
-            HidePointerDot();
             StopLaserSampling();
             LaserTrail.Lift();
             InkSurface.Cursor = Cursors.None;
+            if (e.StylusDevice.InAir)
+            {
+                UpdateHoverPointerDot(e);
+            }
+            else
+            {
+                HidePointerDot();
+            }
         }
         else if (EffectiveTool == BoardTool.Select)
         {
@@ -456,9 +467,13 @@ public partial class MainWindow : Window
 
         if (EffectiveTool == BoardTool.Laser)
         {
-            HidePointerDot();
             LaserTrail.HideHead();
             InkSurface.Cursor = Cursors.None;
+            if (!_penInContact)
+            {
+                UpdateHoverPointerDot(e);
+            }
+
             return;
         }
 
@@ -1741,7 +1756,6 @@ public partial class MainWindow : Window
         else
         {
             InkSurface.SetLaserMode(true);
-            HidePointerDot();
             InkSurface.Cursor = Cursors.None;
         }
 
@@ -3860,7 +3874,7 @@ public partial class MainWindow : Window
     private void UpdateHoverPointerDotAt(Point rootPosition, bool overBoard)
     {
         if (_penInContact ||
-            EffectiveTool is BoardTool.Select or BoardTool.Laser ||
+            EffectiveTool == BoardTool.Select ||
             !overBoard)
         {
             HidePointerDot();
@@ -3884,7 +3898,7 @@ public partial class MainWindow : Window
 
     private void ShowPointerDot(Point position)
     {
-        if (EffectiveTool is BoardTool.Select or BoardTool.Laser)
+        if (EffectiveTool == BoardTool.Select)
         {
             HidePointerDot();
             return;


### PR DESCRIPTION
The red hover tracker was withheld while the laser tool was selected. Hover now uses the same dot as pen, highlighter, and calligraphy; contact still hides it.

VersionPrefix is 0.5.1.