### PR TITLE
Loop the teaser

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -323,11 +323,19 @@ has nothing to adapt between, and the site collects no analytics anyway.
 
 The two renditions and the poster live in `site/` (`teaser-av1.mp4`, `teaser-h264.mp4`,
 `teaser-poster.jpg`) and deploy with every site publish. The `<video>` element lists AV1
-first and H.264 as the universal fallback, is click-to-play (`preload="metadata"`), and
-costs page load only the poster. The 4K Camtasia master is kept outside the repository;
-re-encoding is two ffmpeg commands recorded in `docs/teaser/shot-script.md`. GitHub
-Pages' soft bandwidth limit is ~100 GB/month; only visitors who press play download a
-rendition, so the limit is far away at this site's traffic.
+first and H.264 as the universal fallback, and plays automatically — muted, looping,
+with controls kept visible — because the ink only reads in motion. A visitor whose
+system asks for reduced motion gets the poster and a play button instead: a small
+script removes the autoplay. A YouTube `nocookie` embed was considered for the loop and
+rejected — its privacy-enhanced mode only defers cookies until playback, which an
+autoplaying loop triggers on page load for everyone.
+
+The 4K Camtasia master is kept outside the repository; re-encoding is two ffmpeg
+commands recorded in `docs/teaser/shot-script.md`. Autoplay means every home-page visit
+downloads a rendition (about 3 MB), so GitHub Pages' ~100 GB/month soft bandwidth limit
+maps to roughly 30,000 visits a month — far beyond this site's traffic, and GitHub has
+no bandwidth meter to watch anyway. If a launch ever approaches that, the escape hatch
+is a lighter loop rendition or a caching proxy in front of the domain, not an embed.
 
 ---
 

--- a/site/index.html
+++ b/site/index.html
@@ -81,7 +81,7 @@
       <div class="teaser-frame">
         <!-- Served from this site: no third party, and it plays where embeds are
              blocked. Decision 19 in docs/decisions.md. -->
-        <video controls playsinline preload="metadata"
+        <video controls autoplay muted loop playsinline
                poster="teaser-poster.jpg"
                title="SQLBI Whiteboard, forty seconds">
           <source src="teaser-av1.mp4" type='video/mp4; codecs="av01.0.12M.08"'>
@@ -306,6 +306,18 @@
     fromManifest().catch(function () {
       return fromApi().catch(function () {});
     });
+  })();
+</script>
+<script>
+  // The teaser loop is motion the visitor did not ask for. Stop it for those
+  // who asked their system for less; the poster and controls remain.
+  (function () {
+    if (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches) { return; }
+    var teaser = document.querySelector('.teaser video');
+    if (teaser) {
+      teaser.removeAttribute('autoplay');
+      teaser.pause();
+    }
   })();
 </script>
 </body>


### PR DESCRIPTION
Internal discussion concluded the teaser should always be running: the ink only reads in motion, and a poster frame sells a still image. The video element now autoplays muted in a loop. Controls stay visible so the loop remains pausable, and a small script removes the autoplay for visitors whose system asks for reduced motion — they get the poster and a play button.

A YouTube nocookie embed was considered for this and rejected: privacy-enhanced mode only defers cookies until playback, and an autoplaying loop triggers playback on page load for every visitor, so the no-cookie claim would not survive. It would also reintroduce the region-blocking and third-party problems decision 19 removed.

The cost that changes is bandwidth: every home-page visit now downloads a rendition (~3 MB), which puts GitHub Pages'' ~100 GB/month soft limit at roughly 30,000 visits a month. Decision 19 is amended with the loop, the rejection reasoning, and the escape hatch if traffic ever gets there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)