### PR TITLE
Fix the MSIX Store identity and bump to 0.9.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>0.9.1</VersionPrefix>
+    <VersionPrefix>0.9.2</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/TODO.md
+++ b/TODO.md
@@ -44,10 +44,12 @@ Packaging is in the repo. `scripts/build-installer.ps1` writes an unsigned
 the SQLBI certificate is not involved.
 
 Listing, screenshots, age rating, and the first Partner Center upload are still manual.
-Follow [installer/msix/STORE-LISTING.md](installer/msix/STORE-LISTING.md). Publisher
-display name and the default `CN=` are `SQLBI Corp` (no period). Copyright elsewhere is
-`SQLBI Corp.` Do not automate submission until that first upload has succeeded.
-Certification must never gate the GitHub MSI release.
+Follow [installer/msix/STORE-LISTING.md](installer/msix/STORE-LISTING.md), which records
+the reserved package identity. `PublisherDisplayName` is `SQLBI Corp` (no period) and
+copyright elsewhere is `SQLBI Corp.`, but the manifest `Publisher` is the Store identity
+`CN=<GUID>`, not a readable name — the two are unrelated fields. Do not automate
+submission until that first upload has succeeded. Certification must never gate the
+GitHub MSI release.
 
 Store availability is uneven on managed corporate machines, which is why the MSI channel
 stays the primary route rather than a fallback (decision 10). The teaser can wait; the

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@ The delivery chain works end to end: a merge to `main` builds, signs, and publis
 pre-release to GitHub Releases, and one approval promotes that same build to a release.
 <https://whiteboard.sqlbi.com> resolves its download links at load time and needs no edit
 per release. The current product version is `VersionPrefix` in `Directory.Build.props`
-(0.9.1). Identity version for the Store package is `VersionPrefix.0` (`0.9.1.0`).
+(0.9.2). Identity version for the Store package is `VersionPrefix.0` (`0.9.2.0`).
 
 What 1.0 was waiting on is in the product: Preferences, `.wimport`, Explorer and VS Code
 previews, the public documentation site, and Finger drawing (default when no pen is

--- a/installer/msix/AppxManifest.xml
+++ b/installer/msix/AppxManifest.xml
@@ -11,8 +11,11 @@
   <!--
     Version is major.minor.patch.0 from VersionPrefix. The Store requires the last
     part to be 0; the desktop assembly version uses a different four-part stamp.
-    Publisher and Name are replaced at pack time. Partner Center overwrites
-    Publisher with the Store identity after association.
+
+    Name and Publisher are replaced at pack time by scripts/build-msix.ps1 and must
+    already match the identity reserved in Partner Center, which validates the
+    uploaded package rather than rewriting it. The package family name is derived
+    from those two values and is never declared here.
   -->
   <Identity
     Name="__PACKAGE_NAME__"

--- a/installer/msix/STORE-LISTING.md
+++ b/installer/msix/STORE-LISTING.md
@@ -5,6 +5,52 @@ The pipeline and `scripts/build-installer.ps1` produce
 (so 0.9.1 becomes `0.9.1.0`). The Store re-signs the package. Do not upload
 until the listing assets below exist.
 
+## Package identity
+
+Assigned by Partner Center when the name was reserved. The first three are the
+only ones written anywhere: they are the defaults in `scripts/build-msix.ps1`
+and the `PublisherDisplayName` in `AppxManifest.xml`, so an ordinary build is
+submittable without extra arguments.
+
+| Field | Value | Set where |
+|---|---|---|
+| `Package/Identity/Name` | `17351SQLBICorp.SQLBIWhiteboard` | `build-msix.ps1` default |
+| `Package/Identity/Publisher` | `CN=922444FE-B5BD-491C-A501-DD2EC37191C8` | `build-msix.ps1` default |
+| `Package/Properties/PublisherDisplayName` | `SQLBI Corp` | `AppxManifest.xml` |
+| Package family name (PFN) | `17351SQLBICorp.SQLBIWhiteboard_x5fb4jp2zkb6m` | derived, never written |
+| Package SID | `S-1-15-2-1890532371-2375246573-3128893498-3639117771-3030907503-1416850920-4129476770` | derived, never written |
+| Store ID | `9NN5N0L2TMTF` | Partner Center only |
+
+None of this is secret. Identity, PFN, and SID ship inside every copy of the
+package and are readable with `Get-AppxPackage` on any machine that installs
+it; the Store ID is the public listing URL. What must never enter the repo is
+the Partner Center sign-in, the Azure AD client secret if submission is ever
+automated, and the code-signing certificate.
+
+The last three rows are **derived and self-checking**, which is why they are
+worth recording even though nothing reads them:
+
+- the PFN suffix is a base32 hash of the Publisher string, so it can only match
+  if Publisher is character-exact;
+- the SID is `SHA-256` over the lowercased PFN as UTF-16LE, taken as seven
+  little-endian `uint32` sub-authorities under `S-1-15-2`.
+
+Both were recomputed from the values above and match, so the block is
+internally consistent. Re-derive them after any identity change rather than
+trusting a copy-paste.
+
+A Store rejection reports Name, Publisher, and PFN as three separate errors.
+It is one problem: fix the first two and the rest follow.
+
+Partner Center validates the identity in the package you upload and rejects a
+mismatch. It does not rewrite your manifest — "associating" an app in Visual
+Studio rewrites a *local* manifest, which is the source of the opposite belief.
+
+Overriding `-PackageName` / `-Publisher` is only for a locally installable
+build. A package can be signed only by a certificate whose subject equals
+Publisher exactly, so sideload testing needs a self-signed certificate with a
+matching subject; such a package is not submittable.
+
 ## What the repo already produces
 
 - Unsigned MSIX with `.wboard` / `.wimport` open verbs and the thumbnail COM
@@ -14,30 +60,37 @@ until the listing assets below exist.
 
 ## What only you can do in Partner Center
 
-1. **Reserve the name** “SQLBI Whiteboard” (Windows desktop).
-2. **Read the Store identity** (Package/Identity Name and Publisher `CN=…`) and,
-   if they differ from `SQLBI.Whiteboard` / `CN=SQLBI Corp`, pack again:
-
-   ```powershell
-   ./scripts/build-msix.ps1 -Publisher "CN=…from Partner Center…" -PackageName "…from Partner Center…"
-   ```
-
-3. **Associate** the app so Partner Center accepts that identity.
-4. **Age rating** questionnaire.
-5. **Privacy policy URL** (required). Use
+1. **Reserve the name** “SQLBI Whiteboard” (Windows desktop). Done — the
+   identity above is the result. If it is ever re-reserved, update the defaults
+   in `scripts/build-msix.ps1`.
+2. **Age rating** questionnaire.
+3. **Privacy policy URL** (required). Use
    `https://whiteboard.sqlbi.com/privacy.html`.
-6. **Support contact** (email or https://www.sqlbi.com).
-7. **Category** — Productivity is the closest fit.
-8. **`runFullTrust` declaration** — required for this Win32 package. Partner
+4. **Support contact** (email or https://www.sqlbi.com).
+5. **Category** — Productivity is the closest fit.
+6. **`runFullTrust` declaration** — required for this Win32 package. Partner
    Center will ask why; answer that it is a full-trust desktop whiteboard that
    uses Windows Graphics Capture and an Explorer thumbnail handler.
-9. **Screenshots** — at least one, 1366×768 or 1920×1080, of the real UI
+7. **Screenshots** — at least one, 1366×768 or 1920×1080, of the real UI
    (ink, a text container, a LiveView). The teaser in TODO.md can wait; the
    listing cannot ship without stills.
-10. **Description** — draft below. Edit freely in Partner Center.
+8. **Description** — draft below. Edit freely in Partner Center.
 
 Do **not** start certification. Upload the MSIX only when you are ready to
 submit. Certification must never gate the MSI / GitHub release.
+
+## Once the listing is live
+
+The Store ID gives the public addresses. Both 404 until the listing is
+published, so nothing links to them yet:
+
+- `https://apps.microsoft.com/detail/9NN5N0L2TMTF`
+- `ms-windows-store://pdp/?ProductId=9NN5N0L2TMTF` (opens the Store app)
+
+Then, and not before, the Store becomes a second route on
+`whiteboard.sqlbi.com`. It stays second: Store availability is uneven on
+managed corporate machines, which is why the MSI is the primary channel
+(decision 10).
 
 ## Draft listing copy (0.9.1)
 

--- a/installer/msix/STORE-LISTING.md
+++ b/installer/msix/STORE-LISTING.md
@@ -2,7 +2,7 @@
 
 The pipeline and `scripts/build-installer.ps1` produce
 `SQLBI.Whiteboard.<version>.x64.msix`. Identity version is `VersionPrefix.0`
-(so 0.9.1 becomes `0.9.1.0`). The Store re-signs the package. Do not upload
+(so 0.9.2 becomes `0.9.2.0`). The Store re-signs the package. Do not upload
 until the listing assets below exist.
 
 ## Package identity
@@ -92,7 +92,7 @@ Then, and not before, the Store becomes a second route on
 managed corporate machines, which is why the MSI is the primary channel
 (decision 10).
 
-## Draft listing copy (0.9.1)
+## Draft listing copy (0.9.2)
 
 **Title:** SQLBI Whiteboard
 

--- a/scripts/build-msix.ps1
+++ b/scripts/build-msix.ps1
@@ -4,7 +4,7 @@
     Packs the published Whiteboard binaries into an unsigned MSIX for the Store.
 
 .DESCRIPTION
-    Store Identity Version is VersionPrefix with a trailing .0 (0.9.1.0). That is
+    Store Identity Version is VersionPrefix with a trailing .0 (0.9.2.0). That is
     not the four-part assembly stamp the MSI uses. The Store re-signs the package,
     so this script does not apply the EV certificate.
 

--- a/scripts/build-msix.ps1
+++ b/scripts/build-msix.ps1
@@ -8,16 +8,27 @@
     not the four-part assembly stamp the MSI uses. The Store re-signs the package,
     so this script does not apply the EV certificate.
 
-    Partner Center overwrites Publisher after the app is associated. Pass
-    -Publisher from the Partner Center identity page when packing a Store upload.
+    Identity Name and Publisher must already match what Partner Center reserved.
+    Partner Center validates the identity in the uploaded package and rejects a
+    mismatch; it never rewrites the manifest. (Visual Studio's "Associate App with
+    the Store" rewrites a local manifest, which is where the opposite belief comes
+    from.) The defaults below are the reserved identity, so an ordinary build is
+    submittable as-is.
+
+    The package family name is derived from these two values and cannot be set.
+    Getting Name and Publisher right yields 17351SQLBICorp.SQLBIWhiteboard_x5fb4jp2zkb6m.
+
+    Override them only to pack a locally installable build: a package can be signed
+    only by a certificate whose subject equals Publisher exactly, so sideload testing
+    needs a self-signed certificate with a matching subject.
 #>
 [CmdletBinding()]
 param(
     [string] $Version,
     [string] $PublishFolder,
     [string] $OutputFolder,
-    [string] $PackageName = 'SQLBI.Whiteboard',
-    [string] $Publisher = 'CN=SQLBI Corp',
+    [string] $PackageName = '17351SQLBICorp.SQLBIWhiteboard',
+    [string] $Publisher = 'CN=922444FE-B5BD-491C-A501-DD2EC37191C8',
     [ValidateSet('x64')]
     [string] $Architecture = 'x64'
 )
@@ -91,6 +102,10 @@ try {
     Set-Content -Path (Join-Path $staging 'AppxManifest.xml') -Value $manifest -Encoding utf8
 
     $msixPath = Join-Path $OutputFolder "SQLBI.Whiteboard.$Version.$Architecture.msix"
+    # Print the identity. A Store rejection reads as three separate errors, so
+    # having the packed values in the build log is what makes it one glance.
+    Write-Host "    Identity Name : $PackageName"
+    Write-Host "    Publisher     : $Publisher"
     Write-Host "==> makeappx pack ($identityVersion)" -ForegroundColor Cyan
     & $makeAppxPath pack /d $staging /p $msixPath /o
     if ($LASTEXITCODE -ne 0) { throw "makeappx failed with exit code $LASTEXITCODE" }


### PR DESCRIPTION
Partner Center rejected `SQLBI.Whiteboard.0.9.1.x64.msix` with three errors — wrong identity name, wrong family name, wrong publisher.

## Cause

`build-installer.ps1` calls `build-msix.ps1` without `-PackageName` or `-Publisher`, so every MSIX the pipeline has ever produced carried the script's placeholder defaults, `SQLBI.Whiteboard` and `CN=SQLBI Corp`. Those are exactly the two values Partner Center reported.

The defaults were placeholders because three files — the script header, the manifest comment, and this checklist — asserted that *Partner Center overwrites Publisher after the app is associated*. It does not. Partner Center validates the identity in the uploaded package and rejects a mismatch. What rewrites a manifest is Visual Studio's "Associate App with the Store", and only the local copy. Believing otherwise is why placeholder values were considered acceptable and why the real fix was documented as a manual re-pack nobody would remember at submission time.

The three errors are also one problem, not three: the package family name is derived from Name and Publisher and is never set anywhere.

## Changes

- `scripts/build-msix.ps1` — defaults are the reserved Store identity, so an ordinary build is submittable with no extra arguments. The identity is echoed while packing, which is what would have made this visible before upload rather than after.
- `installer/msix/AppxManifest.xml` — corrected the comment.
- `installer/msix/STORE-LISTING.md` — records the full identity block, replacing the "go read it from Partner Center and pack again" step.
- `Directory.Build.props` — `VersionPrefix` 0.9.1 → 0.9.2, plus the version-stamped references in `TODO.md`, `STORE-LISTING.md`, and the `build-msix.ps1` example.

Identity and version are one unit here: the point of the change is a submittable 0.9.2 package.

## On storing the identity

Nothing recorded is secret. Identity, package family name, and package SID ship inside every copy of the package and are readable with `Get-AppxPackage` on any machine that installs it; the Store ID is the public listing URL. `STORE-LISTING.md` names what must stay out of the repo: the Partner Center sign-in, the Azure AD client secret if submission is ever automated, and the code-signing certificate.

The Store ID also gives the public listing addresses. Nothing links to them — they 404 until the listing is published — so they are recorded for later rather than wired up now. Per decision 10 the Store stays the second route behind the MSI.

## Verification

`dotnet build -c Release` clean with 0 warnings, smoke tests pass, and MSBuild reports `VersionPrefix` as `0.9.2`.

A real MSIX was packed from the current publish output and its manifest read back from inside the package:

```
<Identity Name="17351SQLBICorp.SQLBIWhiteboard" ProcessorArchitecture="x64"
          Publisher="CN=922444FE-B5BD-491C-A501-DD2EC37191C8" Version="0.9.1.0" />
```

The two derived values were then recomputed from it and both match Partner Center: the family name (base32 hash of the Publisher string) and the package SID (SHA-256 over the lowercased family name as UTF-16LE, as seven little-endian `uint32` under `S-1-15-2`). Since each hashes the value above it, that chain proves the publisher GUID is character-exact rather than merely similar — a single wrong hex digit would have reproduced the original rejection with no obvious cause.