### PR TITLE
Wait for a new release to appear before writing the manifests

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -56,11 +56,16 @@ jobs:
 
       # Generated into the checkout, so the manifests ship with the page in one
       # deployment. Both files are gitignored: this is the only thing that writes them.
+      # ExpectTag is empty for every trigger except a release, and that is the point: a
+      # release event fires seconds before the releases API lists the release, so without
+      # it this step reads the previous version and writes a stale manifest while
+      # reporting success. That happened to 0.9.5.
       - name: Generate the release manifests
         shell: pwsh
-        run: ./scripts/build-release-manifests.ps1 -Repository "$env:GITHUB_REPOSITORY" -OutputFolder site -Token "$env:GH_TOKEN"
+        run: ./scripts/build-release-manifests.ps1 -Repository "$env:GITHUB_REPOSITORY" -OutputFolder site -Token "$env:GH_TOKEN" -ExpectTag "$env:EXPECT_TAG"
         env:
           GH_TOKEN: ${{ github.token }}
+          EXPECT_TAG: ${{ github.event.release.tag_name }}
 
       - uses: actions/configure-pages@v5
 

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -238,6 +238,21 @@ A channel with no published release produces no file. The contract is that the f
 existing means a release exists, so a consumer that gets a 404 knows to fall back rather
 than having to interpret an empty manifest.
 
+Two properties of the releases API are easy to be caught by, and the script now handles
+both:
+
+- **It lags publication.** A release event fires seconds before the release appears in
+  `/releases`, so a run triggered by one can read a list that does not contain it yet and
+  write a manifest describing the *previous* version — while reporting success. The
+  workflow passes the tag being published as `-ExpectTag`, and the script waits for it to
+  appear rather than trusting the first answer. It fails after ten attempts instead of
+  writing a stale manifest, because a loud failure is recoverable and a quiet wrong answer
+  is not. 0.9.5 shipped with `stable.json` still on 0.9.4 for this reason.
+- **It does not order by publication.** The list is ordered by `created_at`, which for a
+  release is the date of the commit its tag points at, not the moment it was published — so
+  a pre-release built from a later commit sorts above a release promoted from an earlier
+  one. The script sorts on `published_at`, which is what "newest" has to mean here.
+
 The download page reads `stable.json` first and falls back to the API, so it makes no API
 call at all on an ordinary visit.
 

--- a/scripts/build-release-manifests.ps1
+++ b/scripts/build-release-manifests.ps1
@@ -33,12 +33,20 @@
 
 .PARAMETER Token
     Optional GitHub token. Only raises the API rate limit; the data read is public.
+
+.PARAMETER ExpectTag
+    Tag that must appear in the API response before the manifests are written. Set it when
+    a release has just been published: the releases API lags publication by seconds, so a
+    run triggered by the release event can otherwise read a list that does not contain it
+    yet and write a manifest describing the previous version - successfully, and silently.
+    Waiting is better than that, and failing is better than either.
 #>
 [CmdletBinding()]
 param(
     [string] $Repository = 'sql-bi/SQLBI-Whiteboard',
     [string] $OutputFolder = (Join-Path $PSScriptRoot '..' 'site'),
-    [string] $Token
+    [string] $Token,
+    [string] $ExpectTag
 )
 
 $ErrorActionPreference = 'Stop'
@@ -117,14 +125,37 @@ if ($Token) { $headers['Authorization'] = "Bearer $Token" }
 # the array of releases into a single object, and everything downstream then filters it
 # away and reports that nothing is published.
 $uri = "https://api.github.com/repos/$Repository/releases?per_page=50"
-try {
-    $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get
-}
-catch {
-    throw "Could not read releases from $uri - $($_.Exception.Message)"
-}
 
-$releases = @($response) | Where-Object { -not $_.draft }
+# The API does not return releases in publication order. It orders by created_at, which
+# for a release carries the date of the commit its tag points at, not the moment it was
+# published - so a pre-release built from a later commit sorts above a release promoted
+# from an earlier one. Sorting on published_at is what the word "newest" means here.
+$releases = $null
+for ($attempt = 1; $attempt -le 10; $attempt++) {
+    try {
+        $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method Get
+    }
+    catch {
+        throw "Could not read releases from $uri - $($_.Exception.Message)"
+    }
+
+    $releases = @($response) |
+        Where-Object { -not $_.draft } |
+        Sort-Object -Property @{ Expression = { [datetime]$_.published_at } } -Descending
+
+    if (-not $ExpectTag) { break }
+    if (@($releases | Where-Object { $_.tag_name -eq $ExpectTag }).Count -gt 0) {
+        Write-Host "$ExpectTag is visible in the releases API."
+        break
+    }
+
+    if ($attempt -eq 10) {
+        throw "$ExpectTag has not appeared in $uri after $attempt attempts. Refusing to write manifests that would describe an older release as the newest one."
+    }
+
+    Write-Host "$ExpectTag is not in the releases API yet. Waiting (attempt $attempt)."
+    Start-Sleep -Seconds 15
+}
 
 # Select-Object rather than [0]: indexing an empty result throws under Set-StrictMode,
 # and a channel with nothing published is an ordinary state, not an error.


### PR DESCRIPTION
`v0.9.5` was published at 06:23:40. The **Publish site** run it triggered started at
06:23:42 and succeeded — writing a `stable.json` that said 0.9.4.

The releases API lags publication by seconds. The script takes the newest non-prerelease
from `/releases`, got the previous one, and reported success. The site offered 0.9.4 and
the in-app update check agreed with it, which is the same user-visible damage as the tag
rule in #53 arriving by a different route.

`dev.json` was correct only because the pre-release had eighteen minutes of lead time
before its own run.

## The fix

The workflow passes the tag being published as `-ExpectTag`; the script polls until that
tag appears, and **fails after ten attempts rather than writing a manifest it knows is
stale**. A loud failure is recoverable; a quiet wrong answer is what cost us a release.
The tag is empty for push and manual runs, so those paths are unchanged.

## A latent bug found alongside it

The same fetch now sorts on `published_at`. The API orders by `created_at`, which for a
release carries the date of the commit its tag points at — not when it was published. It is
already observable: `v0.9.4-dev.3244` (created 20:32) sorts above `v0.9.4` (created 19:43).
Today's filters hide it, since the channels are separated before anything is picked. It
stops being hidden the first time an older commit is promoted after a newer one has already
been released.

## Verified

Ran the script three ways against the live API: with `-ExpectTag v0.9.5` (found, proceeds),
with an empty tag (unchanged behaviour), and confirmed both manifests select correctly with
the new sort. The site has already been redeployed manually, so
`whiteboard.sqlbi.com/stable.json` now reports 0.9.5.