### PR TITLE
Submit released versions to the Microsoft Store from the pipeline

### DIFF
--- a/.azure/pipelines/build-whiteboard.yaml
+++ b/.azure/pipelines/build-whiteboard.yaml
@@ -17,6 +17,12 @@
 #   SQLBI.Whiteboard
 #     AppInformationalVersionExtendedInfo  (optional, 'true' appends build and commit details)
 #
+#   SQLBI-StoreSubmission
+#     StoreTenantId, StoreClientId, StoreClientSecret, StoreSellerId
+#     Declared on the Store stage rather than here, so the build and signing stages cannot
+#     read it. Its tenant is not the signing tenant: the Partner Center account is
+#     associated with a different one.
+#
 # The version is not a pipeline variable: it comes from VersionPrefix in
 # Directory.Build.props, so releasing is a reviewed change to the repository.
 
@@ -28,6 +34,12 @@ parameters:
   values: [minimal, normal, detailed, diagnostic]
 - name: sign
   displayName: Code sign the outputs
+  type: boolean
+  default: true
+# Turn off to promote a release without touching the Store - when a submission is already
+# pending for the product, or when the release is being rebuilt rather than shipped.
+- name: submitToStore
+  displayName: Submit the released MSIX to the Microsoft Store
   type: boolean
   default: true
 
@@ -362,3 +374,118 @@ stages:
               assets: '$(Build.ArtifactStagingDirectory)/release/*'
               isPreRelease: false
               addChangeLog: false
+
+# Submission runs after the release rather than beside it. Certification takes hours to
+# days, so it must never gate the download (decision 13) - by the time this stage starts,
+# the GitHub release already exists and a failure here changes nothing that shipped.
+# Depending on Release also means a build that was never promoted is never submitted.
+- stage: Store
+  displayName: Submit to the Microsoft Store
+  dependsOn: Release
+  condition: and(succeeded(), eq(variables.isMain, true), ${{ parameters.submitToStore }})
+  # The Store credential is scoped to this stage. The build and signing stages have no use
+  # for it, and a variable group declared at pipeline level is readable by all of them.
+  #
+  #   SQLBI-StoreSubmission
+  #     StoreTenantId, StoreClientId, StoreClientSecret, StoreSellerId
+  #
+  # The tenant is deliberately not SigningTenantId: the Partner Center account SQLBI Corp
+  # is associated with a different Microsoft Entra tenant than the one this pipeline signs
+  # in. That is also why the names carry a Store prefix - two groups defining a bare
+  # TenantId would collide, and Azure DevOps resolves a collision silently.
+  variables:
+  - group: 'SQLBI-StoreSubmission'
+  # Public: it is the address of the listing, apps.microsoft.com/detail/9NN5N0L2TMTF.
+  - name: storeProductId
+    value: '9NN5N0L2TMTF'
+  jobs:
+  - job: Submit
+    displayName: Submit the released MSIX
+    # windows-latest for parity with the Build stage. The CLI is cross-platform, but its
+    # Linux build needs a matching .NET runtime present on the agent, which is one more
+    # thing to keep in step for no gain here.
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    - checkout: none
+
+    # Only the self-contained artifact. Both matrix jobs pack a stable MSIX and
+    # build-msix.ps1 names them identically - SQLBI.Whiteboard.<version>.x64.msix carries
+    # no flavour - so a recursive search over the whole workspace can just as easily find
+    # the framework-dependent copy and submit a package that needs a .NET runtime nobody
+    # installed. Naming the artifact makes that mistake unreachable.
+    - download: current
+      displayName: 'Download the released-channel package'
+      artifact: 'drop-x64-true'
+
+    - task: PowerShell@2
+      displayName: 'Locate the MSIX'
+      inputs:
+        targetType: 'inline'
+        pwsh: true
+        script: |
+          $ErrorActionPreference = 'Stop'
+          Set-StrictMode -Version Latest
+
+          $packages = @(Get-ChildItem -Path $env:ARTIFACT -Filter '*.msix' -File)
+          if ($packages.Count -ne 1) {
+              throw "Expected exactly one MSIX in $env:ARTIFACT, found $($packages.Count)."
+          }
+
+          $msix = $packages[0]
+          Write-Host ('Submitting {0} ({1:N1} MB)' -f $msix.Name, ($msix.Length / 1MB))
+          Write-Host "##vso[task.setvariable variable=MsixPath;]$($msix.FullName)"
+      env:
+        ARTIFACT: $(Pipeline.Workspace)/drop-x64-true
+
+    - task: UseMSStoreCLI@0
+      displayName: 'Install the Microsoft Store Developer CLI'
+
+    # Credentials go through the environment rather than the command line: a native command
+    # line is echoed by the agent, and masking is a safety net rather than a guarantee.
+    - task: PowerShell@2
+      displayName: 'Configure the Store CLI'
+      inputs:
+        targetType: 'inline'
+        pwsh: true
+        script: |
+          $ErrorActionPreference = 'Stop'
+          Set-StrictMode -Version Latest
+
+          msstore reconfigure `
+              --tenantId $env:STORE_TENANT_ID `
+              --sellerId $env:STORE_SELLER_ID `
+              --clientId $env:STORE_CLIENT_ID `
+              --clientSecret $env:STORE_CLIENT_SECRET
+          if ($LASTEXITCODE -ne 0) { throw "msstore reconfigure exited with $LASTEXITCODE" }
+      env:
+        STORE_TENANT_ID: $(StoreTenantId)
+        STORE_SELLER_ID: $(StoreSellerId)
+        STORE_CLIENT_ID: $(StoreClientId)
+        STORE_CLIENT_SECRET: $(StoreClientSecret)
+
+    # Packages only. The listing text, screenshots, and 'What's new' are carried over from
+    # the last published submission untouched; changing them is 'msstore submission
+    # updateMetadata' and a deliberate act, recorded in installer/msix/STORE-LISTING.md.
+    #
+    # This fails if a submission is already pending for the product. That is correct: an
+    # in-flight submission may be someone's manual listing edit, and a pipeline must not
+    # discard it. Resolve it in Partner Center, then re-run this stage.
+    - task: PowerShell@2
+      displayName: 'Submit the package'
+      inputs:
+        targetType: 'inline'
+        pwsh: true
+        script: |
+          $ErrorActionPreference = 'Stop'
+          Set-StrictMode -Version Latest
+
+          msstore publish $env:MSIX_PATH -id $env:STORE_PRODUCT_ID
+          if ($LASTEXITCODE -ne 0) {
+              throw "msstore publish exited with $LASTEXITCODE. A pending submission in Partner Center is the usual cause; the release itself is unaffected."
+          }
+
+          Write-Host 'Submitted. Certification takes hours to days and is tracked in Partner Center.'
+      env:
+        MSIX_PATH: $(MsixPath)
+        STORE_PRODUCT_ID: $(storeProductId)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ selected with the `Channel` and `Scope` preprocessor variables:
 | `SQLBI.Whiteboard.<version>.x64-dev-userinstaller.msi` | `%LOCALAPPDATA%\Programs\SQLBI\Whiteboard Dev`, no elevation |
 | `SQLBI.Whiteboard.<version>.x64-portable.zip` | runs without installing |
 | `SQLBI.Whiteboard.<version>.x64-dev-portable.zip` | runs without installing, as the pre-release channel |
-| `SQLBI.Whiteboard.<version>.x64.msix` | unsigned Store package for the released channel. Identity version is `<version>.0`. Not submitted automatically. |
+| `SQLBI.Whiteboard.<version>.x64.msix` | unsigned Store package for the released channel. Identity version is `<version>.0`. The pipeline submits it to Partner Center after a release is promoted; the Store re-signs it. |
 
 ### Channels
 

--- a/TODO.md
+++ b/TODO.md
@@ -55,10 +55,14 @@ visible and gates nothing.
 
 ## Waiting on the first automated Store submission
 
-Also not work. The pipeline's Store stage has never run: 0.9.2 and 0.9.3 were submitted by
-hand, and the stage was written against the documented behaviour of the Microsoft Store
-Developer CLI rather than against a run of it. The first promoted release after this lands
-is the one that proves it.
+Also not work. The pipeline's Store stage has never run. The only submission so far is the
+manual one for 0.9.2, and the stage was written against the documented behaviour of the
+Microsoft Store Developer CLI rather than against a run of it. The first promoted release
+after this lands is the one that proves it.
+
+It needs a version the Store has not seen. The Release stage refuses to reuse an existing
+tag, so exercising this at all means bumping `VersionPrefix` — 0.9.3 cannot be released a
+second time to carry the test.
 
 Watch two things on that run. The stage has to pick the MSIX out of `drop-x64-true`, since
 both matrix jobs pack an identically named package and only one of them is self-contained.

--- a/TODO.md
+++ b/TODO.md
@@ -22,9 +22,10 @@ What 1.0 was waiting on is in the product: Preferences, `.wimport`, Explorer and
 previews, the public documentation site, and Finger drawing (default when no pen is
 detected). The Store listing was submitted by hand on 20 August 2026 for 0.9.2.
 
-Two items remain. The release manifests and winget are done: the manifests are live at
-<https://whiteboard.sqlbi.com/stable.json>, and the first winget submission is in review.
-Both are described in [docs/release-management.md](docs/release-management.md).
+One item remains. The release manifests, winget, and Store submission are done: the
+manifests are live at <https://whiteboard.sqlbi.com/stable.json>, the first winget
+submission is in review, and the pipeline's Store stage submits each promoted release.
+All three are described in [docs/release-management.md](docs/release-management.md).
 
 ## 1. Video teaser
 
@@ -40,39 +41,6 @@ Record against the current UI: Preferences, Finger drawing, the tab strip, LiveV
 freeze/disconnect/reconnect, and a `.wimport` drop. The campaign hero on the home page
 stays through 14 September 2026; the teaser is independent of that art.
 
-## 2. Automatic Store submission
-
-The one-time work is done: 0.9.2 was submitted by hand on 20 August 2026, with the listing,
-screenshots, age rating, and package upload entered in Partner Center. Every field that was
-entered is recorded in [installer/msix/STORE-LISTING.md](installer/msix/STORE-LISTING.md),
-so an automated submission has an exact target rather than a guess. That page is also where
-a listing change belongs, so the record does not drift from what the Store shows.
-
-What remains is publishing the next version without visiting Partner Center, through the
-Microsoft Store submission API. It needs an Azure AD application authorized for the Partner
-Center account; its tenant, client id, and secret are infrastructure, so they belong in the
-pipeline's variable group and never in this repository (CONTRIBUTING.md).
-
-Two constraints shape where it can sit in the pipeline:
-
-- Certification takes hours to days, so submission runs beside the GitHub release and never
-  gates it (decision 13). A failed or slow submission must leave the MSI download unaffected.
-- Only the released channel is submittable, and only from a run that already produced the
-  MSIX it uploads (decision 9). Do not rebuild for the Store.
-
-Packaging itself needs no work. `scripts/build-installer.ps1` writes an unsigned
-`SQLBI.Whiteboard.<version>.x64.msix` for the released channel, the package declares
-`.wboard` / `.wimport` and the thumbnail handler, and the Store re-signs it, so the SQLBI
-certificate is not involved.
-
-Watch the identity fields when touching any of this: `PublisherDisplayName` is `SQLBI Corp`
-(no period) and copyright elsewhere is `SQLBI Corp.`, while the manifest `Publisher` is the
-Store identity `CN=<GUID>` rather than a readable name. The three are unrelated fields.
-
-Store availability is uneven on managed corporate machines, which is why the MSI channel
-stays the primary route rather than a fallback (decision 10). Nothing links to the Store
-until certification completes.
-
 ## Waiting on the first winget submission
 
 Not work, but the reason winget is not finished yet.
@@ -84,3 +52,18 @@ token it needs is set.
 Until that pull request merges, `.github/workflows/publish-winget.yml` fails on every
 release, because `wingetcreate update` has no previous version to read. That failure is
 visible and gates nothing.
+
+## Waiting on the first automated Store submission
+
+Also not work. The pipeline's Store stage has never run: 0.9.2 and 0.9.3 were submitted by
+hand, and the stage was written against the documented behaviour of the Microsoft Store
+Developer CLI rather than against a run of it. The first promoted release after this lands
+is the one that proves it.
+
+Watch two things on that run. The stage has to pick the MSIX out of `drop-x64-true`, since
+both matrix jobs pack an identically named package and only one of them is self-contained.
+And a submission already pending in Partner Center makes `msstore publish` fail by design —
+the stage does not delete someone else's in-flight submission to make room for its own.
+
+Nothing gates on it. The stage runs after the GitHub release exists, so a failure leaves
+every download in place and is visible as a failed stage.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -194,7 +194,7 @@ later touches no installer plumbing.
 
 ## 13. Microsoft Store is a later, separate piece of work
 
-**Implemented** for packaging and for the listing. Submission is still manual.
+**Implemented.**
 
 Three constraints shape it:
 
@@ -203,15 +203,28 @@ Three constraints shape it:
   followed (full-trust desktop package, file-type associations in the manifest).
 - Store version numbers must end in `.0`. The MSIX Identity Version is `VersionPrefix.0`,
   not the four-part assembly stamp the MSI uses.
-- Certification takes hours to days, so submission must run in parallel with the web
-  release and must never gate it.
+- Certification takes hours to days, so submission must never gate the web release. The
+  Store stage runs after Release rather than beside it: the GitHub release already exists
+  by the time it starts, so a failed or slow submission changes nothing that shipped, and
+  a build that was never promoted is never submitted.
 
 The first submission was manual, and was made on 20 August 2026 for 0.9.2: listing,
 screenshots, and age rating are one-time work no pipeline performs.
-`installer/msix/STORE-LISTING.md` records every field that was entered, which is what a
-later automated submission reproduces. Automating the upload was deliberately held until
-that first submission had succeeded, so an API failure could never be confused with an
+`installer/msix/STORE-LISTING.md` records every field that was entered, which is what the
+automated submission reproduces. Automating the upload was deliberately held until that
+first submission had succeeded, so an API failure could never be confused with an
 incomplete listing.
+
+Everything after it is the Store stage's job. It submits packages only — listing text,
+screenshots, and **What's new** carry over from the last published submission untouched.
+Changing them stays a deliberate act in Partner Center, recorded in `STORE-LISTING.md`, for
+the same reason the pipeline does not delete a pending submission to make room for its own:
+an in-flight submission may be a person's listing edit, and a pipeline must not discard it.
+
+The submission identity is not the signing one. The Partner Center account is associated
+with a different Microsoft Entra tenant than the one the pipeline signs in, so the two
+cannot be the same principal even if sharing one were desirable — which it is not, since a
+single leaked secret would then both sign as SQLBI and publish as SQLBI.
 
 ## 14. Bravo's telemetry was not ported
 

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -1,10 +1,7 @@
 # Development and release
 
 How the project is built, packaged, and shipped. The reasoning behind these choices is in
-[decisions.md](decisions.md).
-
-Sections marked **Not yet built** describe an agreed design that does not exist in the
-repository yet.
+[decisions.md](decisions.md). Everything described here is built and in use.
 
 ## What to run
 
@@ -21,7 +18,7 @@ itself. Do not run it to “release” anything.
 | Update whiteboard.sqlbi.com | Merge a change under `site/`. The **Publish site** Action deploys. To retry: Actions → **Publish site** → **Run workflow**. |
 | Rebuild brand assets | Run `scripts/build-assets.ps1` locally. Only when the artwork changes. |
 | Build a Store MSIX | `scripts/build-installer.ps1` already writes `SQLBI.Whiteboard.<version>.x64.msix`. To pack only: `scripts/build-msix.ps1`. Identity version is `VersionPrefix.0`. |
-| Submit to the Store | By hand in Partner Center, from the MSIX the release run produced. The listing exists (0.9.2, submitted 20 August 2026); `installer/msix/STORE-LISTING.md` is what to enter. The pipeline does not submit. |
+| Submit to the Store | Nothing. Approving the **Release** stage also runs the **Store** stage, which submits that run's MSIX. To skip it for one run, clear **Submit the released MSIX to the Microsoft Store** in **Run pipeline**. Listing text is still by hand: `installer/msix/STORE-LISTING.md`. |
 
 The three GitHub Actions live under **Actions** in this repository. Their names are
 **Pull request**, **Publish VS Code extension**, and **Publish site**. The signed
@@ -149,11 +146,20 @@ Parameters:
 | `verbosity` | `normal` | MSBuild verbosity |
 | `sign` | on | Code sign binaries and MSIs |
 
-Two variable groups must be authorized for the pipeline. Their contents stay in Azure
+Three variable groups must be authorized for the pipeline. Their contents stay in Azure
 DevOps, not in this repository:
 
 - **SQLBI-CodeSigning** — vault URL, tenant, client, secret, certificate name (decision 1).
 - **SQLBI.Whiteboard** — product settings. The version is not among them.
+- **SQLBI-StoreSubmission** — Partner Center tenant, client, secret, and seller id. Declared
+  on the Store stage rather than at pipeline level, so the build and signing stages cannot
+  read it.
+
+> **The Store tenant is not the signing tenant.** The Partner Center account is associated
+> with a different Microsoft Entra tenant than the one this pipeline signs in, so the two
+> credentials are different principals in different directories. That is also why every
+> variable in the Store group carries a `Store` prefix: two groups defining a bare
+> `TenantId` would collide, and Azure DevOps resolves a collision between groups silently.
 
 Signing uses `AzureSignTool` against the certificate in Azure Key Vault.
 
@@ -165,9 +171,8 @@ Signing uses `AzureSignTool` against the certificate in Azure Key Vault.
 Stages: **Build** produces every installer variant plus an unsigned released-channel
 MSIX, **PreRelease** publishes the pre-release channel to GitHub, **Release** is gated
 by approvals on the `whiteboard-release` environment and uploads the released-channel
-installers **that the same run already produced** (decision 9). The MSIX is an artifact
-the pipeline publishes but does not submit; uploading it to Partner Center is still a
-manual act.
+installers **that the same run already produced** (decision 9), and **Store** submits that
+run's MSIX to Partner Center.
 
 Creating a GitHub Release uses the `sql-bi write assets` service connection
 (`contents: write`).
@@ -194,9 +199,9 @@ The agreed shape, now in use for the pre-release path:
    prerelease.
 3. Promotion is an approval on the Release stage of **that** run. It publishes the
    already-built released-channel artifacts — nothing is rebuilt.
-4. The Store submission follows from the published release, by hand for now. winget
-   submission follows the same way once it exists. Neither gates the download being
-   available.
+4. The Store submission and the winget submission both follow from the published release,
+   the first as a pipeline stage and the second as a GitHub Action. Neither gates the
+   download being available.
 
 ### Release manifests
 
@@ -274,11 +279,44 @@ Locally, `wingetcreate` needs no token at all: run it without `--token` and it u
 browser OAuth flow, which is what its own documentation recommends, because a token on the
 command line ends up in shell history.
 
-### Still to build
+### Microsoft Store
 
-Automate Store submission from the published release (decision 13). The listing and the
-first submission were done by hand on 20 August 2026, which was the precondition;
-`installer/msix/STORE-LISTING.md` records what an automated submission must reproduce.
+The **Store** stage of the Azure pipeline submits the released MSIX to Partner Center. It
+depends on **Release**, so it runs only for a build that was actually promoted, and only
+after the GitHub release exists — by the time a submission can fail, every download is
+already published. Certification takes hours to days and gates nothing (decision 13).
+
+`UseMSStoreCLI@0` installs the [Microsoft Store Developer CLI][msstore]; `msstore
+reconfigure` authenticates with the `SQLBI-StoreSubmission` group, and `msstore publish`
+uploads the package against Store product `9NN5N0L2TMTF`. Credentials are passed through
+the environment rather than the command line, because the agent echoes a native command
+line and log masking is a safety net rather than a guarantee.
+
+[msstore]: https://learn.microsoft.com/windows/apps/publish/msstore-dev-cli/overview
+
+Three things about it are deliberate:
+
+- **It takes the MSIX from the `drop-x64-true` artifact by name.** Both matrix jobs pack a
+  released-channel MSIX and `build-msix.ps1` names them identically —
+  `SQLBI.Whiteboard.<version>.x64.msix` carries no flavour — so a recursive search of the
+  workspace could just as easily submit the framework-dependent package, which needs a .NET
+  runtime the Store cannot assume. Naming the artifact makes that unreachable, and the stage
+  fails rather than guessing if the count is not exactly one.
+- **It submits packages only.** Listing text, screenshots, and **What's new** carry over
+  from the last published submission untouched. Changing them is `msstore submission
+  updateMetadata` and stays a deliberate act in Partner Center, recorded in
+  `installer/msix/STORE-LISTING.md`.
+- **It does not clear a pending submission.** If one is already in flight `msstore publish`
+  fails, which is correct: that submission may be a person's listing edit, and a pipeline
+  must not discard it. Resolve it in Partner Center and re-run the stage.
+
+The first submission was manual, on 20 August 2026 for 0.9.2, because the listing,
+screenshots, and age rating are one-time work no API performs — and holding the automation
+until it had succeeded meant an API failure could never be confused with an incomplete
+listing. The same reasoning as winget, arrived at independently.
+
+Clearing **Submit the released MSIX to the Microsoft Store** in **Run pipeline** promotes a
+release without touching the Store.
 
 ### Verification before a public release
 

--- a/installer/msix/STORE-LISTING.md
+++ b/installer/msix/STORE-LISTING.md
@@ -45,6 +45,12 @@ trusting a copy-paste.
 A Store rejection reports Name, Publisher, and PFN as three separate errors.
 It is one problem: fix the first two and the rest follow.
 
+Three fields that look like the same name and are not: `PublisherDisplayName`
+is `SQLBI Corp` with no period, the copyright string elsewhere in the product
+is `SQLBI Corp.` with one, and the manifest `Publisher` is the Store identity
+`CN=<GUID>` rather than anything readable. Changing one to match another is a
+rejection.
+
 Partner Center validates the identity in the package you upload and rejects a
 mismatch. It does not rewrite your manifest — "associating" an app in Visual
 Studio rewrites a *local* manifest, which is the source of the opposite belief.
@@ -90,10 +96,14 @@ repeat.
    freely in Partner Center.
 
 Certification must never gate the MSI / GitHub release, which is why the
-submission is a separate act from the pipeline run that produced the package
-(decision 13). Automating it is the remaining work, tracked in TODO.md: the
-first submission had to be manual, and now that it has happened the pipeline
-has a listing to submit against.
+submission is a separate stage from the one that publishes the download
+(decision 13). That stage now exists: the pipeline submits the MSIX after a
+release is promoted, so nothing above repeats per version except a screenshot
+when the UI moves on.
+
+What it submits is packages only. Listing text, screenshots, and **What's new**
+carry over from the last published submission untouched, so this page stays the
+record of them and a change here means a change made by hand in Partner Center.
 
 ## Once the listing is live
 

--- a/installer/msix/STORE-LISTING.md
+++ b/installer/msix/STORE-LISTING.md
@@ -62,10 +62,11 @@ Partner Center does not show it on **Account settings > Identifiers**; that
 page carries the Windows publisher ID, which is the `CN=<GUID>` above. The
 dependable way to read it is to let the CLI resolve it - run `msstore
 reconfigure` without `--sellerId`, which retrieves it from the enrollment
-accounts API, then `msstore info` to print what it stored. The numeric prefix
-of the package identity name is built from the same value, so `17351SQLBICorp.…`
-and the Seller ID should agree; if they do not, the account is not the one you
-think it is.
+accounts API, then `msstore info` to print what it stored.
+
+The `17351` in the package identity name is **not** the Seller ID. Both are
+numbers Microsoft assigned to this account and it is tempting to read one as
+the other, but they do not match and neither can be derived from the other.
 
 Give the pipeline the number explicitly even though the argument is optional.
 When auto-retrieval fails the CLI falls through to an interactive prompt, which

--- a/installer/msix/STORE-LISTING.md
+++ b/installer/msix/STORE-LISTING.md
@@ -51,6 +51,16 @@ is `SQLBI Corp.` with one, and the manifest `Publisher` is the Store identity
 `CN=<GUID>` rather than anything readable. Changing one to match another is a
 rejection.
 
+A fourth identifier belongs to the account rather than the package, and is the
+one that gets confused with `Publisher`: the **Seller ID** is a plain number,
+shown under **Account settings > Identifiers**, and it is what the Store
+Developer CLI wants for `--sellerId`. Passing the `CN=<GUID>` publisher there
+fails inside the CLI with an unhandled `System.FormatException` from a numeric
+parse, which names neither the argument nor the expected shape. The numeric
+prefix of the package identity name is built from it, so `17351SQLBICorp.…`
+and the Seller ID should agree - if they do not, the account is not the one
+you think it is.
+
 Partner Center validates the identity in the package you upload and rejects a
 mismatch. It does not rewrite your manifest — "associating" an app in Visual
 Studio rewrites a *local* manifest, which is the source of the opposite belief.

--- a/installer/msix/STORE-LISTING.md
+++ b/installer/msix/STORE-LISTING.md
@@ -52,14 +52,24 @@ is `SQLBI Corp.` with one, and the manifest `Publisher` is the Store identity
 rejection.
 
 A fourth identifier belongs to the account rather than the package, and is the
-one that gets confused with `Publisher`: the **Seller ID** is a plain number,
-shown under **Account settings > Identifiers**, and it is what the Store
-Developer CLI wants for `--sellerId`. Passing the `CN=<GUID>` publisher there
+one that gets confused with `Publisher`: the **Seller ID**, which is what the
+Store Developer CLI wants for `--sellerId`. It is an `Int32` - a plain number,
+never a GUID and never a `CN=` string. Passing the publisher identity there
 fails inside the CLI with an unhandled `System.FormatException` from a numeric
-parse, which names neither the argument nor the expected shape. The numeric
-prefix of the package identity name is built from it, so `17351SQLBICorp.…`
-and the Seller ID should agree - if they do not, the account is not the one
-you think it is.
+parse that names neither the argument nor the expected shape.
+
+Partner Center does not show it on **Account settings > Identifiers**; that
+page carries the Windows publisher ID, which is the `CN=<GUID>` above. The
+dependable way to read it is to let the CLI resolve it - run `msstore
+reconfigure` without `--sellerId`, which retrieves it from the enrollment
+accounts API, then `msstore info` to print what it stored. The numeric prefix
+of the package identity name is built from the same value, so `17351SQLBICorp.…`
+and the Seller ID should agree; if they do not, the account is not the one you
+think it is.
+
+Give the pipeline the number explicitly even though the argument is optional.
+When auto-retrieval fails the CLI falls through to an interactive prompt, which
+on a build agent hangs the job instead of failing it.
 
 Partner Center validates the identity in the package you upload and rejects a
 mismatch. It does not rewrite your manifest — "associating" an app in Visual


### PR DESCRIPTION
Closes the last item in the release chain that still needed a person: promoting a
release now submits its MSIX to Partner Center.

## Why it sits where it does

The winget pattern could not be copied. `publish-winget.yml` works because it runs on
`release: published` and pulls MSIs off the GitHub release, but the MSIX never gets
there — `collect-release-assets.yml` gathers only `*.msi` and `*-portable.zip`, so the
package exists solely as the `drop-x64-true` pipeline artifact. Attaching it to the
release would publish an unsigned package carrying the Store identity, which nobody can
install by double-clicking; submitting from the pipeline keeps it where it already is,
alongside the credential.

The stage depends on `Release` rather than running beside it. Only a promoted build is
submitted, and by the time a submission can fail the GitHub release already exists, so
certification gates nothing (decision 13).

## Three deliberate choices

- **The MSIX comes from `drop-x64-true` by artifact name.** Both matrix jobs pack a
  released-channel MSIX and `build-msix.ps1` names them identically, with no flavour in
  the name, so a recursive search could just as easily submit the framework-dependent
  package — one that needs a .NET runtime the Store cannot assume. The stage fails rather
  than guessing if the count is not exactly one.
- **Packages only.** Listing text, screenshots, and What's new carry over from the last
  published submission untouched. Changing them stays a deliberate act in Partner Center,
  recorded in `STORE-LISTING.md`.
- **A pending submission makes it fail.** That submission may be a person's listing edit,
  and a pipeline must not discard it to make room for its own.

## Credential

`SQLBI-StoreSubmission` is declared on the stage, not at pipeline level, so the build and
signing stages cannot read it. Its tenant is not the signing tenant — the Partner Center
account is associated with a different Microsoft Entra tenant — which is also why every
variable in the group carries a `Store` prefix: two groups defining a bare `TenantId`
would collide, and Azure DevOps resolves a collision between groups silently.

## Before merging

The **Microsoft Store Developer CLI Tasks** extension must be installed in the Azure
DevOps organization. Task references resolve when the YAML compiles, before any stage
runs, so a missing extension fails the whole pipeline rather than just this stage.
Already installed on `sqlbi`.

## Verifying it

The stage has never run; it was written against the documented behaviour of the CLI.
Testing it needs a version the Store has not seen, since Release refuses to reuse an
existing tag — 0.9.4, in a separate bump PR. `TODO.md` records what to watch on that run.