### PR TITLE
Prefer images from mixed clipboard formats

### DIFF
--- a/src/SQLBI.Whiteboard.Core/Import/ClipboardImageImport.cs
+++ b/src/SQLBI.Whiteboard.Core/Import/ClipboardImageImport.cs
@@ -1,0 +1,136 @@
+using System.Buffers.Binary;
+
+namespace SQLBI.Whiteboard.Core.Import;
+
+public enum ClipboardImageDataKind
+{
+    Encoded,
+    Bitmap,
+    Dib,
+    FileDrop,
+}
+
+public readonly record struct ClipboardImageFormat(
+    string Name,
+    ClipboardImageDataKind Kind);
+
+public static class ClipboardImageImport
+{
+    private static readonly ClipboardImageFormat[] Priority =
+    [
+        new("PNG", ClipboardImageDataKind.Encoded),
+        new("image/png", ClipboardImageDataKind.Encoded),
+        new("Bitmap", ClipboardImageDataKind.Bitmap),
+        new("image/bmp", ClipboardImageDataKind.Encoded),
+        new("DeviceIndependentBitmap", ClipboardImageDataKind.Dib),
+        new("Format17", ClipboardImageDataKind.Dib),
+        new("TaggedImageFileFormat", ClipboardImageDataKind.Encoded),
+        new("image/tiff", ClipboardImageDataKind.Encoded),
+        new("JFIF", ClipboardImageDataKind.Encoded),
+        new("image/jpeg", ClipboardImageDataKind.Encoded),
+        new("image/jpg", ClipboardImageDataKind.Encoded),
+        new("image/gif", ClipboardImageDataKind.Encoded),
+        new("FileDrop", ClipboardImageDataKind.FileDrop),
+    ];
+
+    public static IReadOnlyList<ClipboardImageFormat> PreferredFormats(
+        IEnumerable<string> availableFormats)
+    {
+        ArgumentNullException.ThrowIfNull(availableFormats);
+        var available = availableFormats
+            .Where(format => !string.IsNullOrWhiteSpace(format))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var preferred = new List<ClipboardImageFormat>();
+
+        foreach (var candidate in Priority)
+        {
+            var actualName = available.FirstOrDefault(format =>
+                string.Equals(format, candidate.Name, StringComparison.OrdinalIgnoreCase));
+            if (actualName is not null)
+            {
+                preferred.Add(candidate with { Name = actualName });
+            }
+        }
+
+        return preferred;
+    }
+
+    public static byte[] WrapDibAsBmp(ReadOnlySpan<byte> dib)
+    {
+        const int bitmapFileHeaderSize = 14;
+        if (dib.Length < 12)
+        {
+            throw new InvalidDataException("The clipboard DIB header is incomplete.");
+        }
+
+        var dibHeaderSize = BinaryPrimitives.ReadUInt32LittleEndian(dib);
+        var pixelOffset = PixelOffset(dib, dibHeaderSize);
+        var fileSize = checked(bitmapFileHeaderSize + dib.Length);
+        var bitmap = new byte[fileSize];
+
+        bitmap[0] = (byte)'B';
+        bitmap[1] = (byte)'M';
+        BinaryPrimitives.WriteUInt32LittleEndian(bitmap.AsSpan(2), (uint)fileSize);
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            bitmap.AsSpan(10),
+            checked((uint)(bitmapFileHeaderSize + pixelOffset)));
+        dib.CopyTo(bitmap.AsSpan(bitmapFileHeaderSize));
+        return bitmap;
+    }
+
+    private static int PixelOffset(ReadOnlySpan<byte> dib, uint headerSize)
+    {
+        if (headerSize == 12)
+        {
+            var bitCount = BinaryPrimitives.ReadUInt16LittleEndian(dib.Slice(10, 2));
+            var colorCount = bitCount <= 8 ? 1 << bitCount : 0;
+            return ValidatePixelOffset(dib, checked(12 + (colorCount * 3)));
+        }
+
+        if (headerSize < 40 || headerSize > dib.Length)
+        {
+            throw new InvalidDataException("The clipboard DIB header is not supported.");
+        }
+
+        var bitCountInfo = BinaryPrimitives.ReadUInt16LittleEndian(dib.Slice(14, 2));
+        var compression = BinaryPrimitives.ReadUInt32LittleEndian(dib.Slice(16, 4));
+        var colorsUsed = BinaryPrimitives.ReadUInt32LittleEndian(dib.Slice(32, 4));
+        var colorCountInfo = colorsUsed > 0
+            ? checked((int)colorsUsed)
+            : bitCountInfo <= 8
+                ? 1 << bitCountInfo
+                : 0;
+        var masksAfterHeader = headerSize == 40
+            ? compression switch
+            {
+                3 => 12,
+                6 => 16,
+                _ => 0,
+            }
+            : 0;
+        var offset = checked((int)headerSize + masksAfterHeader + (colorCountInfo * 4));
+
+        if (headerSize >= 124)
+        {
+            var profileOffset = BinaryPrimitives.ReadUInt32LittleEndian(dib.Slice(112, 4));
+            var profileSize = BinaryPrimitives.ReadUInt32LittleEndian(dib.Slice(116, 4));
+            if (profileOffset > 0 && profileSize > 0)
+            {
+                offset = Math.Max(offset, checked((int)(profileOffset + profileSize)));
+            }
+        }
+
+        return ValidatePixelOffset(dib, offset);
+    }
+
+    private static int ValidatePixelOffset(ReadOnlySpan<byte> dib, int offset)
+    {
+        if (offset < 0 || offset > dib.Length)
+        {
+            throw new InvalidDataException("The clipboard DIB pixel offset is invalid.");
+        }
+
+        return offset;
+    }
+}

--- a/src/SQLBI.Whiteboard/ClipboardImageReader.cs
+++ b/src/SQLBI.Whiteboard/ClipboardImageReader.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using System.Windows.Media.Imaging;
+using SQLBI.Whiteboard.Core.Import;
+
+namespace SQLBI.Whiteboard;
+
+internal static class ClipboardImageReader
+{
+    public static bool TryRead(IDataObject? dataObject, out byte[] pngBytes)
+    {
+        pngBytes = [];
+        if (dataObject is null)
+        {
+            return false;
+        }
+
+        IReadOnlyList<ClipboardImageFormat> formats =
+            ClipboardImageImport.PreferredFormats(dataObject.GetFormats(autoConvert: false));
+        foreach (var format in formats)
+        {
+            try
+            {
+                if (TryRead(dataObject, format, out pngBytes))
+                {
+                    return true;
+                }
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                Debug.WriteLine(
+                    $"[Clipboard] Could not decode image format '{format.Name}': {exception.Message}");
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryRead(
+        IDataObject dataObject,
+        ClipboardImageFormat format,
+        out byte[] pngBytes)
+    {
+        pngBytes = [];
+        var data = dataObject.GetData(format.Name, autoConvert: false);
+        return format.Kind switch
+        {
+            ClipboardImageDataKind.Bitmap =>
+                TryEncodeBitmap(data as BitmapSource, out pngBytes),
+            ClipboardImageDataKind.Encoded =>
+                TryNormalizeImage(ReadBytes(data), out pngBytes),
+            ClipboardImageDataKind.Dib =>
+                TryNormalizeDib(ReadBytes(data), out pngBytes),
+            ClipboardImageDataKind.FileDrop =>
+                TryReadImageFile(data as string[], out pngBytes),
+            _ => false,
+        };
+    }
+
+    private static bool TryEncodeBitmap(BitmapSource? bitmap, out byte[] pngBytes)
+    {
+        if (bitmap is null)
+        {
+            pngBytes = [];
+            return false;
+        }
+
+        pngBytes = WpfImageCodec.EncodePng(bitmap);
+        return true;
+    }
+
+    private static bool TryNormalizeImage(byte[]? bytes, out byte[] pngBytes)
+    {
+        if (bytes is null || bytes.Length == 0)
+        {
+            pngBytes = [];
+            return false;
+        }
+
+        return TryEncodeBitmap(WpfImageCodec.Decode(bytes), out pngBytes);
+    }
+
+    private static bool TryNormalizeDib(byte[]? dib, out byte[] pngBytes)
+    {
+        if (dib is null || dib.Length == 0)
+        {
+            pngBytes = [];
+            return false;
+        }
+
+        try
+        {
+            return TryNormalizeImage(dib, out pngBytes);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            Debug.WriteLine($"[Clipboard] DIB needs a bitmap file header: {exception.Message}");
+            return TryNormalizeImage(ClipboardImageImport.WrapDibAsBmp(dib), out pngBytes);
+        }
+    }
+
+    private static bool TryReadImageFile(string[]? paths, out byte[] pngBytes)
+    {
+        pngBytes = [];
+        if (paths is null)
+        {
+            return false;
+        }
+
+        foreach (var path in paths)
+        {
+            if (DroppedFileImport.Classify(path) != DroppedFileKind.Image)
+            {
+                continue;
+            }
+
+            if (TryNormalizeImage(File.ReadAllBytes(path), out pngBytes))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static byte[]? ReadBytes(object? data)
+    {
+        if (data is byte[] bytes)
+        {
+            return bytes;
+        }
+
+        if (data is MemoryStream memory)
+        {
+            return memory.ToArray();
+        }
+
+        if (data is not Stream stream)
+        {
+            return null;
+        }
+
+        var originalPosition = stream.CanSeek ? stream.Position : 0;
+        try
+        {
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
+
+            using var copy = new MemoryStream();
+            stream.CopyTo(copy);
+            return copy.ToArray();
+        }
+        finally
+        {
+            if (stream.CanSeek)
+            {
+                stream.Position = originalPosition;
+            }
+        }
+    }
+}

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -2926,24 +2926,20 @@ public partial class MainWindow : Window
     {
         try
         {
-            if (Clipboard.ContainsImage())
+            var clipboard = Clipboard.GetDataObject();
+            if (ClipboardImageReader.TryRead(clipboard, out var pngBytes))
             {
-                var bitmap = Clipboard.GetImage();
-                if (bitmap is null)
-                {
-                    return Task.CompletedTask;
-                }
-
                 AddImage(
-                    WpfImageCodec.EncodePng(bitmap),
+                    pngBytes,
                     "clipboard-image.png",
                     "image/png");
                 return Task.CompletedTask;
             }
 
-            if (Clipboard.ContainsText(TextDataFormat.UnicodeText))
+            if (clipboard?.GetDataPresent(DataFormats.UnicodeText, autoConvert: true) == true &&
+                clipboard.GetData(DataFormats.UnicodeText, autoConvert: true) is string text)
             {
-                AddText(Clipboard.GetText(TextDataFormat.UnicodeText));
+                AddText(text);
             }
         }
         catch (Exception exception)

--- a/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
+++ b/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
@@ -69,6 +69,37 @@ Assert(
     DroppedFileImport.LanguageIdFor("notes.txt") == TextLanguageIds.Plain,
     "Dropped text files should pick a language from the extension.");
 
+var mixedClipboardFormats = ClipboardImageImport.PreferredFormats(
+    ["UnicodeText", "HTML Format", "DeviceIndependentBitmap", "PNG"]);
+Assert(
+    mixedClipboardFormats.Count == 2 &&
+    mixedClipboardFormats[0] == new ClipboardImageFormat("PNG", ClipboardImageDataKind.Encoded) &&
+    mixedClipboardFormats[1] == new ClipboardImageFormat(
+        "DeviceIndependentBitmap",
+        ClipboardImageDataKind.Dib),
+    "Clipboard images should be preferred by fidelity rather than source format order.");
+var reorderedClipboardFormats = ClipboardImageImport.PreferredFormats(
+    ["DeviceIndependentBitmap", "UnicodeText", "png"]);
+Assert(
+    reorderedClipboardFormats.Count == 2 &&
+    reorderedClipboardFormats[0].Name == "png" &&
+    reorderedClipboardFormats[1].Kind == ClipboardImageDataKind.Dib,
+    "Clipboard image selection should be case-insensitive and independent of enumeration order.");
+var clipboardDib = new byte[44];
+BitConverter.GetBytes(40).CopyTo(clipboardDib, 0);
+BitConverter.GetBytes(1).CopyTo(clipboardDib, 4);
+BitConverter.GetBytes(1).CopyTo(clipboardDib, 8);
+BitConverter.GetBytes((short)1).CopyTo(clipboardDib, 12);
+BitConverter.GetBytes((short)32).CopyTo(clipboardDib, 14);
+BitConverter.GetBytes(4).CopyTo(clipboardDib, 20);
+var clipboardBmp = ClipboardImageImport.WrapDibAsBmp(clipboardDib);
+Assert(
+    clipboardBmp.Length == clipboardDib.Length + 14 &&
+    clipboardBmp[0] == 'B' &&
+    clipboardBmp[1] == 'M' &&
+    BitConverter.ToInt32(clipboardBmp, 10) == 54,
+    "A clipboard DIB should gain a valid bitmap file header before WPF decoding.");
+
 var parsedImport = ImportDocument.Parse(
     """
     # Contoso workshop


### PR DESCRIPTION
## Summary

- inspect one clipboard snapshot and prefer supported image representations over text regardless of enumeration order
- support native PNG, Bitmap, DIB/DIBV5, TIFF, JPEG, GIF, and image file-drop representations
- continue to the next image representation when decoding fails, preserving PNG transparency when available
- add smoke coverage for mixed-format priority and DIB conversion

## Validation

- `dotnet build Whiteboard.sln -c Release -p:Platform=x64 --no-restore`
- `dotnet run --project tests/SQLBI.Whiteboard.Core.SmokeTests/SQLBI.Whiteboard.Core.SmokeTests.csproj -c Release --no-build --no-restore`
- changed production files pass `dotnet format --verify-no-changes`

Fixes #34