### PR TITLE
Record how the winget token has to be shaped, and that setup is done

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -10,20 +10,33 @@
 # the download being available may depend on it. A failure here is visible as a failed run
 # and changes nothing that has already shipped.
 #
-# One-time setup, in this order:
+# Setup was done on 20 August 2026 and is recorded here because it has to be repeated if
+# the token is ever rotated or the account changes.
 #
-#   1. Submit installer/winget/ to microsoft/winget-pkgs by hand, once. `wingetcreate
-#      update` below needs a previous version to read, so it cannot make the first
-#      submission. From a Windows machine with the manifests checked out:
+#   1. The first submission was made by hand. `wingetcreate update` below reads the
+#      previous version's manifests out of winget-pkgs, so it cannot make the first one.
+#      From a Windows machine with this repository checked out:
 #
 #          winget install Microsoft.WingetCreate
-#          wingetcreate submit --token <pat> installer/winget
+#          winget validate installer\winget
+#          wingetcreate submit installer\winget
 #
-#   2. Add a WINGET_TOKEN repository secret: a classic PAT with the public_repo scope,
-#      owned by the account that will carry the fork of microsoft/winget-pkgs.
-#      wingetcreate forks that repository and opens the pull request as this account, so
-#      the token is an identity, not just a permission. It is not GITHUB_TOKEN: that has
-#      no rights outside this repository.
+#      With no --token, wingetcreate runs a browser OAuth flow, which is what the tool's
+#      own documentation recommends locally: a token passed on the command line ends up in
+#      shell history and in any transcript of the session.
+#
+#   2. WINGET_TOKEN is a repository secret holding a GitHub personal access token. A
+#      workflow has no browser, so this is the one place a token is unavoidable.
+#
+#      It must be a **classic** token - wingetcreate does not support fine-grained tokens,
+#      which is now what GitHub offers first. The scope is public_repo, not full repo;
+#      winget-pkgs and the fork are both public. delete_repo is worth adding as well: it
+#      lets wingetcreate remove the fork it created when a submission fails, instead of
+#      leaving one behind on every failure.
+#
+#      wingetcreate forks winget-pkgs and opens the pull request as whoever owns the
+#      token, so it is an identity rather than only a permission. GITHUB_TOKEN cannot
+#      stand in: it has no rights outside this repository.
 name: Publish to winget
 
 on:

--- a/TODO.md
+++ b/TODO.md
@@ -22,9 +22,9 @@ What 1.0 was waiting on is in the product: Preferences, `.wimport`, Explorer and
 previews, the public documentation site, and Finger drawing (default when no pen is
 detected). The Store listing was submitted by hand on 20 August 2026 for 0.9.2.
 
-Three items remain. The release manifests and the winget workflow are built and
-described in [docs/release-management.md](docs/release-management.md); what is left of
-winget is account setup nothing in a repository can do for itself.
+Two items remain. The release manifests and winget are done: the manifests are live at
+<https://whiteboard.sqlbi.com/stable.json>, and the first winget submission is in review.
+Both are described in [docs/release-management.md](docs/release-management.md).
 
 ## 1. Video teaser
 
@@ -73,20 +73,14 @@ Store availability is uneven on managed corporate machines, which is why the MSI
 stays the primary route rather than a fallback (decision 10). Nothing links to the Store
 until certification completes.
 
-## 3. winget account setup
+## Waiting on the first winget submission
 
-`scripts/build-release-manifests.ps1` and `.github/workflows/publish-winget.yml` are
-built and need no further work. Two things have to be done once, by hand, before the
-workflow can succeed:
+Not work, but the reason winget is not finished yet.
+[microsoft/winget-pkgs#421386](https://github.com/microsoft/winget-pkgs/pull/421386)
+submits `SQLBI.Whiteboard` 0.9.2 and is in review. Nothing in this repository depends on
+it: the workflow that keeps the package current afterwards is already in place, and the
+token it needs is set.
 
-1. Submit `installer/winget/` to microsoft/winget-pkgs once. `wingetcreate update` reads
-   the previous version's manifests from that repository, so it cannot make the first
-   submission. `PackageIdentifier` is `SQLBI.Whiteboard`, which the first accepted pull
-   request reserves.
-2. Add a `WINGET_TOKEN` repository secret: a classic PAT with `public_repo`, owned by the
-   account that will carry the fork of microsoft/winget-pkgs. `wingetcreate` opens the pull
-   request as that account, so the token is an identity rather than only a permission.
-   `GITHUB_TOKEN` cannot stand in: it has no rights outside this repository.
-
-Until both are done the workflow fails on every release, which is visible and harmless -
-it runs beside the release and gates nothing.
+Until that pull request merges, `.github/workflows/publish-winget.yml` fails on every
+release, because `wingetcreate update` has no previous version to read. That failure is
+visible and gates nothing.

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -243,9 +243,24 @@ It runs beside the release rather than inside it, for the reason the Store submi
 by people, and it can sit for days. Nothing about the download being available depends on
 it.
 
-Two one-time steps are outstanding, and until both are done the workflow fails on every
-release. They are listed in [TODO.md](../TODO.md): the first submission by hand, and a
-`WINGET_TOKEN` secret.
+The first submission was made by hand on 20 August 2026, which reserved the
+`SQLBI.Whiteboard` identifier. Everything after it is the workflow's job.
+
+`WINGET_TOKEN` is a repository secret holding a GitHub personal access token, and the
+workflow cannot succeed without it. Two constraints on that token are easy to get wrong:
+
+- It must be a **classic** token. `wingetcreate` does not support fine-grained tokens, and
+  fine-grained is what GitHub offers first now.
+- The scope is `public_repo`, not full `repo` - winget-pkgs and the fork are both public.
+  Adding `delete_repo` lets `wingetcreate` clean up the fork it created when a submission
+  fails, rather than leaving one behind each time.
+
+`wingetcreate` forks winget-pkgs and opens the pull request as whoever owns the token, so
+it is an identity rather than only a permission, and `GITHUB_TOKEN` cannot stand in.
+
+Locally, `wingetcreate` needs no token at all: run it without `--token` and it uses a
+browser OAuth flow, which is what its own documentation recommends, because a token on the
+command line ends up in shell history.
 
 ### Still to build
 


### PR DESCRIPTION
The setup notes said "a classic PAT with the `public_repo` scope" and left the two things that actually cost time unsaid.

`wingetcreate` **does not support fine-grained tokens**, and fine-grained is what GitHub now offers first — so the obvious path produces a token the tool rejects. And **locally no token is needed at all**: run `wingetcreate` without `--token` and it uses a browser OAuth flow, which [its own documentation](https://github.com/microsoft/winget-create/blob/main/doc/token.md) recommends over passing a token that then sits in shell history. The instruction had it the other way round.

`delete_repo` is worth adding to the token too: without it, a failed submission leaves behind the fork `wingetcreate` created, once per failure.

Both steps were done on 20 August 2026, so `TODO.md` no longer describes them as work. What is left is waiting for [winget-pkgs#421386](https://github.com/microsoft/winget-pkgs/pull/421386) to merge, which reserves the identifier and gives `wingetcreate update` a previous version to read. The durable half — what the token has to be — moves to `release-management.md`, where it stays true after the wait ends.

Docs and one workflow comment block only; no behaviour change.