### PR TITLE
Restore the mouse arrow while the laser tool is selected

### DIFF
--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -870,14 +870,16 @@ public partial class MainWindow : Window
         var screen = ToPointD(e.GetPosition(InkSurface));
         if (EffectiveTool == BoardTool.Laser)
         {
-            HidePointerDot();
-            InkSurface.Cursor = Cursors.None;
+            // The laser hides the cursor for pen input. A physical mouse still
+            // gets the arrow, matching pen, highlighter, and calligraphy. Hide
+            // it only while the mouse is drawing a trail.
             if (_mouseAction == PointerAction.Laser)
             {
-                UpdateLaser(e.GetPosition(LaserTrail), leaveTrail: true, MouseLaserPressure);
+                InkSurface.Cursor = Cursors.None;
             }
             else
             {
+                InkSurface.Cursor = Cursors.Arrow;
                 LaserTrail.HideHead();
             }
         }
@@ -941,11 +943,20 @@ public partial class MainWindow : Window
         {
             CompleteContainerGesture();
         }
+        else if (_mouseAction == PointerAction.Laser)
+        {
+            StopLaserSampling();
+            LaserTrail.Lift();
+        }
 
         _mouseAction = PointerAction.None;
         if (hadMouseAction && EffectiveTool != BoardTool.Laser)
         {
             SetActiveTool(_lastDrawingTool);
+        }
+        else if (hadMouseAction)
+        {
+            InkSurface.Cursor = Cursors.Arrow;
         }
     }
 
@@ -979,6 +990,10 @@ public partial class MainWindow : Window
         if (EffectiveTool != BoardTool.Laser)
         {
             SetActiveTool(_lastDrawingTool);
+        }
+        else
+        {
+            InkSurface.Cursor = Cursors.Arrow;
         }
     }
 
@@ -2023,7 +2038,6 @@ public partial class MainWindow : Window
         else
         {
             InkSurface.SetLaserMode(true);
-            InkSurface.Cursor = Cursors.None;
         }
 
         var penFamilyActive = tool is BoardTool.Pen or BoardTool.Calligraphy;


### PR DESCRIPTION
Selecting the laser hid the mouse pointer and never restored it. The laser still works with the pen; a physical mouse now gets the regular arrow again, matching pen, highlighter, and calligraphy.

Fixes #42

## Cause

`InkSurface.Cursor` is `None` while the pen is over the board, which is correct — the hover dot is the pointer. For every other drawing tool, a physical mouse move puts `Cursors.Arrow` back. The laser path did the opposite: mouse move set `Cursors.None` again, and `SetActiveTool` hid the cursor the moment the laser was selected. Combined with `LaserTrail.HideHead()` on hover, there was no pointer at all until another tool was chosen.

WPF also promotes pen input to mouse events. Those are ignored (`StylusDevice is not null`); only a real mouse restores the arrow.

## Changes

- Mouse move with the laser selected restores the arrow. The cursor stays hidden only while the mouse is drawing a laser trail (left-drag).
- Selecting the laser no longer forces `Cursors.None`. Pen enter/move/contact still hide it, as they do for the other ink tools.
- Releasing a mouse-drawn trail restores the arrow. Unexpected capture loss also lifts the trail so it does not stick.

## Verification

`dotnet build Whiteboard.sln -c Release` is clean (0 warnings). Core smoke tests pass.

This is a WPF cursor interaction with a real pen and mouse, which the smoke tests cannot exercise. Please confirm on a tablet:

1. Select the laser, use the pen (trail on contact, hover dot in air).
2. Move the physical mouse over the board — the arrow should return and the hover dot should hide.
3. Left-drag with the mouse — the laser trail should still draw, cursor hidden during the drag, arrow back on release.
4. Select pen or highlighter and confirm the existing mouse-arrow / pen-dot behaviour is unchanged.