### PR TITLE
Scope the launch caption to the Whiteboard app

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -74,7 +74,7 @@
            cannot render SVG. -->
       <img class="launch" src="hero-launch.svg" width="1200" height="1000"
            alt="Microsoft is retiring its Whiteboard app on 14 September 2026. SQLBI Whiteboard, shown in its real window: a captured Power BI matrix with highlighter marks, a DAX measure, and red pen annotations.">
-      <figcaption class="launch-caption">Microsoft <a href="https://support.microsoft.com/en-us/whiteboard/migration-of-whiteboards-from-azure-to-onedrive">retires its Whiteboard on 14 September 2026</a>.<br>This is what we drew instead.</figcaption>
+      <figcaption class="launch-caption">Microsoft <a href="https://support.microsoft.com/en-us/whiteboard/migration-of-whiteboards-from-azure-to-onedrive">retires its Whiteboard app on 14 September 2026</a>.<br>This is what we drew instead.</figcaption>
     </figure>
 
     <section class="teaser" aria-label="Product teaser">


### PR DESCRIPTION
Whiteboard survives in Teams and on the web; only the standalone app retires on September 14, 2026. The image alt text, compare.html, and the hero artwork all already say "Whiteboard app" — the home-page caption was the one public claim missing the scoping, and it sits on the page every campaign link points to. One word added, per the citing rules in `docs/retirement/README.md` (#66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)