### PR TITLE
Add the public documentation and VS Code 1.0.1

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "sqlbi.sqlbi-whiteboard"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "*.wimport": "markdown"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ opening section of [docs/release-management.md](docs/release-management.md).
 
 ## Landing page
 
-`site/` is the landing page for <https://whiteboard.sqlbi.com>, and is self-contained: one
-HTML file plus the generated favicons and social card.
+`site/` is <https://whiteboard.sqlbi.com>: the download landing page plus the public
+guide, shortcuts, and `.wimport` contract. Styles live in `site/styles.css`. Pages are
+hand-authored HTML, not generated from this README.
 
 `.github/workflows/publish-site.yml` deploys it to GitHub Pages whenever `site/` changes on
 `main`. `site/CNAME` carries the custom domain so it survives each deployment. Asset paths

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ running when the artwork changes.
 
 `.azure/pipelines/build-whiteboard.yaml` performs the same build in Azure Pipelines and
 signs the binaries and both MSI packages with the SQLBI certificate held in Azure Key Vault.
+What to run for a pre-release, a full release, the VS Code extension, or the site is the
+opening section of [docs/release-management.md](docs/release-management.md).
 
 ## Landing page
 
@@ -213,9 +215,9 @@ The full contract for authors and agents is [docs/wimport.md](docs/wimport.md). 
 
 Plain `.md` files are not imported.
 
-A `.wboard` in the same tree opens as the embedded preview if the extension in
-`vscode/sqlbi-whiteboard` is installed. Marketplace listing is still outstanding; that
-folder's README has the local VSIX steps.
+A `.wboard` in the same tree opens as the embedded preview if
+[SQLBI Whiteboard for VS Code](https://marketplace.visualstudio.com/items?itemName=sqlbi.sqlbi-whiteboard)
+is installed. The source is `vscode/sqlbi-whiteboard`.
 
 ## Architecture
 

--- a/TODO.md
+++ b/TODO.md
@@ -59,11 +59,12 @@ The released installer registers a Native AOT in-process thumbnail handler that 
 The pre-release channel does not register `.wboard`, so it does not register the handler
 either.
 
-### 6. Preview of `.wboard` files in VS Code
+### 6. Preview of `.wboard` files in VS Code — done
 
-The extension lives in `vscode/sqlbi-whiteboard/`. It opens a `.wboard` file as the embedded
-`preview.png` rather than as an archive. Marketplace listing is still outstanding — until then
-install from a local VSIX as described in that folder's README.
+`sqlbi.sqlbi-whiteboard` on the Marketplace opens a `.wboard` file as the embedded
+`preview.png`. The source is `vscode/sqlbi-whiteboard/`. Boards without a preview show a
+short message. Bump that folder's `package.json` version to ship an update; GitHub Actions
+publishes it. The desktop installer does not carry the extension.
 
 ### 7. Video teaser
 

--- a/TODO.md
+++ b/TODO.md
@@ -76,19 +76,12 @@ all need, so it sits on the critical path for all three.
 Here rather than earlier because it should show the 1.0 UI, including the configuration dialog
 and drag and drop.
 
-### 8. Documentation on whiteboard.sqlbi.com
+### 8. Documentation on whiteboard.sqlbi.com — done
 
-The site is a download page today. It needs real documentation: the tool set, containers,
-LiveView, the DAX and SQL Server text containers, the import format, and the keyboard and pen
-shortcuts. The README already carries most of this content, so the open question is whether the
-site renders from those files or keeps its own copy — decide that before writing the pages
-twice. The `.wimport` contract for authors and agents is already written in
-[docs/wimport.md](docs/wimport.md); publish that file rather than rewriting it.
-
-The pages should also spell out user stories, not only what each control does. Features that
-look small in a reference list are the ones people miss in a live session. One to write up:
-copying a LiveView and pasting it produces a bitmap of the last frame, which is how you freeze
-a screenshot onto the board during an interactive explanation without leaving the whiteboard.
+The landing page stays the download. Guide, shortcuts, and the `.wimport` contract are
+separate pages under `site/`, linked from the nav. The site is hand-authored HTML, not
+generated from the README. `docs/wimport.md` remains the in-repo contract; `site/wimport.html`
+is the same grammar for the public site.
 
 ### 9. Microsoft Store
 

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -6,6 +6,33 @@ How the project is built, packaged, and shipped. The reasoning behind these choi
 Sections marked **Not yet built** describe an agreed design that does not exist in the
 repository yet.
 
+## What to run
+
+Day-to-day shipping is a merge, plus one of the GitHub Actions below when the merge is not
+enough (a retry, or a deploy that has no new commit). Pull request validation runs by
+itself. Do not run it to “release” anything.
+
+| You want to | Do this |
+| --- | --- |
+| Land a change | Open a pull request against `main`. The **Pull request** Action builds and tests; merge when it is green. |
+| Ship a Whiteboard pre-release | Merge to `main` (anything except `docs/`, `site/`, `vscode/`, and top-level markdown). Azure Pipelines **SQLBI Whiteboard** signs and publishes the GitHub prerelease. To rebuild an existing commit: Azure DevOps → that pipeline → **Run pipeline**. Do not use **Re-run**. |
+| Promote that build to a full release | Approve the **Release** stage of the same Azure run. Nothing is rebuilt. |
+| Ship a VS Code extension update | Bump `version` in `vscode/sqlbi-whiteboard/package.json` in a pull request and merge. The **Publish VS Code extension** Action publishes `sqlbi.sqlbi-whiteboard` if that version is not already on the Marketplace. To retry: Actions → **Publish VS Code extension** → **Run workflow**. |
+| Update whiteboard.sqlbi.com | Merge a change under `site/`. The **Publish site** Action deploys. To retry: Actions → **Publish site** → **Run workflow**. |
+| Rebuild brand assets | Run `scripts/build-assets.ps1` locally. Only when the artwork changes. |
+
+The three GitHub Actions live under **Actions** in this repository. Their names are
+**Pull request**, **Publish VS Code extension**, and **Publish site**. The signed
+Whiteboard pipeline is not a GitHub Action; it stays in Azure DevOps because of the
+certificate (decision 3).
+
+Version numbers are reviewed in pull requests, not typed into a pipeline UI.
+Whiteboard's version is `VersionPrefix` in `Directory.Build.props`. The VS Code
+extension's version is `version` in `vscode/sqlbi-whiteboard/package.json`. They move
+independently.
+
+---
+
 ## Day to day
 
 `main` is protected. Work on short-lived branches and merge through a pull request — the
@@ -68,42 +95,50 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-assets.ps1
 Colours live in two places that must be changed together: the SVG, and
 `tools/AssetGenerator/Program.cs`.
 
-## Pull request validation
+---
 
-`.github/workflows/pull-request.yml` runs on every pull request against `main`:
+## How it works
+
+### GitHub Actions
+
+Three workflows in `.github/workflows/`. None of them see the EV certificate. Logs are
+public, so they must not print tokens.
+
+**Pull request** (`.github/workflows/pull-request.yml`) runs on every pull request against
+`main`, and can be started by hand if a check needs repeating:
 
 - **Build and test** — restores, builds the solution in Release, and runs the Core smoke
-  tests. `TreatWarningsAsErrors` means a warning fails it.
+  tests. A warning fails it.
 - **Build installers** — runs `scripts/build-installer.ps1` unsigned, so WiX authoring
-  errors surface here rather than at release time. The output is discarded.
+  errors surface here rather than at release time. The output is discarded. It builds a
+  diagonal pair of variants, framework-dependent, which is enough to walk every `<?if?>` in
+  the WiX source.
 - **VS Code extension** — compiles and tests `vscode/sqlbi-whiteboard` when that tree
   changed.
 
-It signs nothing and publishes nothing. Everything that touches the certificate stays in
-Azure Pipelines, because this repository is public and so are these logs (decision 3).
+Fork pull requests get the same jobs and no secrets.
 
-Running on GitHub also means it works for pull requests from forks, which have no access to
-secrets and need none.
+**Publish VS Code extension** (`.github/workflows/publish-vscode-extension.yml`) publishes
+`vscode/sqlbi-whiteboard` as `sqlbi.sqlbi-whiteboard`. It runs when that extension's
+`package.json` lands on `main`, and on **Run workflow**. It packages, then publishes only
+when `version` is not already on the Marketplace, so a description-only edit does not
+republish. It does not rewrite the version.
 
-## VS Code extension publishing
+The repository secret `VSCE_PAT` is a Marketplace **Manage** personal access token with
+organization **All accessible organizations**. Create it in the Azure DevOps organization
+tied to the `sqlbi` publisher, then add it under the GitHub repo **Settings → Secrets and
+variables → Actions**. Forks never receive it.
 
-`.github/workflows/publish-vscode-extension.yml` publishes `vscode/sqlbi-whiteboard` to
-the Visual Studio Marketplace as `sqlbi.sqlbi-whiteboard`. It does not touch the EV
-certificate.
+**Publish site** (`.github/workflows/publish-site.yml`) deploys `site/` to GitHub Pages
+when that tree changes on `main`, and on **Run workflow**. It needs **Settings → Pages →
+Source: GitHub Actions**. `site/CNAME` carries the custom domain.
 
-It runs on a push to `main` that changes that extension's `package.json`, and on
-**Run workflow**. It packages, then publishes only when `package.json` `version` is not
-already on the Marketplace. Bump that version in a pull request to ship; do not let CI
-rewrite it.
+### Azure Pipelines
 
-The repository secret `VSCE_PAT` must be a Marketplace **Manage** personal access token
-with organization **All accessible organizations**. Create it in the Azure DevOps
-organization tied to the `sqlbi` publisher, then add it under the GitHub repo
-**Settings → Secrets and variables → Actions**.
-
-## The pipeline
-
-`.azure/pipelines/build-whiteboard.yaml`, in the `SQLBI Whiteboard` Azure DevOps project.
+`.azure/pipelines/build-whiteboard.yaml`, in the `SQLBI Whiteboard` Azure DevOps project,
+is the only place that signs. A merge to `main` starts it unless the change is only
+`docs/`, `site/`, `vscode/`, `.github/`, or top-level markdown. It can also be started with
+**Run pipeline**.
 
 Parameters:
 
@@ -112,27 +147,31 @@ Parameters:
 | `verbosity` | `normal` | MSBuild verbosity |
 | `sign` | on | Code sign binaries and MSIs |
 
-Two variable groups supply its settings; both must be authorised for the pipeline before it
-can run. The signing group's contents are described in decision 1 and held by the
-maintainers.
+Two variable groups must be authorised for the pipeline. Their contents stay in Azure
+DevOps, not in this repository:
 
-The version is **not** among them: it comes from `VersionPrefix` in `Directory.Build.props`
-(decision 8). `AppVersionMajor`, `AppVersionMinor` and `AppVersionPatch` are obsolete and
-can be removed from the `SQLBI.Whiteboard` group.
+- **SQLBI-CodeSigning** — vault URL, tenant, client, secret, certificate name (decision 1).
+- **SQLBI.Whiteboard** — product settings. The version is not among them.
 
 Signing uses `AzureSignTool` against the certificate in Azure Key Vault.
 
-> **When adding a new first-party project, add its assembly to the signing step.** The
-> installer harvests new files automatically, so an unsigned assembly ships silently
-> beside a signed executable. This has already happened once.
+> **When adding a new first-party assembly, add it to the signing step.** The installer
+> harvests new files automatically, so an unsigned assembly ships silently beside a signed
+> executable. This has already happened once. The VS Code extension is not an assembly and
+> is not signed here.
 
-To run it: **Run pipeline**, set parameters, **Run**. Do not use **Re-run** to pick up a
-fix — that replays the original commit.
+Stages: **Build** produces every installer variant, **PreRelease** publishes the
+pre-release channel to GitHub, **Release** is gated by approvals on the
+`whiteboard-release` environment and uploads the released-channel installers **that the
+same run already produced** (decision 9).
 
-## Versioning
+Creating a GitHub Release uses the `sql-bi write assets` service connection
+(`contents: write`).
 
-`VersionPrefix` in `Directory.Build.props` is the only place the product version is written.
-Everything else derives from it:
+### Versioning
+
+`VersionPrefix` in `Directory.Build.props` is the only place the **desktop** product
+version is written. Everything in the installer derives from it:
 
 - assemblies are stamped `major.minor.<days since 2000-01-01>.<seconds since midnight / 2>`,
   the algorithm MSBuild and the Bravo pipeline use, so every matrix job in a run stamps the
@@ -140,25 +179,21 @@ Everything else derives from it:
 - the informational version is the plain `major.minor.patch`;
 - artifact and installer file names use it directly.
 
-Releasing therefore starts with a pull request that changes one line.
+The VS Code extension does not read `VersionPrefix`.
 
-## Releasing
+### Releasing
 
-**Not yet built.** The agreed shape:
+The agreed shape, now in use for the pre-release path:
 
-1. Every push to `main` builds, signs, and publishes the pre-release channel to a GitHub
-   prerelease automatically. Pull requests build unsigned and publish nothing.
-2. A maintainer bumps the version in a pull request. Once merged, that build carries the
-   release version.
-3. Promotion is an approval on a Release stage of that run. It publishes the **already-built
-   released-channel artifacts from the same run** — nothing is rebuilt (decision 9).
+1. A maintainer bumps `VersionPrefix` in a pull request when the number should change.
+2. The merge to `main` builds, signs, and publishes the pre-release channel to a GitHub
+   prerelease.
+3. Promotion is an approval on the Release stage of **that** run. It publishes the
+   already-built released-channel artifacts — nothing is rebuilt.
 4. winget submission and the Store submission follow from the published release, in
-   parallel; neither gates the download being available.
+   parallel, once those pieces exist. Neither gates the download being available.
 
-Until it exists, releasing means running the pipeline manually and uploading artifacts by
-hand.
-
-## Still to build
+### Still to build
 
 Roughly in dependency order:
 
@@ -167,7 +202,7 @@ Roughly in dependency order:
 2. Add winget submission triggered by a published release.
 3. MSIX packaging and Store submission (decision 13).
 
-## Verification before a public release
+### Verification before a public release
 
 The build, signing, and publishing chain is proven (see above). What has **not** been done
 for a real release is everything that involves installing the result.

--- a/docs/samples/.vscode/extensions.json
+++ b/docs/samples/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "sqlbi.sqlbi-whiteboard"
+  ]
+}

--- a/docs/samples/.vscode/settings.json
+++ b/docs/samples/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "*.wimport": "markdown"
+  }
+}

--- a/docs/wimport.md
+++ b/docs/wimport.md
@@ -1,7 +1,7 @@
 # `.wimport` format for authors and agents
 
 Read this file before writing a `.wimport`. It is the contract SQLBI Whiteboard implements.
-The site documentation (TODO item 8) should publish this same file rather than a second copy.
+The public edition is [whiteboard.sqlbi.com/wimport.html](https://whiteboard.sqlbi.com/wimport.html). Keep the two in step.
 
 A `.wimport` file is a Markdown **recipe**. Whiteboard imports it as image and text
 containers. It is not a board file. There is no export back to `.wimport`. After import the
@@ -13,6 +13,10 @@ renderer. Associate the extension if the editor does not treat it as Markdown:
 ```json
 "files.associations": { "*.wimport": "markdown" }
 ```
+
+A folder of recipes can ship that association in `.vscode/settings.json`, and recommend
+`sqlbi.sqlbi-whiteboard` in `.vscode/extensions.json` so `.wboard` files open as the
+embedded preview. This repository and `docs/samples` both do that.
 
 ## Produce this
 

--- a/site/guide.html
+++ b/site/guide.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Guide — SQLBI Whiteboard</title>
+<meta name="description" content="How to use SQLBI Whiteboard in a live session: ink, containers, LiveView, DAX and SQL, and board files.">
+<link rel="icon" href="favicon.ico" sizes="any">
+<link rel="icon" href="favicon-32.png" type="image/png" sizes="32x32">
+<link rel="apple-touch-icon" href="apple-touch-icon.png">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Guide — SQLBI Whiteboard">
+<meta property="og:description" content="How to use SQLBI Whiteboard in a live session.">
+<meta property="og:url" content="https://whiteboard.sqlbi.com/guide.html">
+<meta property="og:image" content="https://whiteboard.sqlbi.com/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="wrap wide">
+
+  <header class="doc">
+    <nav class="nav" aria-label="Documentation">
+      <a href="index.html">Download</a>
+      <a href="guide.html" aria-current="page">Guide</a>
+      <a href="shortcuts.html">Shortcuts</a>
+      <a href="wimport.html">Import format</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=sqlbi.sqlbi-whiteboard">VS Code</a>
+    </nav>
+    <h1>Using SQLBI Whiteboard</h1>
+    <p class="lede">Built for a live explanation with a pen. The stories below are the reasons the features exist. The <a href="shortcuts.html">shortcut list</a> is the desk reference.</p>
+  </header>
+
+  <article>
+    <h2>In a session</h2>
+
+    <section class="story">
+      <h3>Pin a live demo without leaving the board</h3>
+      <p>Add a LiveView of DAX Studio, SSMS, or a browser. When the query result is the thing you want to keep talking about, copy the LiveView and paste. The paste is a still bitmap of the last frame — a screenshot that stays on the board while you keep drawing.</p>
+      <p>Freeze the original LiveView if you want that same container to stay put and resume later. Reconnect after you reload a board: Windows cannot save the capture permission, so the saved frame appears immediately and Reconnect restores the live feed.</p>
+    </section>
+
+    <section class="story">
+      <h3>Keep ink on the slide you are discussing</h3>
+      <p>A finished stroke that touches only one container — an image, a text block, or a LiveView — travels with that container when you move or resize it. A stroke that crosses two containers stays on the canvas. Delete the container and its linked ink goes with it. Undo treats the whole operation as one step.</p>
+    </section>
+
+    <section class="story">
+      <h3>Explain a measure</h3>
+      <p>Paste DAX, or drop a <code>.dax</code> file. Switch the language selector to DAX, press F6 to format it locally, then draw on the container. The same path works for SQL Server scripts with <code>.sql</code> files and F6.</p>
+      <p>In edit mode the text reflows as you change the width. In display mode a resize scales the whole visual, like a picture of the code, so the room still sees the layout you just formatted.</p>
+    </section>
+
+    <section class="story">
+      <h3>Talk to the room</h3>
+      <p>The laser pointer is for the projector, not for the file. The trail length and fade live in Preferences. A pen in the air shows a small high-contrast hover dot; the dot disappears on contact so it never sits under the nib. A physical mouse keeps a normal arrow.</p>
+    </section>
+
+    <section class="story">
+      <h3>Fit what you are talking about</h3>
+      <p>Double-click a container to center it and fill the view. Double-click empty canvas to frame everything on the board, or to reset an empty board. The canvas is unbounded: one finger pans, two fingers pinch-zoom, the mouse wheel zooms at the pointer.</p>
+    </section>
+
+    <section class="story">
+      <h3>Bring a workshop in</h3>
+      <p>A <code>.wimport</code> file is Markdown that builds image and text containers. Drop it on an open board to add them under the pointer. The toolbar Import button does the same at the top-left of the view. File → Open, or a double-click in the released install, starts a new untitled board from the recipe. Save always writes a <code>.wboard</code>.</p>
+      <p>Missing pictures or scripts are skipped and listed in a dialog you can copy. The <a href="wimport.html">import format</a> is the contract for that file.</p>
+    </section>
+
+    <section class="story">
+      <h3>Keep boards next to the material they document</h3>
+      <p>Save writes a <code>preview.png</code> into the <code>.wboard</code> ZIP. Explorer shows that picture as the thumbnail in the released install. In a repository, install <a href="https://marketplace.visualstudio.com/items?itemName=sqlbi.sqlbi-whiteboard">SQLBI Whiteboard for VS Code</a> so opening the file shows the same picture instead of the archive. Boards saved before previews existed keep the document icon until you open and save them again.</p>
+    </section>
+
+    <h2>The board</h2>
+
+    <h3>Ink and tools</h3>
+    <p>The pen starts on the Pen tool. Pressure is recorded. The rear eraser on a Wacom pen removes whole strokes. Palm rejection suspends touch navigation while the pen is down so a resting hand does not pan the board.</p>
+    <p>The toolbar stays small on purpose. Preferences control whether it sits in a corner or follows a layout you prefer.</p>
+
+    <h3>Navigation</h3>
+    <p>Touch pans. Two fingers pinch-zoom. The mouse wheel zooms at the pointer. Middle mouse, right mouse (held), or Space temporarily pans. F11 toggles full screen; Escape leaves it unless a text container is being edited.</p>
+
+    <h3>Containers</h3>
+    <p>Images, LiveViews, and text blocks are containers. With a mouse, click to move, drag the circular handle to resize while keeping aspect ratio. Releasing the mouse returns to the drawing tool you had. Imported images accept PNG, JPEG, BMP, and GIF, including clipboard paste and Explorer drag-and-drop.</p>
+
+    <h3>Text, DAX, and SQL</h3>
+    <p>Paste plain text to create a text container and enter edit mode. F2 edits the selected container. The language selector chooses Plain text, DAX, or SQL Server. F6 formats DAX or SQL locally. SQL Server mode targets SQL Server 2025 T-SQL, keeps <code>GO</code> batch separators, and leaves an invalid script unchanged. Ctrl+Enter commits; Escape restores the previous text, language, and size.</p>
+
+    <h3>LiveView</h3>
+    <p>Tools → Add LiveView captures a window or a display. The container behaves like an image: move, resize, frame, delete, undo. Tools → Freeze stops capture on the last frame; the same command resumes if the target is still there. Tools → Reconnect picks a new target without losing the container or its ink.</p>
+
+    <h3>Files</h3>
+    <p>Ctrl+S and Ctrl+O save and open a <code>.wboard</code>. The released installer registers that type and <code>.wimport</code>. The pre-release (Dev) channel does not, so it can sit beside a released copy without stealing the file association.</p>
+
+    <h3>Preferences</h3>
+    <p>Tools → Preferences is a searchable list: which monitor to open on, start full screen, laser trail timing, and toolbar placement. New settings are more rows in that list, not a new dialog.</p>
+  </article>
+
+  <footer>
+    <span><a href="index.html">Download SQLBI Whiteboard</a></span>
+    <span>
+      <a href="https://github.com/sql-bi/SQLBI-Whiteboard">GitHub</a> ·
+      <a href="https://www.sqlbi.com">SQLBI</a>
+    </span>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -16,150 +16,12 @@
 <meta property="og:url" content="https://whiteboard.sqlbi.com/">
 <meta property="og:image" content="https://whiteboard.sqlbi.com/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
-
-<style>
-  :root {
-    --ground: #FAFAFB;
-    --surface: #FFFFFF;
-    --line: #E2E4E9;
-    --ink: #15171C;
-    --muted: #5C6371;
-    --brand: #F42727;
-    --brand-deep: #B71D1D;
-    --brand-ink: #FFFFFF;
-    --shadow: 0 1px 2px rgba(21,23,28,.06), 0 12px 32px -18px rgba(21,23,28,.30);
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --ground: #0F1115;
-      --surface: #171A20;
-      --line: #272B33;
-      --ink: #E9EBEF;
-      --muted: #949CAA;
-      --brand: #FF3B3B;
-      --brand-deep: #C92020;
-      --shadow: 0 1px 2px rgba(0,0,0,.5), 0 12px 32px -18px rgba(0,0,0,.9);
-    }
-  }
-
-  * { box-sizing: border-box; }
-
-  body {
-    margin: 0;
-    padding: 0 24px 64px;
-    background: var(--ground);
-    color: var(--ink);
-    font-family: "Segoe UI Variable Text", "Segoe UI", system-ui, -apple-system, sans-serif;
-    line-height: 1.6;
-    -webkit-font-smoothing: antialiased;
-  }
-
-  .wrap { max-width: 640px; margin: 0 auto; }
-
-  header { padding: 88px 0 0; text-align: center; }
-
-  .mark { width: 104px; height: 104px; filter: drop-shadow(0 8px 24px rgba(183,29,29,.28)); }
-
-  h1 {
-    font-size: clamp(34px, 6vw, 46px);
-    line-height: 1.1;
-    letter-spacing: -.025em;
-    font-weight: 650;
-    margin: 22px 0 12px;
-  }
-
-  .tagline { font-size: 18px; color: var(--muted); margin: 0 auto; max-width: 30ch; }
-
-  .actions {
-    margin: 40px 0 0;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 14px;
-  }
-
-  .download {
-    display: inline-flex;
-    align-items: center;
-    gap: 10px;
-    background: linear-gradient(140deg, var(--brand), var(--brand-deep));
-    color: var(--brand-ink);
-    text-decoration: none;
-    font-size: 17px;
-    font-weight: 600;
-    padding: 15px 30px;
-    border-radius: 10px;
-    box-shadow: var(--shadow);
-    transition: transform .12s ease, box-shadow .12s ease;
-  }
-  .download:hover { transform: translateY(-1px); }
-  .download:focus-visible { outline: 3px solid var(--brand); outline-offset: 3px; }
-
-  .meta { font-size: 13.5px; color: var(--muted); min-height: 1.2em; }
-  .meta strong { color: var(--ink); font-weight: 600; }
-
-  .alternates { font-size: 14px; color: var(--muted); }
-  .alternates a { color: var(--muted); text-decoration: underline; text-underline-offset: 3px; }
-  .alternates a:hover { color: var(--ink); }
-  .sep { opacity: .45; padding: 0 8px; }
-
-  .notice {
-    margin: 44px auto 0;
-    max-width: 520px;
-    background: var(--surface);
-    border: 1px solid var(--line);
-    border-left: 3px solid var(--brand);
-    border-radius: 10px;
-    padding: 16px 20px;
-    font-size: 14.5px;
-    color: var(--muted);
-    text-align: left;
-  }
-  .notice strong { color: var(--ink); font-weight: 600; }
-
-  ul.features {
-    margin: 52px 0 0;
-    padding: 0;
-    list-style: none;
-    display: grid;
-    gap: 12px;
-    font-size: 15.5px;
-    color: var(--muted);
-  }
-  ul.features li { padding-left: 26px; position: relative; }
-  ul.features li::before {
-    content: "";
-    position: absolute;
-    left: 6px; top: .62em;
-    width: 6px; height: 6px;
-    border-radius: 50%;
-    background: var(--brand);
-  }
-
-  footer {
-    margin-top: 56px;
-    padding-top: 24px;
-    border-top: 1px solid var(--line);
-    font-size: 13.5px;
-    color: var(--muted);
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px 18px;
-    justify-content: space-between;
-  }
-  footer a { color: var(--muted); text-decoration: none; }
-  footer a:hover { color: var(--ink); text-decoration: underline; }
-
-  @media (prefers-reduced-motion: reduce) {
-    .download { transition: none; }
-    .download:hover { transform: none; }
-  }
-</style>
+<link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <div class="wrap">
 
-  <header>
+  <header class="hero">
     <svg class="mark" viewBox="0 0 256 256" role="img" aria-label="SQLBI Whiteboard">
       <defs>
         <linearGradient id="tile" x1="32" y1="24" x2="224" y2="232" gradientUnits="userSpaceOnUse">
@@ -200,8 +62,15 @@
     <li>An unbounded canvas with touch pan and pinch zoom</li>
     <li>Live capture of any application window or display, embedded on the board</li>
     <li>Text containers with DAX and SQL syntax highlighting and formatting</li>
-    <li>Boards saved as portable <code>.wboard</code> files</li>
+    <li>Boards saved as portable <code>.wboard</code> files — Explorer and <a href="https://marketplace.visualstudio.com/items?itemName=sqlbi.sqlbi-whiteboard">VS Code</a> show the embedded preview</li>
   </ul>
+
+  <nav class="nav" aria-label="Documentation">
+    <a href="guide.html">Guide</a>
+    <a href="shortcuts.html">Shortcuts</a>
+    <a href="wimport.html">Import format</a>
+    <a href="https://marketplace.visualstudio.com/items?itemName=sqlbi.sqlbi-whiteboard">VS Code</a>
+  </nav>
 
   <footer>
     <span>Requires Windows 10 version 2004 or later, 64-bit.</span>

--- a/site/shortcuts.html
+++ b/site/shortcuts.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Shortcuts — SQLBI Whiteboard</title>
+<meta name="description" content="Pen, mouse, touch, and keyboard reference for SQLBI Whiteboard.">
+<link rel="icon" href="favicon.ico" sizes="any">
+<link rel="icon" href="favicon-32.png" type="image/png" sizes="32x32">
+<link rel="apple-touch-icon" href="apple-touch-icon.png">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Shortcuts — SQLBI Whiteboard">
+<meta property="og:description" content="Pen, mouse, touch, and keyboard reference for SQLBI Whiteboard.">
+<meta property="og:url" content="https://whiteboard.sqlbi.com/shortcuts.html">
+<meta property="og:image" content="https://whiteboard.sqlbi.com/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="wrap wide">
+
+  <header class="doc">
+    <nav class="nav" aria-label="Documentation">
+      <a href="index.html">Download</a>
+      <a href="guide.html">Guide</a>
+      <a href="shortcuts.html" aria-current="page">Shortcuts</a>
+      <a href="wimport.html">Import format</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=sqlbi.sqlbi-whiteboard">VS Code</a>
+    </nav>
+    <h1>Shortcuts</h1>
+    <p class="lede">Pen, mouse, touch, and keys. See the <a href="guide.html">guide</a> for why these exist in a live session.</p>
+  </header>
+
+  <article>
+    <h2>Pen</h2>
+    <table>
+      <thead><tr><th>Input</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td>Pen tip</td><td>Current tool. Pen is selected at startup.</td></tr>
+        <tr><td>Pen hover</td><td>Show the small red pointer dot and hide the arrow.</td></tr>
+        <tr><td>Pen contact</td><td>Hide both the pointer dot and the arrow.</td></tr>
+        <tr><td>Pen eraser</td><td>Erase complete strokes.</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Mouse</h2>
+    <table>
+      <thead><tr><th>Input</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td>Physical mouse movement</td><td>Show the normal arrow.</td></tr>
+        <tr><td>Left button</td><td>Select, move, or resize a container. Release returns to the previous drawing tool.</td></tr>
+        <tr><td>Resize handle</td><td>Drag the circular bottom-right handle. Aspect ratio is preserved.</td></tr>
+        <tr><td>Wheel</td><td>Zoom at the pointer.</td></tr>
+        <tr><td>Middle button</td><td>Pan.</td></tr>
+        <tr><td>Right button</td><td>Pan while held. Release returns to Pen.</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Touch</h2>
+    <table>
+      <thead><tr><th>Input</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td>One finger</td><td>Pan. Suspended while the pen is in contact.</td></tr>
+        <tr><td>Two fingers</td><td>Pan and pinch zoom.</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Keyboard</h2>
+    <table>
+      <thead><tr><th>Input</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td>Space</td><td>Pan while held.</td></tr>
+        <tr><td>Ctrl+Z / Ctrl+Y</td><td>Undo / redo.</td></tr>
+        <tr><td>Ctrl+V</td><td>Paste an image, or create a text container from plain text.</td></tr>
+        <tr><td>Ctrl+C</td><td>Copy the selection. Copying a LiveView copies its last frame as a bitmap.</td></tr>
+        <tr><td>Ctrl+S / Ctrl+O</td><td>Save / open a board.</td></tr>
+        <tr><td>Delete</td><td>Delete the selected container and its linked strokes.</td></tr>
+        <tr><td>F2</td><td>Edit the selected text container.</td></tr>
+        <tr><td>F6</td><td>Format DAX or SQL Server code in an active text edit.</td></tr>
+        <tr><td>Ctrl+Enter</td><td>Commit the text edit and return to display mode.</td></tr>
+        <tr><td>Escape</td><td>Cancel the text edit, or leave full screen when not editing.</td></tr>
+        <tr><td>Alt+L</td><td>Laser pointer.</td></tr>
+        <tr><td>F11</td><td>Toggle full screen.</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Double-click</h2>
+    <table>
+      <thead><tr><th>Target</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td>Container</td><td>Center it and fit it to the canvas.</td></tr>
+        <tr><td>Empty canvas</td><td>Center and fit all content, or reset an empty board.</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Tools menu</h2>
+    <table>
+      <thead><tr><th>Command</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td>Preferences…</td><td>Searchable settings: startup monitor, full screen, laser trail, toolbar.</td></tr>
+        <tr><td>Add LiveView…</td><td>Capture an application window or display as a container.</td></tr>
+        <tr><td>Freeze selected LiveView</td><td>Freeze or resume the selected live feed.</td></tr>
+        <tr><td>Reconnect selected LiveView…</td><td>Pick a new capture target for the existing container.</td></tr>
+        <tr><td>Import (toolbar)</td><td>Add a <code>.wimport</code> recipe or an image at the top-left of the view.</td></tr>
+      </tbody>
+    </table>
+  </article>
+
+  <footer>
+    <span><a href="index.html">Download SQLBI Whiteboard</a></span>
+    <span>
+      <a href="https://github.com/sql-bi/SQLBI-Whiteboard">GitHub</a> ·
+      <a href="https://www.sqlbi.com">SQLBI</a>
+    </span>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,233 @@
+:root {
+  --ground: #FAFAFB;
+  --surface: #FFFFFF;
+  --line: #E2E4E9;
+  --ink: #15171C;
+  --muted: #5C6371;
+  --brand: #F42727;
+  --brand-deep: #B71D1D;
+  --brand-ink: #FFFFFF;
+  --shadow: 0 1px 2px rgba(21,23,28,.06), 0 12px 32px -18px rgba(21,23,28,.30);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ground: #0F1115;
+    --surface: #171A20;
+    --line: #272B33;
+    --ink: #E9EBEF;
+    --muted: #949CAA;
+    --brand: #FF3B3B;
+    --brand-deep: #C92020;
+    --shadow: 0 1px 2px rgba(0,0,0,.5), 0 12px 32px -18px rgba(0,0,0,.9);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  padding: 0 24px 64px;
+  background: var(--ground);
+  color: var(--ink);
+  font-family: "Segoe UI Variable Text", "Segoe UI", system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.wrap { max-width: 640px; margin: 0 auto; }
+.wrap.wide { max-width: 720px; }
+
+header.hero { padding: 88px 0 0; text-align: center; }
+
+header.doc {
+  padding: 36px 0 0;
+}
+
+.mark { width: 104px; height: 104px; filter: drop-shadow(0 8px 24px rgba(183,29,29,.28)); }
+header.doc .mark { width: 56px; height: 56px; filter: drop-shadow(0 4px 14px rgba(183,29,29,.24)); }
+
+h1 {
+  font-size: clamp(34px, 6vw, 46px);
+  line-height: 1.1;
+  letter-spacing: -.025em;
+  font-weight: 650;
+  margin: 22px 0 12px;
+}
+
+header.doc h1 {
+  font-size: clamp(28px, 5vw, 36px);
+  margin: 16px 0 10px;
+}
+
+h2 {
+  font-size: 1.25rem;
+  letter-spacing: -.015em;
+  font-weight: 650;
+  margin: 2.2em 0 .6em;
+}
+
+h3 {
+  font-size: 1.05rem;
+  font-weight: 650;
+  margin: 1.6em 0 .4em;
+}
+
+.tagline { font-size: 18px; color: var(--muted); margin: 0 auto; max-width: 36ch; }
+header.doc .lede { font-size: 17px; color: var(--muted); margin: 0 0 8px; }
+
+.actions {
+  margin: 40px 0 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.download {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background: linear-gradient(140deg, var(--brand), var(--brand-deep));
+  color: var(--brand-ink);
+  text-decoration: none;
+  font-size: 17px;
+  font-weight: 600;
+  padding: 15px 30px;
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+  transition: transform .12s ease, box-shadow .12s ease;
+}
+.download:hover { transform: translateY(-1px); }
+.download:focus-visible { outline: 3px solid var(--brand); outline-offset: 3px; }
+
+.meta { font-size: 13.5px; color: var(--muted); min-height: 1.2em; }
+.meta strong { color: var(--ink); font-weight: 600; }
+
+.alternates { font-size: 14px; color: var(--muted); }
+.alternates a { color: var(--muted); text-decoration: underline; text-underline-offset: 3px; }
+.alternates a:hover { color: var(--ink); }
+.sep { opacity: .45; padding: 0 8px; }
+
+.notice {
+  margin: 44px auto 0;
+  max-width: 520px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--brand);
+  border-radius: 10px;
+  padding: 16px 20px;
+  font-size: 14.5px;
+  color: var(--muted);
+  text-align: left;
+}
+.notice strong { color: var(--ink); font-weight: 600; }
+
+ul.features {
+  margin: 52px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+  font-size: 15.5px;
+  color: var(--muted);
+}
+ul.features a { color: inherit; text-decoration: underline; text-underline-offset: 3px; }
+ul.features a:hover { color: var(--ink); }
+ul.features li { padding-left: 26px; position: relative; }
+ul.features li::before {
+  content: "";
+  position: absolute;
+  left: 6px; top: .62em;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--brand);
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  justify-content: center;
+  margin: 36px 0 0;
+  font-size: 14.5px;
+}
+header.doc .nav { justify-content: flex-start; margin: 0 0 8px; }
+.nav a {
+  color: var(--muted);
+  text-decoration: none;
+}
+.nav a:hover { color: var(--ink); text-decoration: underline; text-underline-offset: 3px; }
+.nav a[aria-current="page"] {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+article {
+  font-size: 16px;
+}
+article p, article li { color: var(--ink); }
+article p { margin: 0 0 1em; }
+article ul, article ol { margin: 0 0 1em; padding-left: 1.3em; }
+article li { margin: .25em 0; }
+article a { color: var(--brand-deep); }
+@media (prefers-color-scheme: dark) {
+  article a { color: #FF8A8A; }
+}
+article code, table code {
+  font-family: "Cascadia Mono", "Segoe UI Mono", ui-monospace, Consolas, monospace;
+  font-size: .9em;
+}
+article pre {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 14px 16px;
+  overflow-x: auto;
+  font-size: 13.5px;
+  line-height: 1.45;
+}
+article pre code { font-size: inherit; }
+
+.story {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 16px 20px 4px;
+  margin: 0 0 14px;
+}
+.story h3 { margin-top: 0; }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14.5px;
+  margin: 0 0 1.4em;
+}
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: .55em .6em .55em 0;
+  border-bottom: 1px solid var(--line);
+}
+th { color: var(--muted); font-weight: 600; }
+
+footer {
+  margin-top: 56px;
+  padding-top: 24px;
+  border-top: 1px solid var(--line);
+  font-size: 13.5px;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  justify-content: space-between;
+}
+footer a { color: var(--muted); text-decoration: none; }
+footer a:hover { color: var(--ink); text-decoration: underline; }
+
+@media (prefers-reduced-motion: reduce) {
+  .download { transition: none; }
+  .download:hover { transform: none; }
+}

--- a/site/wimport.html
+++ b/site/wimport.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>.wimport format — SQLBI Whiteboard</title>
+<meta name="description" content="The .wimport Markdown recipe format for building image and text containers in SQLBI Whiteboard.">
+<link rel="icon" href="favicon.ico" sizes="any">
+<link rel="icon" href="favicon-32.png" type="image/png" sizes="32x32">
+<link rel="apple-touch-icon" href="apple-touch-icon.png">
+<meta property="og:type" content="website">
+<meta property="og:title" content=".wimport format — SQLBI Whiteboard">
+<meta property="og:description" content="Markdown recipes that build image and text containers on a whiteboard.">
+<meta property="og:url" content="https://whiteboard.sqlbi.com/wimport.html">
+<meta property="og:image" content="https://whiteboard.sqlbi.com/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="wrap wide">
+
+  <header class="doc">
+    <nav class="nav" aria-label="Documentation">
+      <a href="index.html">Download</a>
+      <a href="guide.html">Guide</a>
+      <a href="shortcuts.html">Shortcuts</a>
+      <a href="wimport.html" aria-current="page">Import format</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=sqlbi.sqlbi-whiteboard">VS Code</a>
+    </nav>
+    <h1>The <code>.wimport</code> format</h1>
+    <p class="lede">A Markdown recipe that builds image and text containers. It is not a board file. There is no export back to <code>.wimport</code>. After import you rearrange, draw, and save a <code>.wboard</code>.</p>
+  </header>
+
+  <article>
+    <p>This page is the public edition of the in-repo contract <a href="https://github.com/sql-bi/SQLBI-Whiteboard/blob/main/docs/wimport.md"><code>docs/wimport.md</code></a>. Authors and agents should treat the two as the same grammar. A <a href="https://github.com/sql-bi/SQLBI-Whiteboard/blob/main/docs/samples/contoso-workshop.wimport">sample workshop</a> lives next to that file.</p>
+    <p>The file must be valid CommonMark so it previews in VS Code and GitHub without a custom renderer. Associate the extension if the editor does not treat it as Markdown:</p>
+    <pre><code>"files.associations": { "*.wimport": "markdown" }</code></pre>
+
+    <h2>Produce this</h2>
+    <ul>
+      <li>Extension: <code>.wimport</code> (not <code>.md</code>).</li>
+      <li>Encoding: UTF-8.</li>
+      <li>Paths: local and relative to the <code>.wimport</code> file. No <code>http://</code> or <code>https://</code>.</li>
+      <li>One idea per <code>##</code> heading. One container per heading.</li>
+    </ul>
+
+    <h2>Heading grammar</h2>
+    <table>
+      <thead><tr><th>Line</th><th>Meaning</th></tr></thead>
+      <tbody>
+        <tr><td><code># Title</code></td><td>Optional board title. At most one. Not a container. Ignored if it appears after the first <code>##</code>.</td></tr>
+        <tr><td><code>## Title</code></td><td>Starts a container. The heading text is the container title.</td></tr>
+        <tr><td><code>###</code> and deeper</td><td>Stay inside the current container body. They do not start a new object.</td></tr>
+        <tr><td><code>---</code>, <code>***</code>, or <code>___</code> on its own line</td><td>Thematic break. Starts a new row of containers. Not a container.</td></tr>
+        <tr><td>Any other line before the first <code>##</code></td><td>Documentation for the preview. Not imported.</td></tr>
+      </tbody>
+    </table>
+    <p>An empty <code>##</code> heading is titled <code>Text</code>.</p>
+
+    <h2>How the body becomes a container</h2>
+    <p>Recognizers run in this order. The first match wins. Extra material after the match is ignored.</p>
+    <ol>
+      <li><strong>Markdown image</strong> — <code>![optional alt](relative/path.png)</code>. Image container. Title is the <code>##</code> heading, then the alt text, then the file name. Allowed extensions: <code>.png</code>, <code>.jpg</code>, <code>.jpeg</code>, <code>.bmp</code>, <code>.gif</code>.</li>
+      <li><strong>Fenced code</strong> whose info-string is a registered language. Text container. Contents of the fence. Language from the tag.</li>
+      <li><strong>Markdown link</strong> to an image extension — same as an image.</li>
+      <li><strong>Markdown link</strong> to a registered language extension — <code>[label](relative/path.dax)</code>. Text container. File contents. Language from the extension.</li>
+      <li><strong>Any remaining text</strong> — text container. The Markdown source is stored as plain text. Whiteboard does not render Markdown.</li>
+      <li><strong>Empty body</strong> — the heading is skipped.</li>
+    </ol>
+    <p>Do not put an image and a measure under the same <code>##</code>. Use two headings.</p>
+    <p>A fenced block whose tag is unknown (for example <code>python</code> today) is not a language container. The whole body, fence included, becomes plain text.</p>
+
+    <h3>Languages shipped today</h3>
+    <table>
+      <thead><tr><th>Language</th><th>Fence info-string</th><th>File extensions</th></tr></thead>
+      <tbody>
+        <tr><td>DAX</td><td><code>dax</code></td><td><code>.dax</code></td></tr>
+        <tr><td>SQL Server</td><td><code>sql</code>, <code>tsql</code></td><td><code>.sql</code></td></tr>
+      </tbody>
+    </table>
+    <p>Further languages will be extra rows in this table. Do not invent fence tags Whiteboard does not list here: they import as plain text. Linked text files larger than 1&nbsp;000&nbsp;000 bytes are skipped and reported as missing.</p>
+
+    <h2>Layout</h2>
+    <p>Whiteboard measures each container, then packs them left to right. A thematic break starts a new row even if the current row is not full. Without a break, a row wraps when the next item would exceed about 2400 world units.</p>
+    <p>On drop, the group’s top-left is the pointer. On Open or toolbar Import, the group’s top-left is the top-left of the visible view. Do not put coordinates in the file. There is no <code>pos:</code>, no YAML front matter, and no HTML comment layout.</p>
+
+    <h2>How the file is opened</h2>
+    <table>
+      <thead><tr><th>Action</th><th>Result</th></tr></thead>
+      <tbody>
+        <tr><td>Drop onto an open board</td><td>Containers are added. Pointer is the group top-left. Undo is one step.</td></tr>
+        <tr><td>Toolbar Import</td><td>Containers are added at the visible top-left.</td></tr>
+        <tr><td>File → Open, or double-click</td><td>New untitled board, then import. Save / Save As writes <code>.wboard</code> only. The <code>.wimport</code> path is used only to resolve relative links.</td></tr>
+      </tbody>
+    </table>
+    <p>Missing or unreadable linked files are skipped. Whiteboard then shows a dialog listing the resolved paths, which can be copied.</p>
+
+    <h2>Template</h2>
+    <pre><code># Optional board title
+
+Optional notes for the Markdown preview. Not imported.
+
+## Container title for an image
+![short alt](./images/diagram.png)
+
+## Container title for notes
+- Bullet one
+- Bullet two
+
+---
+
+## Container title for embedded DAX
+&#96;&#96;&#96;dax
+Total Sales := SUM(Sales[Amount])
+&#96;&#96;&#96;
+
+## Container title for linked SQL
+[Top customers](./sql/top-customers.sql)</code></pre>
+
+    <h2>Checklist</h2>
+    <ul>
+      <li>File name ends in <code>.wimport</code>.</li>
+      <li>Every container is a <code>##</code> heading with exactly one payload.</li>
+      <li>Images and linked code exist next to the file, using relative paths.</li>
+      <li>Image files are png/jpeg/bmp/gif. Linked code files are <code>.dax</code> or <code>.sql</code>, or the code is embedded in a <code>dax</code> / <code>sql</code> / <code>tsql</code> fence.</li>
+      <li>Row breaks are a thematic break on its own line, not a fake heading.</li>
+      <li>You did not use <code>http://</code>, YAML, or explicit positions.</li>
+      <li>Opening the file in a Markdown preview still reads as a normal document.</li>
+    </ul>
+
+    <h2>Do not</h2>
+    <ul>
+      <li>Write a <code>.md</code> and expect Whiteboard to import it.</li>
+      <li>Ask Whiteboard to save or export <code>.wimport</code>.</li>
+      <li>Embed bitmap bytes. Images are always a link to a file.</li>
+      <li>Mix two payloads in one <code>##</code> section.</li>
+      <li>Use HTML, YAML front matter, or custom XML.</li>
+      <li>Reference network URLs.</li>
+      <li>Generate ink, LiveViews, or a <code>.wboard</code> ZIP. Those are not this format.</li>
+    </ul>
+  </article>
+
+  <footer>
+    <span><a href="index.html">Download SQLBI Whiteboard</a></span>
+    <span>
+      <a href="https://github.com/sql-bi/SQLBI-Whiteboard">GitHub</a> ·
+      <a href="https://www.sqlbi.com">SQLBI</a>
+    </span>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/vscode/sqlbi-whiteboard/README.md
+++ b/vscode/sqlbi-whiteboard/README.md
@@ -20,7 +20,7 @@ Then **Run > Start Debugging**, or package a VSIX:
 
 ```powershell
 npx --yes @vscode/vsce package
-code --install-extension sqlbi-whiteboard-1.0.0.vsix
+code --install-extension sqlbi-whiteboard-1.0.1.vsix
 ```
 
 Shipping a new Marketplace version is a `package.json` version bump merged to `main`. See [docs/release-management.md](../../docs/release-management.md).

--- a/vscode/sqlbi-whiteboard/README.md
+++ b/vscode/sqlbi-whiteboard/README.md
@@ -6,7 +6,9 @@ This extension does not render the board and does not edit the file. Open the bo
 
 ## Install
 
-Not on the Marketplace yet. From the repository:
+Install [SQLBI Whiteboard](https://marketplace.visualstudio.com/items?itemName=sqlbi.sqlbi-whiteboard) from the Marketplace (`sqlbi.sqlbi-whiteboard`).
+
+To run from this folder during development:
 
 ```powershell
 cd vscode/sqlbi-whiteboard
@@ -14,12 +16,14 @@ npm install
 npm run compile
 ```
 
-Then **Run > Start Debugging** in VS Code with this folder as the workspace, or install a packaged VSIX:
+Then **Run > Start Debugging**, or package a VSIX:
 
 ```powershell
 npx --yes @vscode/vsce package
 code --install-extension sqlbi-whiteboard-1.0.0.vsix
 ```
+
+Shipping a new Marketplace version is a `package.json` version bump merged to `main`. See [docs/release-management.md](../../docs/release-management.md).
 
 ## Use
 

--- a/vscode/sqlbi-whiteboard/package-lock.json
+++ b/vscode/sqlbi-whiteboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlbi-whiteboard",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlbi-whiteboard",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"

--- a/vscode/sqlbi-whiteboard/package.json
+++ b/vscode/sqlbi-whiteboard/package.json
@@ -2,7 +2,7 @@
   "name": "sqlbi-whiteboard",
   "displayName": "SQLBI Whiteboard",
   "description": "Opens .wboard files as the embedded preview image instead of a ZIP archive.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "sqlbi",
   "license": "MIT",
   "engines": {
@@ -29,6 +29,17 @@
     "onCustomEditor:sqlbi.whiteboard.preview"
   ],
   "contributes": {
+    "languages": [
+      {
+        "id": "wboard",
+        "aliases": ["Whiteboard", "SQLBI Whiteboard"],
+        "extensions": [".wboard"]
+      },
+      {
+        "id": "markdown",
+        "extensions": [".wimport"]
+      }
+    ],
     "customEditors": [
       {
         "viewType": "sqlbi.whiteboard.preview",


### PR DESCRIPTION
The landing page links a guide, a shortcuts reference, and the `.wimport` contract. Release-management now starts with what to run, then how the pipelines work.

The VS Code extension is 1.0.1: it treats `.wimport` as Markdown and recommends itself from the repository and from `docs/samples`. Whiteboard VersionPrefix is unchanged.