### PR TITLE
Publish the VS Code extension from GitHub Actions

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -34,7 +34,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/configure-pages@v5
 

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -1,0 +1,84 @@
+# Publishes vscode/sqlbi-whiteboard to the Visual Studio Marketplace.
+#
+# Not the Whiteboard installer: that is signed in Azure Pipelines (decision 3).
+# This job needs only a Marketplace token, stored as the repository secret VSCE_PAT.
+#
+# Automatic runs fire when package.json lands on main. The job still no-ops unless
+# that file's version is higher than anything already on the Marketplace, so a
+# description-only edit of package.json does not republish 0.1.0. workflow_dispatch
+# is the retry path and uses the same version check.
+name: Publish VS Code extension
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'vscode/sqlbi-whiteboard/package.json'
+      - '.github/workflows/publish-vscode-extension.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-vscode-extension
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to Marketplace
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: vscode/sqlbi-whiteboard
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: vscode/sqlbi-whiteboard/package-lock.json
+
+      - name: Install, test, and package
+        run: |
+          npm ci
+          npm test
+          npx --yes @vscode/vsce package --no-update-package-json
+
+      - name: Decide whether this version is new
+        id: decide
+        run: |
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "vsix=sqlbi-whiteboard-${version}.vsix" >> "$GITHUB_OUTPUT"
+
+          if npx --yes @vscode/vsce show sqlbi.sqlbi-whiteboard --json > "$RUNNER_TEMP/published.json"; then
+            already=$(VERSION="$version" node -e "
+              const data = require(process.env.RUNNER_TEMP + '/published.json');
+              const versions = (data.versions || []).map((item) => item.version);
+              process.stdout.write(versions.includes(process.env.VERSION) ? 'yes' : 'no');
+            ")
+          else
+            echo "Extension is not on the Marketplace yet."
+            already=no
+          fi
+
+          if [ "$already" = "yes" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "sqlbi.sqlbi-whiteboard $version is already published."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Will publish sqlbi.sqlbi-whiteboard $version."
+          fi
+
+      - name: Publish
+        if: steps.decide.outputs.publish == 'true'
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "Repository secret VSCE_PAT is missing. Create a Marketplace Manage PAT and add it as VSCE_PAT."
+            exit 1
+          fi
+          npx --yes @vscode/vsce publish --packagePath "${{ steps.decide.outputs.vsix }}" --no-update-package-json --pat "$VSCE_PAT"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,7 +32,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       vscode: ${{ steps.filter.outputs.vscode }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -61,10 +61,10 @@ jobs:
     needs: changes
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.changes.outputs.code == 'true'
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         if: needs.changes.outputs.code == 'true'
         with:
           dotnet-version: '10.0.x'
@@ -90,10 +90,10 @@ jobs:
     needs: changes
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.changes.outputs.code == 'true'
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         if: needs.changes.outputs.code == 'true'
         with:
           dotnet-version: '10.0.x'
@@ -130,10 +130,10 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.changes.outputs.vscode == 'true'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         if: needs.changes.outputs.vscode == 'true'
         with:
           node-version: '22'

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -70,18 +70,36 @@ Colours live in two places that must be changed together: the SVG, and
 
 ## Pull request validation
 
-`.github/workflows/pull-request.yml` runs on every pull request against `main`, in two jobs:
+`.github/workflows/pull-request.yml` runs on every pull request against `main`:
 
 - **Build and test** — restores, builds the solution in Release, and runs the Core smoke
   tests. `TreatWarningsAsErrors` means a warning fails it.
 - **Build installers** — runs `scripts/build-installer.ps1` unsigned, so WiX authoring
   errors surface here rather than at release time. The output is discarded.
+- **VS Code extension** — compiles and tests `vscode/sqlbi-whiteboard` when that tree
+  changed.
 
 It signs nothing and publishes nothing. Everything that touches the certificate stays in
 Azure Pipelines, because this repository is public and so are these logs (decision 3).
 
 Running on GitHub also means it works for pull requests from forks, which have no access to
 secrets and need none.
+
+## VS Code extension publishing
+
+`.github/workflows/publish-vscode-extension.yml` publishes `vscode/sqlbi-whiteboard` to
+the Visual Studio Marketplace as `sqlbi.sqlbi-whiteboard`. It does not touch the EV
+certificate.
+
+It runs on a push to `main` that changes that extension's `package.json`, and on
+**Run workflow**. It packages, then publishes only when `package.json` `version` is not
+already on the Marketplace. Bump that version in a pull request to ship; do not let CI
+rewrite it.
+
+The repository secret `VSCE_PAT` must be a Marketplace **Manage** personal access token
+with organization **All accessible organizations**. Create it in the Azure DevOps
+organization tied to the `sqlbi` publisher, then add it under the GitHub repo
+**Settings → Secrets and variables → Actions**.
 
 ## The pipeline
 

--- a/vscode/sqlbi-whiteboard/README.md
+++ b/vscode/sqlbi-whiteboard/README.md
@@ -18,7 +18,7 @@ Then **Run > Start Debugging** in VS Code with this folder as the workspace, or 
 
 ```powershell
 npx --yes @vscode/vsce package
-code --install-extension sqlbi-whiteboard-0.1.0.vsix
+code --install-extension sqlbi-whiteboard-1.0.0.vsix
 ```
 
 ## Use

--- a/vscode/sqlbi-whiteboard/package-lock.json
+++ b/vscode/sqlbi-whiteboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlbi-whiteboard",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlbi-whiteboard",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"

--- a/vscode/sqlbi-whiteboard/package.json
+++ b/vscode/sqlbi-whiteboard/package.json
@@ -2,7 +2,7 @@
   "name": "sqlbi-whiteboard",
   "displayName": "SQLBI Whiteboard",
   "description": "Opens .wboard files as the embedded preview image instead of a ZIP archive.",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "publisher": "sqlbi",
   "license": "MIT",
   "engines": {
@@ -43,6 +43,7 @@
     ]
   },
   "scripts": {
+    "vscode:prepublish": "npm run compile",
     "compile": "tsc -p .",
     "watch": "tsc -watch -p .",
     "test": "npm run compile && node --test out/extractPreview.test.js"


### PR DESCRIPTION
Bump `sqlbi.sqlbi-whiteboard` to 1.0.0. A new workflow publishes that version to the Marketplace when it is not already listed. Whiteboard VersionPrefix is unchanged.

Official Actions move to their Node 24 majors so the runner deprecation warning goes away.