### PR TITLE
Link the Store listing from the download page

### DIFF
--- a/installer/msix/STORE-LISTING.md
+++ b/installer/msix/STORE-LISTING.md
@@ -126,18 +126,23 @@ What it submits is packages only. Listing text, screenshots, and **What's new**
 carry over from the last published submission untouched, so this page stays the
 record of them and a change here means a change made by hand in Partner Center.
 
-## Once the listing is live
+## The listing is live
 
-The Store ID gives the public addresses. Both 404 until certification
-completes and the listing is published, so nothing links to them yet:
+0.9.5 completed certification and is published. The Store ID gives the public
+addresses:
 
 - `https://apps.microsoft.com/detail/9NN5N0L2TMTF`
 - `ms-windows-store://pdp/?ProductId=9NN5N0L2TMTF` (opens the Store app)
 
-Then, and not before, the Store becomes a second route on
-`whiteboard.sqlbi.com`. It stays second: Store availability is uneven on
-managed corporate machines, which is why the MSI is the primary channel
-(decision 10).
+`whiteboard.sqlbi.com` links to the first of those from the alternates under the
+download button. It stays an alternate rather than the headline: Store
+availability is uneven on managed corporate machines, which is why the MSI is
+the primary channel (decision 10). The `ms-windows-store:` form is recorded
+here but not linked from the site, because it fails silently in a browser that
+has no Store app to hand it to.
+
+Store installs update through the Store and never make the daily version check,
+which is what the site and `privacy.html` already say about them.
 
 ## The listing page, field by field (0.9.2)
 

--- a/site/index.html
+++ b/site/index.html
@@ -55,6 +55,8 @@
         </div>
         <p class="meta" id="meta"></p>
         <p class="alternates">
+          <a href="https://apps.microsoft.com/detail/9NN5N0L2TMTF">Microsoft Store, updates automatically</a>
+          <span class="sep">&middot;</span>
           <a id="user-installer" href="https://github.com/sql-bi/SQLBI-Whiteboard/releases">Per-user installer, no elevation</a>
           <span class="sep">&middot;</span>
           <a id="portable" href="https://github.com/sql-bi/SQLBI-Whiteboard/releases">Portable ZIP, no install</a>


### PR DESCRIPTION
0.9.5 completed certification and is published, so
[apps.microsoft.com/detail/9NN5N0L2TMTF](https://apps.microsoft.com/detail/9NN5N0L2TMTF)
resolves — verified, it redirects to the localized listing and returns 200.

## Where the link goes, and why not higher

It joins the alternates under the download button, not the button itself. Store availability
is uneven on managed corporate machines, which is why the MSI stays the primary channel
(decision 10) — the same reasoning `STORE-LISTING.md` recorded in advance for this moment.

The label says what the Store route offers that the MSI does not: the Store updates the app,
and a Store install never makes the daily version check that `privacy.html` describes.

## One layout note

The alternates row wraps to two lines on desktop now. Measured in a browser: **any** fourth
entry wraps it, including a bare "Microsoft Store", so the informative label costs nothing
over a terse one. On mobile the row already stacks into a column; it becomes four rows
instead of three, with no horizontal overflow at 375px.

## Documentation

`STORE-LISTING.md` said both Store addresses 404 and that nothing links to them. Both
stopped being true today. It now records that the `ms-windows-store:` form is deliberately
*not* linked from the site, since it fails silently in a browser with no Store app to hand
it to — worth stating so the next reader does not add it as an improvement.