### PR TITLE
Accept SVG as an image, and keep it vector

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ How the project is developed and shipped is documented separately:
 - Basic palm rejection: touch navigation is suspended when the pen makes contact
 - Mouse-wheel zoom and middle-button or temporary Space-key panning
 - Whole-stroke erasing
-- PNG, JPEG, BMP, and GIF import, clipboard bitmap paste, and Explorer drag-and-drop of images, text files, and `.wimport` recipes
+- PNG, JPEG, BMP, GIF, and SVG import, clipboard bitmap paste, and Explorer drag-and-drop of images, text files, and `.wimport` recipes
+- SVG stays vector: it is stored as its markup and redrawn at every zoom and resize rather than rasterized on arrival. Pasting SVG markup that was copied as text — the output of a DAX SVG measure, for instance — creates a picture, and copying an SVG container puts both the markup and a bitmap on the clipboard
 - Image selection, movement, resizing, and deletion
 - Text containers created by pasting plain text, with display and in-place edit modes
 - Plain-text, DAX, and SQL Server language modes, with live syntax highlighting and local F6 formatting

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -358,6 +358,32 @@ version its first submission settles on.
 
 ---
 
+## 21. SVG is kept as markup and drawn by SharpVectors
+
+**Implemented.**
+
+WPF has no SVG decoder, so supporting SVG at all meant taking a rendering library —
+including the option of rasterizing on arrival, which needs one just the same. That made
+the choice about which library, not whether to have one.
+
+`SharpVectors.Wpf` produces a `DrawingGroup`, so an SVG container is redrawn at whatever
+size it is displayed at rather than stretched from pixels. That is the point of accepting
+SVG on a canvas whose zoom is unbounded. It is BSD-3, managed-only, and ships no native
+binary, which keeps it out of the signing step and out of the per-architecture question
+the installer would otherwise have to answer. Direct2D was the tempting alternative, since
+`Vortice` is already referenced and would have cost nothing: it implements a restricted
+SVG subset with no `<text>` element, which is most of what a DAX SVG measure emits.
+
+Assets are stored as the bytes that arrived, and `BoardArchive` has always treated them as
+opaque, so the format version did not move. A board holding an SVG opened in 1.0.3 draws
+the missing-image placeholder for it rather than failing to open.
+
+The renderer is given `ExternalResourcesAccessModes.Ignore`. Its default is to fetch what
+the markup names, which would let a pasted or dropped file turn opening a board into an
+outbound request.
+
+---
+
 ## Open questions
 
 - arm64 is not built; add it if Surface devices matter for a pen application.

--- a/docs/samples/contoso-workshop.wimport
+++ b/docs/samples/contoso-workshop.wimport
@@ -17,6 +17,9 @@ Total Sales := SUM(Sales[Amount])
 ## Test picture
 ![demo](../../src/SQLBI.Whiteboard/Assets/SQLBI.Whiteboard.png)
 
+## Test vector
+![the same mark, as SVG](../../src/SQLBI.Whiteboard/Assets/SQLBI.Whiteboard.svg)
+
 ## Warehouse query
 ```sql
 SELECT TOP (10)

--- a/docs/wimport.md
+++ b/docs/wimport.md
@@ -46,7 +46,10 @@ ignored.
    - Image container.
    - Title is the `##` heading. If the heading is empty, the alt text is used, then the file
      name.
-   - Allowed extensions: `.png`, `.jpg`, `.jpeg`, `.bmp`, `.gif`.
+   - Allowed extensions: `.png`, `.jpg`, `.jpeg`, `.bmp`, `.gif`, `.svg`.
+   - An `.svg` stays vector on the board. Whiteboard sizes it from the `width`/`height` or
+     the `viewBox`, so give the file one; and anything the markup fetches from elsewhere —
+     an external stylesheet, an `<image href>` pointing outside the file — is ignored.
 2. **Fenced code** whose info-string is a registered language
    - Text container. Contents of the fence. Language from the tag.
 3. **Markdown link** to an image extension — `[label](relative/path.png)`
@@ -131,7 +134,7 @@ A complete sample is `docs/samples/contoso-workshop.wimport`.
 - File name ends in `.wimport`.
 - Every container is a `##` heading with exactly one payload.
 - Images and linked code exist next to the file, using relative paths.
-- Image files are png/jpeg/bmp/gif. Code files you link are `.dax` or `.sql`, or the code is
+- Image files are png/jpeg/bmp/gif/svg. Code files you link are `.dax` or `.sql`, or the code is
   embedded in a `dax` / `sql` / `tsql` fence.
 - Row breaks are a thematic break on its own line, not a fake heading.
 - You did not use `http://`, YAML, or explicit positions.
@@ -141,7 +144,8 @@ A complete sample is `docs/samples/contoso-workshop.wimport`.
 
 - Write a `.md` and expect Whiteboard to import it.
 - Ask Whiteboard to save or export `.wimport`.
-- Embed bitmap bytes. Images are always a link to a file.
+- Embed bitmap bytes, or paste SVG markup into the document. Images are always a link to a
+  file, whatever their format.
 - Mix two payloads in one `##` section.
 - Use HTML, YAML front matter, or custom XML.
 - Reference network URLs.

--- a/installer/msix/STORE-LISTING.md
+++ b/installer/msix/STORE-LISTING.md
@@ -178,7 +178,7 @@ Live application capture — put any window or display on the board with LiveVie
 
 Code containers — paste DAX or T-SQL and get syntax highlighting, a language-aware title, and F6 to format the code in place. Plain text works the same way.
 
-Images and text — import PNG, JPEG, BMP, and GIF, paste from the clipboard, or drag files in from File Explorer. Ink that touches a container travels with it when you move or resize it.
+Images and text — import PNG, JPEG, BMP, GIF, and SVG, paste from the clipboard, or drag files in from File Explorer. SVG stays vector, so it is still sharp when you enlarge it. Ink that touches a container travels with it when you move or resize it.
 
 Portable board files — boards save as .wboard files with an embedded preview, so File Explorer and Visual Studio Code both show what is inside.
 

--- a/installer/winget/SQLBI.Whiteboard.locale.en-US.yaml
+++ b/installer/winget/SQLBI.Whiteboard.locale.en-US.yaml
@@ -29,7 +29,7 @@ Description: |-
 
   Code containers: paste SQL or DAX and get syntax highlighting, a language-aware title, and F6 to format the code in place. Plain text works the same way.
 
-  Images and text: import PNG, JPEG, BMP, and GIF, paste from the clipboard, or drag files in from File Explorer. Ink that touches a container travels with it when you move or resize it.
+  Images and text: import PNG, JPEG, BMP, GIF, and SVG, paste from the clipboard, or drag files in from File Explorer. Ink that touches a container travels with it when you move or resize it.
 
   Portable board files: boards save as .wboard files with an embedded preview, so File Explorer and Visual Studio Code both show what is inside.
 

--- a/site/guide.html
+++ b/site/guide.html
@@ -686,11 +686,12 @@
     <p>The window can sit in a narrow strip beside another app. <kbd>F11</kbd> fills the monitor and hides the title and tabs. <kbd>Ctrl</kbd><span class="plus">+</span><kbd>F11</kbd> hides the same chrome and keeps the window where it is. <kbd>Escape</kbd> leaves either unless a text container is being edited.</p>
 
     <h3>Containers</h3>
-    <p>Images, LiveViews, and text blocks are containers. With a mouse, click to move, drag the circular handle to resize while keeping aspect ratio. Releasing the mouse returns to the drawing tool you had. Imported images accept PNG, JPEG, BMP, and GIF, including clipboard paste and Explorer drag-and-drop.</p>
+    <p>Images, LiveViews, and text blocks are containers. With a mouse, click to move, drag the circular handle to resize while keeping aspect ratio. Releasing the mouse returns to the drawing tool you had. Imported images accept PNG, JPEG, BMP, GIF, and SVG, including clipboard paste and Explorer drag-and-drop. An SVG is kept as its markup and redrawn at every size, so enlarging one costs it nothing.</p>
     <p><span class="ui">View → Bring to front</span> and <span class="ui">View → Send to back</span> reorder the selected container and its linked strokes. Strokes cannot be reordered on their own.</p>
 
     <h3>Text, SQL, and DAX</h3>
     <p>Paste prefers an image when the clipboard has one, including a file SnagIt or another capture tool left on the clipboard. Paste plain text to create a selected text container.</p>
+    <p>SVG counts as an image, whether the source application published it as SVG or the markup was simply copied as text — the output of a DAX SVG measure pastes as a picture, not as a snippet. Copying an SVG container puts the markup and a bitmap on the clipboard together, so an editor receives the source and a slide receives the picture.</p>
     <p><span class="ui">Help → Preferences</span> sets Snippet format order: paste tries those languages from top to bottom. Plain text always matches, so putting it first keeps paste as plain text. Use the title-bar chip to choose Plain text, SQL Server, or DAX afterward.</p>
     <p><kbd>F6</kbd> formats SQL or DAX on the selected container, without entering edit mode. <kbd>F2</kbd> edits the container, and double-click still centers it and fits it to the canvas; inside an edit <kbd>F6</kbd> formats in place and <kbd>Ctrl</kbd><span class="plus">+</span><kbd>Enter</kbd> commits that format with the rest of the edit. SQL Server mode targets SQL Server 2025 T-SQL, keeps <code>GO</code> batch separators, and leaves an invalid script unchanged. <kbd>Escape</kbd> restores the previous text, language, and size.</p>
 

--- a/site/wimport.html
+++ b/site/wimport.html
@@ -72,7 +72,7 @@
     <h2>How the body becomes a container</h2>
     <p>Recognizers run in this order. The first match wins. Extra material after the match is ignored.</p>
     <ol>
-      <li><strong>Markdown image</strong>: <code>![optional alt](relative/path.png)</code>. Image container. Title is the <code>##</code> heading, then the alt text, then the file name. Allowed extensions: <code>.png</code>, <code>.jpg</code>, <code>.jpeg</code>, <code>.bmp</code>, <code>.gif</code>.</li>
+      <li><strong>Markdown image</strong>: <code>![optional alt](relative/path.png)</code>. Image container. Title is the <code>##</code> heading, then the alt text, then the file name. Allowed extensions: <code>.png</code>, <code>.jpg</code>, <code>.jpeg</code>, <code>.bmp</code>, <code>.gif</code>, <code>.svg</code>. An <code>.svg</code> stays vector on the board, so give it a <code>width</code>/<code>height</code> or a <code>viewBox</code> to be sized from; anything it fetches from elsewhere is ignored.</li>
       <li><strong>Fenced code</strong> whose info-string is a registered language. Text container. Contents of the fence. Language from the tag.</li>
       <li><strong>Markdown link</strong> to an image extension: same as an image.</li>
       <li><strong>Markdown link</strong> to a registered language extension: <code>[label](relative/path.dax)</code>. Text container. File contents. Language from the extension.</li>
@@ -134,7 +134,7 @@ Total Sales := SUM(Sales[Amount])
       <li>File name ends in <code>.wimport</code>.</li>
       <li>Every container is a <code>##</code> heading with exactly one payload.</li>
       <li>Images and linked code exist next to the file, using relative paths.</li>
-      <li>Image files are png/jpeg/bmp/gif. Linked code files are <code>.dax</code> or <code>.sql</code>, or the code is embedded in a <code>dax</code> / <code>sql</code> / <code>tsql</code> fence.</li>
+      <li>Image files are png/jpeg/bmp/gif/svg. Linked code files are <code>.dax</code> or <code>.sql</code>, or the code is embedded in a <code>dax</code> / <code>sql</code> / <code>tsql</code> fence.</li>
       <li>Row breaks are a thematic break on its own line, not a fake heading.</li>
       <li>You did not use <code>http://</code>, YAML, or explicit positions.</li>
       <li>Opening the file in a Markdown preview still reads as a normal document.</li>

--- a/src/SQLBI.Whiteboard.Core/Import/DroppedFileImport.cs
+++ b/src/SQLBI.Whiteboard.Core/Import/DroppedFileImport.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace SQLBI.Whiteboard.Core.Import;
 
 public enum DroppedFileKind
@@ -11,7 +13,12 @@ public enum DroppedFileKind
 public static class DroppedFileImport
 {
     public const int MaximumTextBytes = 1_000_000;
+    public const int MaximumSvgBytes = 16_000_000;
     public const string ImportExtension = ".wimport";
+    public const string SvgExtension = ".svg";
+    public const string SvgContentType = "image/svg+xml";
+
+    private const char ByteOrderMark = '\uFEFF';
 
     private static readonly HashSet<string> PlainTextExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -99,6 +106,113 @@ public static class DroppedFileImport
             }
         }
 
+        return true;
+    }
+
+    /// <summary>
+    /// Recognizes an SVG document from its markup. Clipboard content arrives without a
+    /// file name, so the shape of the text is the only signal there is. The root element
+    /// has to be the SVG one — a page of HTML with a picture inside it carries the same
+    /// tags and is not an image.
+    /// </summary>
+    public static bool LooksLikeSvg(string? markup)
+    {
+        if (string.IsNullOrWhiteSpace(markup))
+        {
+            return false;
+        }
+
+        var text = markup.TrimStart(ByteOrderMark).TrimStart();
+        while (TryMeasurePrologue(text, out var prologue))
+        {
+            text = text[prologue..].TrimStart();
+        }
+
+        if (text.Length < 2 || text[0] != '<')
+        {
+            return false;
+        }
+
+        var end = 1;
+        while (end < text.Length &&
+               !char.IsWhiteSpace(text[end]) &&
+               text[end] is not ('>' or '/'))
+        {
+            end++;
+        }
+
+        if (end == text.Length)
+        {
+            return false;
+        }
+
+        // Any prefix may be bound to the SVG namespace, so compare the local name.
+        var name = text[1..end];
+        var colon = name.LastIndexOf(':');
+        return string.Equals(
+            colon >= 0 ? name[(colon + 1)..] : name,
+            "svg",
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool LooksLikeSvg(byte[]? bytes)
+    {
+        if (bytes is null || bytes.Length is 0 or > MaximumSvgBytes)
+        {
+            return false;
+        }
+
+        // Bitmaps fail on their first byte, so the decode below only runs for markup.
+        var start = bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF
+            ? 3
+            : 0;
+        while (start < bytes.Length && bytes[start] is 0x20 or 0x09 or 0x0D or 0x0A)
+        {
+            start++;
+        }
+
+        if (start >= bytes.Length || bytes[start] != (byte)'<')
+        {
+            return false;
+        }
+
+        try
+        {
+            return LooksLikeSvg(new UTF8Encoding(false, throwOnInvalidBytes: true)
+                .GetString(bytes, start, bytes.Length - start));
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Measures an XML declaration, comment, or doctype sitting ahead of the root element.
+    /// </summary>
+    private static bool TryMeasurePrologue(string text, out int length)
+    {
+        length = 0;
+        var (opening, closing) = text switch
+        {
+            _ when text.StartsWith("<?", StringComparison.Ordinal) => ("<?", "?>"),
+            _ when text.StartsWith("<!--", StringComparison.Ordinal) => ("<!--", "-->"),
+            _ when text.StartsWith("<!", StringComparison.Ordinal) => ("<!", ">"),
+            _ => (string.Empty, string.Empty),
+        };
+
+        if (opening.Length == 0)
+        {
+            return false;
+        }
+
+        var end = text.IndexOf(closing, opening.Length, StringComparison.Ordinal);
+        if (end < 0)
+        {
+            return false;
+        }
+
+        length = end + closing.Length;
         return true;
     }
 }

--- a/src/SQLBI.Whiteboard.Core/Import/ImportCatalog.cs
+++ b/src/SQLBI.Whiteboard.Core/Import/ImportCatalog.cs
@@ -28,7 +28,7 @@ public sealed class ImportCatalog
                 Extensions = [".sql"],
             },
         ],
-        [".png", ".jpg", ".jpeg", ".bmp", ".gif"]);
+        [".png", ".jpg", ".jpeg", ".bmp", ".gif", ".svg"]);
 
     public ImportCatalog(
         IReadOnlyList<ImportLanguage> languages,

--- a/src/SQLBI.Whiteboard.Core/Import/ImportLayout.cs
+++ b/src/SQLBI.Whiteboard.Core/Import/ImportLayout.cs
@@ -8,6 +8,7 @@ public static class ImportLayout
     public const double Gap = 32;
     public const double MaxImageWidth = 900;
     public const double MaxImageHeight = 700;
+    public const double MinVectorImageEdge = 240;
 
     public static IReadOnlyList<RectD> Place(
         IReadOnlyList<(double Width, double Height, bool StartNewRow)> items,
@@ -49,5 +50,18 @@ public static class ImportLayout
         var height = Math.Max(1, naturalHeight);
         var scale = Math.Min(1, Math.Min(MaxImageWidth / width, MaxImageHeight / height));
         return (width * scale, height * scale);
+    }
+
+    /// <summary>
+    /// Sizes a vector image. Icons are authored at 16 or 24 units and would arrive as a
+    /// speck on a board whose rows are 2400 wide, so a vector is grown to a legible edge
+    /// first. Enlarging costs a bitmap its sharpness and a vector nothing.
+    /// </summary>
+    public static (double Width, double Height) VectorImageSize(double naturalWidth, double naturalHeight)
+    {
+        var width = Math.Max(1, naturalWidth);
+        var height = Math.Max(1, naturalHeight);
+        var grow = Math.Max(1, MinVectorImageEdge / Math.Max(width, height));
+        return ImageSize(width * grow, height * grow);
     }
 }

--- a/src/SQLBI.Whiteboard/BoardImageCodec.cs
+++ b/src/SQLBI.Whiteboard/BoardImageCodec.cs
@@ -1,0 +1,84 @@
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using SQLBI.Whiteboard.Core.Geometry;
+using SQLBI.Whiteboard.Core.Import;
+
+namespace SQLBI.Whiteboard;
+
+/// <summary>
+/// A decoded image asset. <see cref="IsVector"/> decides how it is sized on arrival and
+/// whether the clipboard can be handed the markup as well as a picture.
+/// </summary>
+internal readonly record struct BoardImage(
+    ImageSource Source,
+    double NaturalWidth,
+    double NaturalHeight,
+    bool IsVector);
+
+/// <summary>
+/// The one place an asset's bytes become something drawable. Assets are stored as they
+/// arrived and carry a content type, but boards written before SVG support have none, so
+/// the bytes themselves decide which decoder runs.
+/// </summary>
+internal static class BoardImageCodec
+{
+    public static BoardImage Decode(byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        if (DroppedFileImport.LooksLikeSvg(bytes))
+        {
+            var drawing = SvgImageCodec.Decode(bytes);
+            var bounds = drawing.Drawing?.Bounds ?? Rect.Empty;
+            return new BoardImage(
+                drawing,
+                Math.Max(1, bounds.Width),
+                Math.Max(1, bounds.Height),
+                IsVector: true);
+        }
+
+        var bitmap = WpfImageCodec.Decode(bytes);
+        return new BoardImage(
+            bitmap,
+            Math.Max(1, bitmap.PixelWidth),
+            Math.Max(1, bitmap.PixelHeight),
+            IsVector: false);
+    }
+
+    /// <summary>
+    /// The size a newly arrived image takes on the board.
+    /// </summary>
+    public static (double Width, double Height) ArrivalSize(BoardImage image) => image.IsVector
+        ? ImportLayout.VectorImageSize(image.NaturalWidth, image.NaturalHeight)
+        : ImportLayout.ImageSize(image.NaturalWidth, image.NaturalHeight);
+
+    /// <summary>
+    /// Flattens an image to pixels for the clipboard, which cannot carry a WPF drawing.
+    /// A vector is rendered at whichever is larger of the size it is shown at and its
+    /// natural size, so the copy is never coarser than either.
+    /// </summary>
+    public static BitmapSource Rasterize(BoardImage image, RectD? shownAs = null)
+    {
+        if (image.Source is BitmapSource bitmap)
+        {
+            return bitmap;
+        }
+
+        var scale = shownAs is { } bounds
+            ? Math.Max(1, bounds.Width / image.NaturalWidth)
+            : 1;
+        var width = (int)Math.Clamp(Math.Round(image.NaturalWidth * scale), 1, 8192);
+        var height = (int)Math.Clamp(Math.Round(image.NaturalHeight * scale), 1, 8192);
+        var visual = new DrawingVisual();
+        using (var context = visual.RenderOpen())
+        {
+            context.DrawImage(image.Source, new Rect(0, 0, width, height));
+        }
+
+        var target = new RenderTargetBitmap(width, height, 96, 96, PixelFormats.Pbgra32);
+        target.Render(visual);
+        target.Freeze();
+        return target;
+    }
+}

--- a/src/SQLBI.Whiteboard/BoardSurface.cs
+++ b/src/SQLBI.Whiteboard/BoardSurface.cs
@@ -2,7 +2,6 @@ using System.Windows;
 using System.Windows.Ink;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using SQLBI.Whiteboard.Core.Geometry;
 using SQLBI.Whiteboard.Core.Model;
 using SQLBI.Whiteboard.Core.Viewport;
@@ -17,7 +16,7 @@ internal sealed class BoardSurface : FrameworkElement
     private static readonly Brush MissingImageBrush = CreateFrozenBrush(0xFFE5E7EB);
     private static readonly Pen MissingImagePen = CreateFrozenPen(0xFF9CA3AF, 1);
 
-    private readonly Dictionary<string, BitmapSource> _bitmapCache = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, ImageSource> _imageCache = new(StringComparer.Ordinal);
     private BoardDocument? _document;
     private Camera2D? _camera;
 
@@ -33,13 +32,13 @@ internal sealed class BoardSurface : FrameworkElement
     {
         _document = document;
         _camera = camera;
-        _bitmapCache.Clear();
+        _imageCache.Clear();
         InvalidateVisual();
     }
 
     public void InvalidateAssets()
     {
-        _bitmapCache.Clear();
+        _imageCache.Clear();
         InvalidateVisual();
     }
 
@@ -129,9 +128,9 @@ internal sealed class BoardSurface : FrameworkElement
             Math.Max(1, bottomRight.X - topLeft.X),
             Math.Max(1, bottomRight.Y - topLeft.Y));
 
-        if (TryGetBitmap(image.AssetId, document, out var bitmap))
+        if (TryGetImage(image.AssetId, document, out var source))
         {
-            drawingContext.DrawImage(bitmap, destination);
+            drawingContext.DrawImage(source, destination);
         }
         else
         {
@@ -149,7 +148,7 @@ internal sealed class BoardSurface : FrameworkElement
         ImageSource? source = LiveViewImageSourceProvider?.Invoke(liveView.Id);
         if (source is null &&
             liveView.SnapshotAssetId is { } assetId &&
-            TryGetBitmap(assetId, document, out BitmapSource? snapshot))
+            TryGetImage(assetId, document, out ImageSource? snapshot))
         {
             source = snapshot;
         }
@@ -190,31 +189,31 @@ internal sealed class BoardSurface : FrameworkElement
             : 0;
     }
 
-    private bool TryGetBitmap(
+    private bool TryGetImage(
         string assetId,
         BoardDocument document,
-        out BitmapSource? bitmap)
+        out ImageSource? image)
     {
-        if (_bitmapCache.TryGetValue(assetId, out bitmap))
+        if (_imageCache.TryGetValue(assetId, out image))
         {
             return true;
         }
 
         if (!document.Assets.TryGetValue(assetId, out var asset))
         {
-            bitmap = null;
+            image = null;
             return false;
         }
 
         try
         {
-            bitmap = WpfImageCodec.Decode(asset.Data);
-            _bitmapCache[assetId] = bitmap;
+            image = BoardImageCodec.Decode(asset.Data).Source;
+            _imageCache[assetId] = image;
             return true;
         }
         catch
         {
-            bitmap = null;
+            image = null;
             return false;
         }
     }

--- a/src/SQLBI.Whiteboard/ClipboardImage.cs
+++ b/src/SQLBI.Whiteboard/ClipboardImage.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
 using System.IO;
+using System.Text;
 using System.Windows;
 using System.Windows.Media.Imaging;
 using SQLBI.Whiteboard.Core.Import;
@@ -20,6 +21,55 @@ internal static class ClipboardImage
             .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path))
             .ToArray();
         return DroppedFileImport.CanImportAny(paths) ? paths : [];
+    }
+
+    /// <summary>
+    /// The clipboard format names that carry SVG markup. Illustrator, Inkscape, Office,
+    /// Figma, and the browsers each publish their own; the last two are what a plain
+    /// "copy as SVG" command tends to use.
+    /// </summary>
+    public static readonly string[] SvgFormats =
+    [
+        "image/svg+xml",
+        "image/svg-xml",
+        "image/x-inkscape-svg",
+        "Scalable Vector Graphics",
+        "SVG",
+    ];
+
+    /// <summary>
+    /// Reads SVG off the clipboard, either as one of its own formats or as markup that
+    /// was copied as text — which is how an SVG built by a DAX measure arrives.
+    /// </summary>
+    public static byte[]? TryGetSvgBytes()
+    {
+        var data = Clipboard.GetDataObject();
+        if (data is not null)
+        {
+            foreach (var format in SvgFormats)
+            {
+                if (!data.GetDataPresent(format, autoConvert: false))
+                {
+                    continue;
+                }
+
+                var bytes = ReadBytes(data.GetData(format)) ?? ReadText(data.GetData(format));
+                if (DroppedFileImport.LooksLikeSvg(bytes))
+                {
+                    return bytes;
+                }
+            }
+        }
+
+        if (!Clipboard.ContainsText(TextDataFormat.UnicodeText))
+        {
+            return null;
+        }
+
+        var text = Clipboard.GetText(TextDataFormat.UnicodeText);
+        return DroppedFileImport.LooksLikeSvg(text)
+            ? new UTF8Encoding(false).GetBytes(text)
+            : null;
     }
 
     public static byte[]? TryGetEncodedPng() =>
@@ -165,6 +215,9 @@ internal static class ClipboardImage
         bytes[1] == (byte)'P' &&
         bytes[2] == (byte)'N' &&
         bytes[3] == (byte)'G';
+
+    private static byte[]? ReadText(object? data) =>
+        data is string text ? new UTF8Encoding(false).GetBytes(text) : null;
 
     private static byte[]? ReadBytes(object? data) => data switch
     {

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -3307,7 +3307,7 @@ public partial class MainWindow : Window
         {
             Title = "Import",
             Filter =
-                "Importable files|*.wimport;*.png;*.jpg;*.jpeg;*.bmp;*.gif|Whiteboard import|*.wimport|Images|*.png;*.jpg;*.jpeg;*.bmp;*.gif",
+                "Importable files|*.wimport;*.png;*.jpg;*.jpeg;*.bmp;*.gif;*.svg|Whiteboard import|*.wimport|Images|*.png;*.jpg;*.jpeg;*.bmp;*.gif;*.svg",
             Multiselect = false,
         };
         if (dialog.ShowDialog(this) != true)
@@ -3343,6 +3343,18 @@ public partial class MainWindow : Window
                 return;
             }
 
+            // Ahead of the bitmap: an application that offers both is offering the same
+            // picture twice, and only one of the two survives being enlarged.
+            byte[]? svg = ClipboardImage.TryGetSvgBytes();
+            if (svg is not null)
+            {
+                AddImage(
+                    svg,
+                    "clipboard-image" + DroppedFileImport.SvgExtension,
+                    DroppedFileImport.SvgContentType);
+                return;
+            }
+
             byte[]? png = ClipboardImage.TryGetEncodedPng();
             if (png is not null)
             {
@@ -3368,16 +3380,12 @@ public partial class MainWindow : Window
         string contentType,
         PointD? worldCenter = null)
     {
-        var bitmap = WpfImageCodec.Decode(bytes);
+        var decoded = BoardImageCodec.Decode(bytes);
         var assetId = Guid.NewGuid().ToString("N");
         _document.AddAsset(new BoardAsset(assetId, fileName, contentType, bytes));
         SceneSurface.InvalidateAssets();
 
-        var naturalWidth = Math.Max(1, bitmap.PixelWidth);
-        var naturalHeight = Math.Max(1, bitmap.PixelHeight);
-        var scale = Math.Min(1, Math.Min(900d / naturalWidth, 700d / naturalHeight));
-        var width = naturalWidth * scale;
-        var height = naturalHeight * scale;
+        var (width, height) = BoardImageCodec.ArrivalSize(decoded);
         var center = worldCenter ?? _camera.Center;
         var image = new ImageBoardObject(
             Guid.NewGuid(),
@@ -4091,7 +4099,26 @@ public partial class MainWindow : Window
                 return;
             }
 
-            Clipboard.SetImage(WpfImageCodec.Decode(asset.Data));
+            BoardImage copied = BoardImageCodec.Decode(asset.Data);
+            if (!copied.IsVector)
+            {
+                Clipboard.SetImage(BoardImageCodec.Rasterize(copied));
+                return;
+            }
+
+            var flattened = BoardImageCodec.Rasterize(copied, selected.Bounds);
+
+            // A vector goes out as both, so an editor receives the markup and a slide
+            // receives a picture, and pasting it back into a board keeps it a vector.
+            var vector = new DataObject();
+            vector.SetData(
+                DroppedFileImport.SvgContentType,
+                new MemoryStream(asset.Data, writable: false));
+            vector.SetText(
+                System.Text.Encoding.UTF8.GetString(asset.Data),
+                TextDataFormat.UnicodeText);
+            vector.SetImage(flattened);
+            Clipboard.SetDataObject(vector, copy: true);
         }
         catch (Exception exception)
         {
@@ -4249,8 +4276,8 @@ public partial class MainWindow : Window
 
                 try
                 {
-                    var bitmap = WpfImageCodec.Decode(item.ImageBytes);
-                    var (width, height) = ImportLayout.ImageSize(bitmap.PixelWidth, bitmap.PixelHeight);
+                    var (width, height) = BoardImageCodec.ArrivalSize(
+                        BoardImageCodec.Decode(item.ImageBytes));
                     sizes.Add((width, height, item.StartNewRow));
                     decoded.Add((item, item.ImageBytes, width, height));
                 }
@@ -4848,6 +4875,7 @@ public partial class MainWindow : Window
             ".jpg" or ".jpeg" => "image/jpeg",
             ".bmp" => "image/bmp",
             ".gif" => "image/gif",
+            DroppedFileImport.SvgExtension => DroppedFileImport.SvgContentType,
             _ => "application/octet-stream",
         };
 

--- a/src/SQLBI.Whiteboard/SQLBI.Whiteboard.csproj
+++ b/src/SQLBI.Whiteboard/SQLBI.Whiteboard.csproj
@@ -32,6 +32,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
+    <!-- WPF has no SVG decoder. This one produces a DrawingGroup, so an SVG container
+         stays vector through zoom and resize instead of being rasterized at import. -->
+    <PackageReference Include="SharpVectors.Wpf" Version="1.8.5" />
     <PackageReference Include="Vortice.Wpf" Version="3.8.3" />
   </ItemGroup>
 </Project>

--- a/src/SQLBI.Whiteboard/SvgImageCodec.cs
+++ b/src/SQLBI.Whiteboard/SvgImageCodec.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using System.Windows.Media;
+using SharpVectors.Converters;
+using SharpVectors.Dom;
+using SharpVectors.Renderers.Wpf;
+
+namespace SQLBI.Whiteboard;
+
+internal static class SvgImageCodec
+{
+    public static DrawingImage Decode(byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        var settings = new WpfDrawingSettings
+        {
+            // Nothing here needs the SharpVectors runtime types; a plain drawing draws faster.
+            IncludeRuntime = false,
+            TextAsGeometry = false,
+
+            // Without these the drawing is only as large as the marks in it, so an SVG
+            // that centres a label in a 300x60 canvas would arrive cropped to the glyphs
+            // and stretched. Together they keep the author's viewBox as the container.
+            EnsureViewboxSize = true,
+            EnsureViewboxPosition = true,
+
+            // Dropped and pasted SVG is untrusted markup. Left at its default this would
+            // fetch whatever an <image href> or an external stylesheet names, which turns
+            // opening a board into an outbound request.
+            ExternalResourcesAccessMode = ExternalResourcesAccessModes.Ignore,
+        };
+
+        using var reader = new FileSvgReader(settings);
+        using var stream = new MemoryStream(bytes, writable: false);
+        var drawing = reader.Read(stream)
+            ?? throw new InvalidDataException("The SVG has nothing to draw.");
+
+        var image = new DrawingImage(drawing);
+        if (image.CanFreeze)
+        {
+            image.Freeze();
+        }
+
+        return image;
+    }
+}

--- a/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
+++ b/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
@@ -82,6 +82,51 @@ Assert(
     DroppedFileImport.LooksLikeText("DEFINE MEASURE Sales[X] = 1"u8.ToArray()) &&
     !DroppedFileImport.LooksLikeText([0x4D, 0x5A, 0x00, 0x00]),
     "Text drops should reject files with a NUL in the header.");
+Assert(
+    DroppedFileImport.Classify("logo.svg") == DroppedFileKind.Image &&
+    DroppedFileImport.Classify(@"C:\art\LOGO.SVG") == DroppedFileKind.Image &&
+    ImportCatalog.Default.IsImageExtension(".svg"),
+    "An SVG is an image everywhere an image is accepted, not a text snippet.");
+Assert(
+    DroppedFileImport.LooksLikeSvg("<svg xmlns='x' width='4'><rect/></svg>") &&
+    DroppedFileImport.LooksLikeSvg("\uFEFF  \n<?xml version=\"1.0\"?><svg><g/></svg>") &&
+    DroppedFileImport.LooksLikeSvg("<!-- note --><!DOCTYPE svg PUBLIC \"x\" \"y\"><svg/>") &&
+    DroppedFileImport.LooksLikeSvg("<svg:svg xmlns:svg='x'><svg:g/></svg:svg>") &&
+    DroppedFileImport.LooksLikeSvg("<s:svg xmlns:s='x'/>"),
+    "Pasted SVG markup should survive a BOM, a prologue, and any namespace prefix.");
+Assert(
+    !DroppedFileImport.LooksLikeSvg("SELECT * FROM <svg> -- </svg>") &&
+    !DroppedFileImport.LooksLikeSvg("<svgx><rect/></svgx>") &&
+    !DroppedFileImport.LooksLikeSvg("<html><body><svg><rect/></svg></body></html>") &&
+    !DroppedFileImport.LooksLikeSvg("<?xml version=\"1.0\"?>") &&
+    !DroppedFileImport.LooksLikeSvg((string?)null),
+    "Only a document whose root element is svg is a picture; one that contains svg is not.");
+Assert(
+    DroppedFileImport.LooksLikeSvg("<svg><g/></svg>"u8.ToArray()) &&
+    !DroppedFileImport.LooksLikeSvg([0x89, 0x50, 0x4E, 0x47]) &&
+    !DroppedFileImport.LooksLikeSvg([0xFF, 0xD8, 0xFF, 0xE0]) &&
+    !DroppedFileImport.LooksLikeSvg((byte[]?)null) &&
+    !DroppedFileImport.LooksLikeSvg([]),
+    "Asset bytes should choose the SVG decoder without relying on a stored content type.");
+Assert(
+    !DroppedFileImport.LooksLikeSvg([0x3C, 0xFF, 0xFE, 0x3C]),
+    "Bytes that open with '<' but are not UTF-8 text are not SVG.");
+
+var svgImport = ImportDocument.Parse(
+    """
+    ## Diagram
+    ![star](./art/star.svg)
+
+    ## Linked
+    [logo](./art/logo.svg)
+    """);
+Assert(
+    svgImport.Items is
+    [
+        { Kind: ImportItemKind.Image, SourcePath: "./art/star.svg" },
+        { Kind: ImportItemKind.Image, SourcePath: "./art/logo.svg" },
+    ],
+    "A .wimport should build image containers from SVG, both embedded and linked.");
 
 var parsedImport = ImportDocument.Parse(
     """
@@ -211,6 +256,12 @@ Assert(
 Assert(
     ImportLayout.ImageSize(1800, 1400) is { Width: 900, Height: 700 },
     "Imported images should use the same 900 by 700 cap as a dropped image.");
+Assert(
+    ImportLayout.VectorImageSize(24, 24) is { Width: 240, Height: 240 } &&
+    ImportLayout.VectorImageSize(1800, 1400) is { Width: 900, Height: 700 } &&
+    ImportLayout.VectorImageSize(100, 20) is { Width: 240, Height: 48 } &&
+    ImportLayout.VectorImageSize(400, 100) is { Width: 400, Height: 100 },
+    "A vector should be grown to a legible edge, keep its aspect, and keep the 900 by 700 cap.");
 
 var document = new BoardDocument();
 Assert(document.ContentBounds is null, "An empty document should not have content bounds.");


### PR DESCRIPTION
SVG now works everywhere an image works: clipboard paste, Explorer drag-and-drop, `File → Import`, and `.wimport` recipes. It is stored as its markup and redrawn at whatever size it is shown at, rather than rasterized once on arrival.

## Why a dependency

WPF has no SVG decoder, so supporting SVG at all meant taking a rendering library — including the option of rasterizing on arrival, which needs one just the same. That made the choice about which library, not whether to have one.

`SharpVectors.Wpf` produces a `DrawingGroup`, which is the point on a canvas whose zoom is unbounded. It is BSD-3, managed-only, and ships no native binary, so it stays out of the signing step and out of the per-architecture question the installer would otherwise have to answer. Direct2D was the tempting alternative — `Vortice` is already referenced and it would have cost nothing — but it implements a restricted SVG subset with no `<text>` element, which is most of what a DAX SVG measure emits. Decision 21 records this.

## What carried and what needed work

Adding `.svg` to `ImportCatalog` is what carries it into drag-and-drop and `.wimport`, since both already route through it. Paste needed the work. SVG arrives either under one of five clipboard format names or, more often here, as markup that was simply copied as text, so the shape of the content decides. The root element has to be `svg` — matching on "contains `<svg`" would make a page of HTML with a picture inside it paste as an image. Copying an SVG container publishes the markup and a bitmap together, so an editor receives the source and a slide receives the picture.

`BoardImageCodec` becomes the one place an asset's bytes turn into something drawable, and `BoardSurface` caches `ImageSource` rather than `BitmapSource`.

## Two details worth stating

The renderer is given `ExternalResourcesAccessModes.Ignore`. Its default fetches whatever the markup names, which would let a pasted or dropped file turn opening a board into an outbound request.

A vector is grown to a legible edge on arrival, because icons are authored at 16 or 24 units and would otherwise land as a speck on a 2400-wide row. Enlarging costs a bitmap its sharpness and a vector nothing.

## Compatibility

Assets were already stored as opaque bytes carrying a content type, so the board format did not move — it is still version 5. The decoder is chosen from the bytes rather than the stored content type, so boards written before this change are unaffected. A board holding an SVG opened in 1.0.3 draws the missing-image placeholder for it rather than failing to open.

`.svg` is deliberately **not** registered as a file type by the installer. Whiteboard opens SVG; it does not take it from the browser.

## Verification

Beyond the smoke tests, the real code paths were exercised against a throwaway harness:

- Shapes, `<text>`, gradients, namespace prefixes, viewBox-only, and a doctype prologue all render.
- The author's declared canvas is preserved. `EnsureViewboxSize` was needed for this: without it a label centred in a 300×60 canvas arrived cropped to its glyphs at 147×26 and stretched.
- An `<image href="http://…">` is ignored, with no fetch.
- A board with an SVG asset round-trips through `.wboard` byte-for-byte and renders identically at 1024×512 — vector, not a 200×100 bitmap enlarged.
- `docs/samples/contoso-workshop.wimport`, which now includes an SVG container, resolves with zero missing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)