### PR TITLE
Show .wboard thumbnails in Explorer

### DIFF
--- a/.azure/pipelines/build-whiteboard.yaml
+++ b/.azure/pipelines/build-whiteboard.yaml
@@ -172,6 +172,20 @@ stages:
         -p:DebugType=none
       displayName: 'dotnet publish'
 
+    - script: >-
+        dotnet publish "src/SQLBI.Whiteboard.ThumbnailHandler/SQLBI.Whiteboard.ThumbnailHandler.csproj"
+        --configuration "$(configuration)"
+        --runtime "win-$(arch)"
+        --self-contained true
+        --output "$(Build.BinariesDirectory)\thumbnail-aot"
+        --verbosity "${{ parameters.verbosity }}"
+        -p:Version="$(AppVersionNumber)"
+        -p:InformationalVersion="$(AppInformationalVersion)"
+        -p:ContinuousIntegrationBuild=true
+        -p:DebugType=none
+        && copy /Y "$(Build.BinariesDirectory)\thumbnail-aot\SQLBI.Whiteboard.ThumbnailHandler.dll" "$(Build.BinariesDirectory)\"
+      displayName: 'dotnet publish thumbnail handler'
+
     - ${{ if parameters.sign }}:
       - script: dotnet tool install --global AzureSignTool
         displayName: 'Install AzureSignTool'
@@ -193,6 +207,7 @@ stages:
             "$(Build.BinariesDirectory)\SQLBI.Whiteboard.Core.dll"
             "$(Build.BinariesDirectory)\SQLBI.Whiteboard.Dax.dll"
             "$(Build.BinariesDirectory)\SQLBI.Whiteboard.SqlServer.dll"
+            "$(Build.BinariesDirectory)\SQLBI.Whiteboard.ThumbnailHandler.dll"
           failOnStderr: true
 
     - script: dotnet tool restore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>0.5.1</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ How the project is developed and shipped is documented separately:
 - LiveView containers for GPU-backed capture of an application window or display, with freeze/resume and saved last-frame previews
 - Double-click a container to center it and fit it to the canvas
 - Undo and redo for strokes, erasing, containers, text edits, and transformations
-- Versioned ZIP-based `.wboard` documents with embedded image assets
+- Versioned ZIP-based `.wboard` documents with an embedded `preview.png`. Explorer shows that picture as the file thumbnail in the released install; older boards keep the document icon.
 - Markdown `.wimport` recipes that build image and text containers from headings
 - An intentionally small floating toolbar
 - Preferences for the startup monitor, full-screen start, laser trail, and toolbar layout

--- a/TODO.md
+++ b/TODO.md
@@ -48,23 +48,16 @@ images and DAX/SQL are inferred from the body or a local link. Drop adds to the 
 Open / double-click (released channel) starts a new board that saves as `.wboard`. There is no
 export. Languages are a table so later fences (Python, C#, …) do not need a new matcher.
 
-### 4. A rendered preview inside the `.wboard` archive
+### 4. A rendered preview inside the `.wboard` archive — done
 
-Both previews below need a picture of the board without opening the application. Rendering one
-on demand means a full WPF load inside a shell extension, which is exactly what a thumbnail
-provider must not do. Writing a rendered bitmap into the archive on save makes both previews
-cheap.
+Saving writes `preview.png` into the ZIP. Older boards and empty boards have none.
 
-This is a file-format change, so it lands before its two consumers rather than being retrofitted
-around them. Boards saved by earlier versions carry no preview and have to degrade to the
-document icon.
+### 5. Preview of `.wboard` files in Explorer — done
 
-### 5. Preview of `.wboard` files in Explorer
-
-The association exists, but a `.wboard` file shows only the document icon. A thumbnail provider
-reading the embedded preview makes a folder of boards browsable. Note this adds the project's
-first shell extension, which the installer has to register and the uninstaller has to remove
-cleanly.
+The released installer registers a Native AOT in-process thumbnail handler that reads
+`preview.png` only. It does not load WPF. Boards without a preview keep the document icon.
+The pre-release channel does not register `.wboard`, so it does not register the handler
+either.
 
 ### 6. Preview of `.wboard` files in VS Code
 

--- a/Whiteboard.sln
+++ b/Whiteboard.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQLBI.Whiteboard", "src\SQL
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQLBI.Whiteboard.CalligraphyPrototype", "prototypes\SQLBI.Whiteboard.CalligraphyPrototype\SQLBI.Whiteboard.CalligraphyPrototype.csproj", "{B45B0BC9-F1F4-4F2F-A71D-9F73C7935512}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQLBI.Whiteboard.ThumbnailHandler", "src\SQLBI.Whiteboard.ThumbnailHandler\SQLBI.Whiteboard.ThumbnailHandler.csproj", "{D4E8A1C0-7B52-4F19-9E6A-3C81D0F4A257}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -44,5 +46,9 @@ Global
 		{B45B0BC9-F1F4-4F2F-A71D-9F73C7935512}.Debug|x64.Build.0 = Debug|Any CPU
 		{B45B0BC9-F1F4-4F2F-A71D-9F73C7935512}.Release|x64.ActiveCfg = Release|Any CPU
 		{B45B0BC9-F1F4-4F2F-A71D-9F73C7935512}.Release|x64.Build.0 = Release|Any CPU
+		{D4E8A1C0-7B52-4F19-9E6A-3C81D0F4A257}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4E8A1C0-7B52-4F19-9E6A-3C81D0F4A257}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4E8A1C0-7B52-4F19-9E6A-3C81D0F4A257}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4E8A1C0-7B52-4F19-9E6A-3C81D0F4A257}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/installer/wix/SQLBI.Whiteboard.en-us.wxl
+++ b/installer/wix/SQLBI.Whiteboard.en-us.wxl
@@ -8,6 +8,7 @@
   <String Id="LaunchApplication" Value="Launch SQLBI Whiteboard" />
   <String Id="BoardFileTypeDescription" Value="SQLBI Whiteboard board" />
   <String Id="ImportFileTypeDescription" Value="SQLBI Whiteboard import" />
+  <String Id="ThumbnailHandlerDescription" Value="SQLBI Whiteboard thumbnail" />
   <String Id="BoardOpenVerb" Value="Open" />
 
 </WixLocalization>

--- a/installer/wix/SQLBI.Whiteboard.wxs
+++ b/installer/wix/SQLBI.Whiteboard.wxs
@@ -23,6 +23,9 @@
   <?define BoardProgId = "SQLBI.Whiteboard.Board" ?>
   <?define ImportExtension = "wimport" ?>
   <?define ImportProgId = "SQLBI.Whiteboard.Import" ?>
+  <?define ThumbnailClsid = "7F3C1A2E-8D64-4B0F-9A51-E2C6D8B04715" ?>
+  <?define ThumbnailHandlerCategory = "e357fccd-a995-4576-b01f-234630154e96" ?>
+  <?define ThumbnailHandlerFile = "SQLBI.Whiteboard.ThumbnailHandler.dll" ?>
 
   <!--
     The pre-release channel is a separate product: its own UpgradeCodes, name, install
@@ -182,6 +185,43 @@
                   Argument="&quot;%1&quot;" />
             </Extension>
           </ProgId>
+          <!--
+            Thumbnail handler is a Native AOT in-process server. Explorer only
+            loads IThumbnailProvider from InprocServer32 and, in the isolated
+            host, only calls IInitializeWithStream. It must not load WPF. Dev
+            does not register .wboard, so it does not register this either.
+          -->
+          <RegistryValue
+              Root="HKMU"
+              Key="Software\Classes\CLSID\{$(var.ThumbnailClsid)}"
+              Value="!(loc.ThumbnailHandlerDescription)"
+              Type="string" />
+          <RegistryValue
+              Root="HKMU"
+              Key="Software\Classes\CLSID\{$(var.ThumbnailClsid)}\InprocServer32"
+              Value="[INSTALLFOLDER]$(var.ThumbnailHandlerFile)"
+              Type="string" />
+          <RegistryValue
+              Root="HKMU"
+              Key="Software\Classes\CLSID\{$(var.ThumbnailClsid)}\InprocServer32"
+              Name="ThreadingModel"
+              Value="Apartment"
+              Type="string" />
+          <RegistryValue
+              Root="HKMU"
+              Key="Software\Classes\$(var.BoardProgId)\shellex\{$(var.ThumbnailHandlerCategory)}"
+              Value="{$(var.ThumbnailClsid)}"
+              Type="string" />
+          <RegistryValue
+              Root="HKMU"
+              Key="Software\Classes\.$(var.BoardExtension)\shellex\{$(var.ThumbnailHandlerCategory)}"
+              Value="{$(var.ThumbnailClsid)}"
+              Type="string" />
+          <RegistryValue
+              Root="HKMU"
+              Key="Software\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved\{$(var.ThumbnailClsid)}"
+              Value="!(loc.ThumbnailHandlerDescription)"
+              Type="string" />
           <ProgId
               Id="$(var.ImportProgId)"
               Description="!(loc.ImportFileTypeDescription)"

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -77,6 +77,26 @@ if ($skipPublish) {
     if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed with exit code $LASTEXITCODE" }
 }
 
+$thumbnailDll = Join-Path $publishFolder 'SQLBI.Whiteboard.ThumbnailHandler.dll'
+if (-not (Test-Path $thumbnailDll)) {
+    $thumbnailProject = Join-Path $repoRoot 'src\SQLBI.Whiteboard.ThumbnailHandler\SQLBI.Whiteboard.ThumbnailHandler.csproj'
+    Write-Host "==> dotnet publish thumbnail handler (Native AOT in-proc)" -ForegroundColor Cyan
+    $thumbnailOut = Join-Path $repoRoot 'artifacts\thumbnail'
+    if (Test-Path $thumbnailOut) { Remove-Item $thumbnailOut -Recurse -Force }
+    dotnet publish $thumbnailProject `
+        --configuration $Configuration `
+        --runtime "win-$Architecture" `
+        --self-contained true `
+        --output $thumbnailOut `
+        -p:Version=$fileVersion `
+        -p:InformationalVersion=$Version `
+        -p:ContinuousIntegrationBuild=true `
+        -p:DebugType=none `
+        --nologo
+    if ($LASTEXITCODE -ne 0) { throw "Thumbnail handler publish failed with exit code $LASTEXITCODE" }
+    Copy-Item (Join-Path $thumbnailOut 'SQLBI.Whiteboard.ThumbnailHandler.dll') $publishFolder -Force
+}
+
 Write-Host '==> Restoring the WiX tool' -ForegroundColor Cyan
 Push-Location $repoRoot
 try {

--- a/src/SQLBI.Whiteboard.Core/Persistence/BoardArchive.cs
+++ b/src/SQLBI.Whiteboard.Core/Persistence/BoardArchive.cs
@@ -9,6 +9,7 @@ public static class BoardArchive
 {
     public const int CurrentVersion = 5;
     private const string SceneEntryName = "scene.json";
+    public const string PreviewEntryName = "preview.png";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -19,12 +20,20 @@ public static class BoardArchive
     public static async Task SaveAsync(
         BoardDocument document,
         Stream destination,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        ReadOnlyMemory<byte> previewPng = default)
     {
         ArgumentNullException.ThrowIfNull(document);
         ArgumentNullException.ThrowIfNull(destination);
 
         using var archive = new ZipArchive(destination, ZipArchiveMode.Create, leaveOpen: true);
+        if (!previewPng.IsEmpty)
+        {
+            var previewEntry = archive.CreateEntry(PreviewEntryName, CompressionLevel.NoCompression);
+            await using var previewStream = previewEntry.Open();
+            await previewStream.WriteAsync(previewPng, cancellationToken);
+        }
+
         var assetDtos = new List<AssetDto>();
 
         foreach (var asset in document.Assets.Values)
@@ -96,6 +105,32 @@ public static class BoardArchive
         }
 
         return document;
+    }
+
+    /// <summary>
+    /// Copies the embedded preview bitmap if the archive has one. Older boards and
+    /// empty boards have none; callers should fall back to the document icon.
+    /// </summary>
+    public static bool TryCopyPreview(Stream source, Stream destination)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        using var archive = new ZipArchive(source, ZipArchiveMode.Read, leaveOpen: true);
+        var previewEntry = archive.GetEntry(PreviewEntryName);
+        if (previewEntry is null)
+        {
+            return false;
+        }
+
+        if (previewEntry.Length == 0)
+        {
+            return false;
+        }
+
+        using var previewStream = previewEntry.Open();
+        previewStream.CopyTo(destination);
+        return true;
     }
 
     private static ObjectDto ToDto(BoardObject item) => item switch

--- a/src/SQLBI.Whiteboard.ThumbnailHandler/ComIStream.cs
+++ b/src/SQLBI.Whiteboard.ThumbnailHandler/ComIStream.cs
@@ -1,0 +1,105 @@
+using System.Runtime.InteropServices;
+
+namespace SQLBI.Whiteboard.ThumbnailHandler;
+
+/// <summary>
+/// Sequential reader over an Explorer-supplied IStream. Isolated thumbnail
+/// hosts often hand out streams that do not implement Stat or Seek, so the
+/// handler copies this into a MemoryStream before ZipArchive sees it.
+/// </summary>
+internal sealed unsafe class ComIStream : Stream
+{
+    private nint _stream;
+    private bool _disposed;
+
+    public ComIStream(nint stream)
+    {
+        if (stream == 0)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        Marshal.AddRef(stream);
+        _stream = stream;
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        if (offset + count > buffer.Length)
+        {
+            throw new ArgumentException("The read range is outside the buffer.", nameof(count));
+        }
+
+        if (count == 0)
+        {
+            return 0;
+        }
+
+        EnsureNotDisposed();
+        uint read;
+        int hr;
+        fixed (byte* pointer = buffer)
+        {
+            hr = StreamRead(_stream, pointer + offset, (uint)count, &read);
+        }
+
+        // S_FALSE means a short read / end of stream. Still return the bytes we got.
+        if (hr < 0)
+        {
+            Marshal.ThrowExceptionForHR(hr);
+        }
+
+        return (int)read;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (_stream != 0)
+            {
+                Marshal.Release(_stream);
+                _stream = 0;
+            }
+
+            _disposed = true;
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void EnsureNotDisposed() =>
+        ObjectDisposedException.ThrowIf(_disposed || _stream == 0, this);
+
+    private static int StreamRead(nint stream, byte* buffer, uint count, uint* read)
+    {
+        var vtable = *(nint**)stream;
+        var function = (delegate* unmanaged[MemberFunction]<nint, byte*, uint, uint*, int>)vtable[3];
+        return function(stream, buffer, count, read);
+    }
+}

--- a/src/SQLBI.Whiteboard.ThumbnailHandler/ComInterfaces.cs
+++ b/src/SQLBI.Whiteboard.ThumbnailHandler/ComInterfaces.cs
@@ -1,0 +1,45 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SQLBI.Whiteboard.ThumbnailHandler;
+
+internal static class ShellGuids
+{
+    // Same GUID as the shellex thumbnail-handler category. Explorer CreateInstance
+    // requests this IID; IPreviewHandler is 8895b1c6-... and must not be used here.
+    public const string ThumbnailProvider = "e357fccd-a995-4576-b01f-234630154e96";
+    public const string InitializeWithStream = "b824b49d-22ac-4161-ac8a-9916e8fa3f7f";
+    public const string ClassFactory = "00000001-0000-0000-C000-000000000046";
+    public const string ThumbnailHandlerId = "7F3C1A2E-8D64-4B0F-9A51-E2C6D8B04715";
+    public const string ThumbnailHandlerCategory = ThumbnailProvider;
+}
+
+[GeneratedComInterface]
+[Guid(ShellGuids.InitializeWithStream)]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal partial interface IInitializeWithStream
+{
+    [PreserveSig]
+    int Initialize(nint stream, uint mode);
+}
+
+[GeneratedComInterface]
+[Guid(ShellGuids.ThumbnailProvider)]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal partial interface IThumbnailProvider
+{
+    [PreserveSig]
+    int GetThumbnail(uint cx, out nint bitmap, out int alphaType);
+}
+
+[GeneratedComInterface]
+[Guid(ShellGuids.ClassFactory)]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal unsafe partial interface IClassFactory
+{
+    [PreserveSig]
+    int CreateInstance(nint outer, Guid* interfaceId, nint* result);
+
+    [PreserveSig]
+    int LockServer([MarshalAs(UnmanagedType.Bool)] bool @lock);
+}

--- a/src/SQLBI.Whiteboard.ThumbnailHandler/Exports.cs
+++ b/src/SQLBI.Whiteboard.ThumbnailHandler/Exports.cs
@@ -1,0 +1,47 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SQLBI.Whiteboard.ThumbnailHandler;
+
+internal static class Exports
+{
+    private const int ClassNotAvailable = unchecked((int)0x80040111);
+    private const int Fail = unchecked((int)0x80004005);
+    private const int False = 1;
+
+    private static readonly StrategyBasedComWrappers Wrappers = new();
+
+    [UnmanagedCallersOnly(EntryPoint = "DllGetClassObject")]
+    public static unsafe int DllGetClassObject(Guid* classId, Guid* interfaceId, nint* result)
+    {
+        *result = 0;
+        try
+        {
+            if (*classId != WboardThumbnailProvider.Clsid)
+            {
+                return ClassNotAvailable;
+            }
+
+            var unknown = Wrappers.GetOrCreateComInterfaceForObject(
+                new ThumbnailClassFactory(),
+                CreateComInterfaceFlags.None);
+            if (unknown == 0)
+            {
+                return Fail;
+            }
+
+            var hr = Marshal.QueryInterface(unknown, in *interfaceId, out var queried);
+            Marshal.Release(unknown);
+            *result = queried;
+            return hr;
+        }
+        catch
+        {
+            return Fail;
+        }
+    }
+
+    // Native AOT modules do not unload cleanly from Explorer. Stay loaded.
+    [UnmanagedCallersOnly(EntryPoint = "DllCanUnloadNow")]
+    public static int DllCanUnloadNow() => False;
+}

--- a/src/SQLBI.Whiteboard.ThumbnailHandler/SQLBI.Whiteboard.ThumbnailHandler.csproj
+++ b/src/SQLBI.Whiteboard.ThumbnailHandler/SQLBI.Whiteboard.ThumbnailHandler.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <AssemblyName>SQLBI.Whiteboard.ThumbnailHandler</AssemblyName>
+    <RootNamespace>SQLBI.Whiteboard.ThumbnailHandler</RootNamespace>
+    <AssemblyTitle>SQLBI Whiteboard Thumbnail Handler</AssemblyTitle>
+    <Product>SQLBI Whiteboard</Product>
+    <Description>
+      Explorer thumbnail handler for .wboard files. Reads the preview.png written
+      on save; it must not load WPF. Published as a Native AOT in-process COM server.
+    </Description>
+    <PublishAot>true</PublishAot>
+    <NativeLib>Shared</NativeLib>
+    <UseAppHost>false</UseAppHost>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SQLBI.Whiteboard.Core\SQLBI.Whiteboard.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/SQLBI.Whiteboard.ThumbnailHandler/ThumbnailClassFactory.cs
+++ b/src/SQLBI.Whiteboard.ThumbnailHandler/ThumbnailClassFactory.cs
@@ -1,0 +1,49 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace SQLBI.Whiteboard.ThumbnailHandler;
+
+[GeneratedComClass]
+internal sealed partial class ThumbnailClassFactory : IClassFactory
+{
+    private const int Ok = 0;
+    private const int NoAggregation = unchecked((int)0x80040110);
+    private const int NoInterface = unchecked((int)0x80004002);
+
+    private static readonly StrategyBasedComWrappers Wrappers = new();
+
+    public unsafe int CreateInstance(nint outer, Guid* interfaceId, nint* result)
+    {
+        *result = 0;
+        if (interfaceId is null)
+        {
+            return NoInterface;
+        }
+
+        if (outer != 0)
+        {
+            return NoAggregation;
+        }
+
+        try
+        {
+            var provider = new WboardThumbnailProvider();
+            var unknown = Wrappers.GetOrCreateComInterfaceForObject(provider, CreateComInterfaceFlags.None);
+            if (unknown == 0)
+            {
+                return NoInterface;
+            }
+
+            var hr = Marshal.QueryInterface(unknown, in *interfaceId, out var queried);
+            Marshal.Release(unknown);
+            *result = queried;
+            return hr;
+        }
+        catch
+        {
+            return NoInterface;
+        }
+    }
+
+    public int LockServer(bool @lock) => Ok;
+}

--- a/src/SQLBI.Whiteboard.ThumbnailHandler/WboardThumbnailProvider.cs
+++ b/src/SQLBI.Whiteboard.ThumbnailHandler/WboardThumbnailProvider.cs
@@ -1,0 +1,98 @@
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices.Marshalling;
+using SQLBI.Whiteboard.Core.Persistence;
+
+namespace SQLBI.Whiteboard.ThumbnailHandler;
+
+[GeneratedComClass]
+internal sealed partial class WboardThumbnailProvider : IInitializeWithStream, IThumbnailProvider
+{
+    internal static readonly Guid Clsid = new(ShellGuids.ThumbnailHandlerId);
+
+    private const int Ok = 0;
+    private const int Unexpected = unchecked((int)0x8000FFFF);
+    private const int InvalidArg = unchecked((int)0x80070057);
+    private const int NotFound = unchecked((int)0x80030002);
+    private const int AlreadyInitialized = unchecked((int)0x800704DF);
+    private const int AlphaArgb = 2;
+
+    private byte[]? _previewPng;
+
+    public int Initialize(nint stream, uint mode)
+    {
+        if (stream == 0)
+        {
+            return InvalidArg;
+        }
+
+        if (_previewPng is not null)
+        {
+            return AlreadyInitialized;
+        }
+
+        try
+        {
+            using var source = new ComIStream(stream);
+            using var copy = new MemoryStream();
+            source.CopyTo(copy);
+            copy.Position = 0;
+            using var preview = new MemoryStream();
+            if (!BoardArchive.TryCopyPreview(copy, preview))
+            {
+                return NotFound;
+            }
+
+            _previewPng = preview.ToArray();
+            return Ok;
+        }
+        catch
+        {
+            return Unexpected;
+        }
+    }
+
+    public int GetThumbnail(uint cx, out nint bitmap, out int alphaType)
+    {
+        bitmap = 0;
+        alphaType = AlphaArgb;
+        if (_previewPng is null)
+        {
+            return Unexpected;
+        }
+
+        try
+        {
+            using var preview = new MemoryStream(_previewPng, writable: false);
+            using var source = Image.FromStream(preview, useEmbeddedColorManagement: false, validateImageData: false);
+            var edge = cx == 0 ? 256 : (int)Math.Clamp(cx, 16, 1024);
+            using var scaled = Scale(source, edge);
+            bitmap = scaled.GetHbitmap();
+            return bitmap == 0 ? Unexpected : Ok;
+        }
+        catch
+        {
+            return Unexpected;
+        }
+    }
+
+    private static Bitmap Scale(Image source, int maxEdge)
+    {
+        var longest = Math.Max(source.Width, source.Height);
+        if (longest <= maxEdge)
+        {
+            return new Bitmap(source);
+        }
+
+        var scale = maxEdge / (double)longest;
+        var width = Math.Max(1, (int)Math.Round(source.Width * scale));
+        var height = Math.Max(1, (int)Math.Round(source.Height * scale));
+        var result = new Bitmap(width, height, PixelFormat.Format32bppPArgb);
+        using var graphics = Graphics.FromImage(result);
+        graphics.CompositingMode = CompositingMode.SourceCopy;
+        graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
+        graphics.DrawImage(source, 0, 0, width, height);
+        return result;
+    }
+}

--- a/src/SQLBI.Whiteboard/BoardPreviewRenderer.cs
+++ b/src/SQLBI.Whiteboard/BoardPreviewRenderer.cs
@@ -1,0 +1,67 @@
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using SQLBI.Whiteboard.Core.Geometry;
+using SQLBI.Whiteboard.Core.Model;
+using SQLBI.Whiteboard.Core.Viewport;
+
+namespace SQLBI.Whiteboard;
+
+internal static class BoardPreviewRenderer
+{
+    public const int MaxEdge = 1024;
+
+    public static byte[]? Render(
+        BoardDocument document,
+        Func<Guid, ImageSource?>? liveViewImageSourceProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (document.ContentBounds is not { } content ||
+            content.Width < 1 ||
+            content.Height < 1)
+        {
+            return null;
+        }
+
+        var pixelSize = PixelSize(content);
+        var camera = new Camera2D();
+        camera.Resize(pixelSize.Width, pixelSize.Height);
+        camera.Frame(content);
+
+        var surface = new BoardSurface
+        {
+            Width = pixelSize.Width,
+            Height = pixelSize.Height,
+            LiveViewImageSourceProvider = liveViewImageSourceProvider,
+        };
+        surface.Configure(document, camera);
+        surface.Measure(new Size(pixelSize.Width, pixelSize.Height));
+        surface.Arrange(new Rect(0, 0, pixelSize.Width, pixelSize.Height));
+        surface.UpdateLayout();
+
+        var bitmap = new RenderTargetBitmap(
+            pixelSize.Width,
+            pixelSize.Height,
+            96,
+            96,
+            PixelFormats.Pbgra32);
+        bitmap.Render(surface);
+        bitmap.Freeze();
+        return WpfImageCodec.EncodePng(bitmap);
+    }
+
+    private static (int Width, int Height) PixelSize(RectD world)
+    {
+        var aspect = world.Width / Math.Max(world.Height, 0.000001);
+        if (aspect >= 1)
+        {
+            var width = MaxEdge;
+            var height = Math.Max(1, (int)Math.Round(MaxEdge / aspect));
+            return (width, height);
+        }
+
+        var tall = MaxEdge;
+        var narrow = Math.Max(1, (int)Math.Round(MaxEdge * aspect));
+        return (narrow, tall);
+    }
+}

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -3184,6 +3184,7 @@ public partial class MainWindow : Window
         try
         {
             RefreshLiveViewSnapshots();
+            var preview = BoardPreviewRenderer.Render(_document, GetLiveViewImageSource);
             await using var stream = new FileStream(
                 filePath,
                 FileMode.Create,
@@ -3191,7 +3192,10 @@ public partial class MainWindow : Window
                 FileShare.None,
                 81920,
                 useAsync: true);
-            await BoardArchive.SaveAsync(_document, stream);
+            await BoardArchive.SaveAsync(
+                _document,
+                stream,
+                previewPng: preview is null ? default : preview);
             _currentBoardPath = filePath;
         }
         catch (Exception exception)

--- a/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
+++ b/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
@@ -501,6 +501,30 @@ Assert(
     TextLanguageIds.SqlServer,
     "Archive round trips should preserve the SQL Server text language.");
 
+await using var previewArchive = new MemoryStream();
+var previewBytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3 };
+await BoardArchive.SaveAsync(
+    sqlArchiveDocument,
+    previewArchive,
+    previewPng: previewBytes);
+previewArchive.Position = 0;
+await using var extractedPreview = new MemoryStream();
+Assert(
+    BoardArchive.TryCopyPreview(previewArchive, extractedPreview) &&
+    extractedPreview.ToArray().SequenceEqual(previewBytes),
+    "A saved preview.png should be readable without loading the scene.");
+previewArchive.Position = 0;
+var loadedWithPreview = await BoardArchive.LoadAsync(previewArchive);
+Assert(
+    loadedWithPreview.Objects.Count == 1,
+    "A board with a preview should still load its scene.");
+await using var noPreviewArchive = new MemoryStream();
+await BoardArchive.SaveAsync(sqlArchiveDocument, noPreviewArchive);
+noPreviewArchive.Position = 0;
+Assert(
+    !BoardArchive.TryCopyPreview(noPreviewArchive, new MemoryStream()),
+    "Boards saved without a preview should report none.");
+
 AssertNear(
     20,
     PenStyleMetrics.MaximumThickness(new PenStyle(0xFF000000, 5, PenKind.Highlighter)),


### PR DESCRIPTION
Saving writes `preview.png` into the archive so Explorer can show a board without loading WPF. The released installer registers a Native AOT in-process thumbnail handler that only reads that bitmap; older and empty boards keep the document icon. The pre-release channel does not register `.wboard`, so it does not register the handler either.

VersionPrefix is 0.6.0.