### PR TITLE
Collect pen ink from the pen, and add straight-line strokes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Use **Copy settings** after finding a useful combination so the exact values can
 | Input | Behavior |
 | --- | --- |
 | Pen tip | Current tool; Pen is selected at startup |
+| Shift + pen tip | Constrain a near-horizontal or near-vertical stroke to that axis |
 | Pen hover | Show the small red pointer dot and hide the arrow |
 | Pen contact | Hide both the pointer dot and arrow |
 | Physical mouse movement | Show the normal arrow |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ How the project is developed and shipped is documented separately:
 - Markdown `.wimport` recipes that build image and text containers from headings
 - An intentionally small floating toolbar
 - A File / Edit / View / Help tab strip. Click a tab for a one-row command strip over the canvas
-- Preferences for the startup monitor, full-screen start, finger drawing, snippet format order, laser trail timing and weight, toolbar position and layout, and (except Store installs) a daily new-version check
+- Preferences for the startup monitor, full-screen start, finger drawing, the pen button, snippet format order, laser trail timing and weight, toolbar position and layout, and (except Store installs) a daily new-version check
 - About, with version and channel
 
 ## Build and run
@@ -174,15 +174,15 @@ Use **Copy settings** after finding a useful combination so the exact values can
 | Input | Behavior |
 | --- | --- |
 | Pen tip | Current tool; Pen is selected at startup |
-| Shift + pen tip | Constrain a near-horizontal or near-vertical stroke to that axis |
+| Shift + pen tip | Constrain the stroke to horizontal or vertical, whichever is nearer, at a uniform width. Press or release mid-stroke to start or end the constraint from that point. The barrel button does the same when assigned to Straight line |
 | Pen hover | Show the small red pointer dot and hide the arrow |
 | Pen contact | Hide both the pointer dot and arrow |
 | Physical mouse movement | Show the normal arrow |
 | Left mouse | Temporarily select/move/resize a container; return to the previous drawing tool on release |
 | Double-click container | Center and fit the image, text, or LiveView to the canvas |
 | Double-click empty canvas | Center and fit all board content, or reset an empty board |
-| Pen eraser | Erase complete strokes |
-| Pen barrel | Hold the lower barrel button for the laser; release returns to the previous tool |
+| Pen eraser | Erase complete strokes. The upper side button erases too: Windows reports it the same way as a pen turned round |
+| Pen barrel | Hold the barrel button for the action assigned in Preferences: Laser (default) or Straight line. Laser returns to the previous tool on release |
 | One finger | Pan. With Finger drawing on, uses the current tool instead |
 | Two fingers | Pan and pinch zoom. Cancels an in-progress finger stroke when Finger drawing is on |
 | Mouse wheel | Zoom at the pointer. Shift+wheel zooms more slowly |
@@ -202,7 +202,7 @@ Use **Copy settings** after finding a useful combination so the exact values can
 | Delete | Delete the selected container and its linked strokes |
 | Alt+L | Laser pointer |
 | File / Edit / View / Help | Tab strip. Click a tab for a one-row command strip over the canvas. Click the canvas to hide it |
-| Help > Preferences | Searchable settings: startup monitor, full screen, finger drawing, snippet format order, laser trail, toolbar, update checks |
+| Help > Preferences | Searchable settings: startup monitor, full screen, finger drawing, pen button, snippet format order, laser trail, toolbar, update checks |
 | View > Bring to front / Send to back | Reorder the selected image, text, or LiveView (and its linked strokes) |
 | Help > About | Version, channel, license, the product site, and a download link when a newer release is known |
 | View > LiveView | Capture, freeze, disconnect, or reconnect a window or display |
@@ -247,13 +247,21 @@ is installed. The source is `vscode/sqlbi-whiteboard`.
 - `SQLBI.Whiteboard.Dax` contains the framework-neutral DAX lexer, parser, classifier, and deterministic formatter adapted from Prompt Assistant.
 - `SQLBI.Whiteboard.SqlServer` contains the framework-neutral SQL Server 2025 adapter over Microsoft's ScriptDOM parser and script generator.
 - `vscode/sqlbi-whiteboard` is a VS Code custom editor that shows `preview.png` from a `.wboard` ZIP. It is not part of the desktop installer.
-- `SQLBI.Whiteboard` is the WPF shell. `InkCanvas` supplies system-managed wet ink, while `BoardSurface` renders completed ink, images, text, and selection on a white canvas in camera space. A transient AvalonEdit surface is overlaid only while a text container is being edited; language services translate parser classifications into WPF text styles.
+- `SQLBI.Whiteboard` is the WPF shell. `TouchInkCanvas` supplies system-managed wet ink for the finger, while `BoardSurface` renders completed ink, images, text, and selection on a white canvas in camera space, plus the pen's own wet stroke. A transient AvalonEdit surface is overlaid only while a text container is being edited; language services translate parser classifications into WPF text styles.
 - `SQLBI.Whiteboard/LiveView` owns Windows Graphics Capture and the Direct3D-to-WPF bridge. Capture retains one GPU frame per active LiveView; CPU bitmap conversion occurs only when copying or saving a snapshot.
 - `SQLBI.Whiteboard.Core.SmokeTests` is a package-free executable test harness for camera anchoring, commands, hit testing, and archive round trips.
 
 The current document query is deliberately linear. A spatial index can be introduced behind `BoardDocument.Query` when profiling demonstrates a need, without changing input, tools, persistence, or rendering call sites.
 
-Live ink uses a transparent WPF `InkCanvas` above the retained scene. WPF renders wet ink on its dedicated dynamic-rendering thread. On stroke completion, pressure points are transformed from screen space into the unbounded world model; camera movement is suspended while the pen is in contact.
+Live ink uses a transparent WPF `TouchInkCanvas` above the retained scene, and it collects
+the finger's strokes only: WPF renders those on its dedicated dynamic-rendering thread.
+Pen ink is read straight from the pen's packets by `MainWindow.AppendPenInk`, which owns
+the contact, the straight-line constraint, and the calligraphy dynamics, and draws the wet
+stroke through `BoardSurface.PendingStroke`. A barrel button tears the WPF contact in two
+every time it is pressed or released — see [TODO.md](TODO.md) — so no stroke built on that
+bookkeeping could behave like the Shift key. In both paths pressure points are transformed
+from screen space into the unbounded world model on completion; camera movement is
+suspended while the pen is in contact.
 
 ## Wacom Cintiq Pro validation
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@ The delivery chain works end to end: a merge to `main` builds, signs, and publis
 pre-release to GitHub Releases, and one approval promotes that same build to a release.
 <https://whiteboard.sqlbi.com> reads its download links from the release manifest
 deployed beside it and needs no edit per release. The current product version is `VersionPrefix` in `Directory.Build.props`
-(1.0.3). Identity version for the Store package is `VersionPrefix.0` (`1.0.3.0`).
+(1.1.1). Identity version for the Store package is `VersionPrefix.0` (`1.1.1.0`).
 
 Declaring that number is decision 20 in [docs/decisions.md](docs/decisions.md). What 1.0
 was waiting on shipped during 0.9.x: Preferences, `.wimport`, Explorer and VS Code
@@ -33,6 +33,52 @@ two releases through certification unattended. The install-side verification lis
 walked in full for 1.0.0, which was the last part of the chain that had only ever been
 reasoned about. winget is the one piece still waiting, below. All of it is described in
 [docs/release-management.md](docs/release-management.md).
+
+## Pen buttons: what was settled, and what is left
+
+The barrel button is the only assignable one, and it takes Laser or Straight line. Adding
+an action means an entry in `PenButtonAction`, a choice in `SettingsCatalog`, and — if it
+swaps the tool rather than acting as a modifier — a case in `MainWindow.BarrelToolFor`.
+Nothing else needs to know.
+
+Erasing is not assignable. The reverse end of the pen erases, and so does the upper side
+button, because they cannot be told apart:
+
+- **The upper button and a reversed pen are the same signal.** A trace from the
+  development pen (`PenTrace`, enabled by pointing `SQLBI_WHITEBOARD_PENTRACE` at a file)
+  settles what several rounds of inference could not. The device exposes exactly two
+  buttons, `Tip Switch` and `Barrel Switch` — no eraser button, no secondary tip button.
+  Clicking the upper side button and turning the pen round produce identical events:
+  `Inverted` goes true, both switches stay up, pressure stays zero, and when either one
+  lands the same tip switch closes. So an inversion is the eraser, full stop. A device
+  that reports a real `SecondaryTipButton` would be distinguishable, and supporting one
+  would mean re-introducing a second slot — worth doing only if such a device turns up.
+
+- **The barrel switch masks the tip switch, and the ink there is recovered by hand.** A
+  barrel press and a barrel release each arrive as a stylus up with `InAir` true. After a
+  release the pen keeps reporting `Tip Switch=Up` and `InAir` until the button is pressed
+  again - while the tip is still on the glass, and while the packets still carry its real
+  pressure (0.54 rising to 0.69 across one such gap in the trace). WPF delivers those as
+  in-air moves, so the InkCanvas collects nothing and the ink drawn in between was lost.
+  `AccumulateMaskedTipInk` keeps them instead and commits them as a freehand stroke when
+  the gap ends. Two consequences worth knowing: a barrel transition splits the line into
+  separate stroke objects, which shows as a seam where a highlighter overlaps itself and
+  as several undo steps; and the recovered stretch appears when the gap closes rather
+  than under the tip, because there is no wet-ink path for points the InkCanvas never
+  sees. Giving it one means drawing a provisional stroke on the scene surface.
+
+- **The straight-line constraint cannot start mid-stroke from a button on this pen.** It
+  can from Shift, and from the barrel button, because both are reported while the tip is
+  down. Anything reported only through `Inverted` is not, since Invert and Tip are
+  mutually exclusive on this device.
+
+- **Two constants stand in for signals the hardware does not give.** `AppendPenInk` calls
+  four consecutive weightless packets a lift rather than a dropped reading — no digitizer
+  misses four readings in a row. `DefaultActivationDistance` is 24 px: how far the pen
+  must travel before the axis is settled. It was 8 px, which let a few milliseconds of
+  the previous direction pick the axis; a trace of real strokes is the way to revisit it.
+  Once settled the axis is kept for the whole segment, however far off it the hand
+  drifts — turning a corner instead was tried and produced a staircase out of a diagonal.
 
 ## Waiting on the first winget submission
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -384,6 +384,44 @@ outbound request.
 
 ---
 
+## 22. Pen ink is collected from the pen, not from the InkCanvas
+
+**Implemented.**
+
+`InkCanvas` collects a stroke between a stylus down and the matching up. On a pen whose
+barrel switch shares the report with the tip switch — the development Cintiq, and the
+reason this was found — pressing or releasing that button fabricates a stylus up followed
+by a stylus down, and between a release and the next press the driver reports the tip as
+open while it is still pressing. WPF therefore reports the pen in the air for as long as
+the button is held, and the contact is torn in two on every click.
+
+Every attempt to repair that inside the InkCanvas moved the fault rather than removing it:
+strokes joined across stretches the pen never drew, ink was lost between a release and the
+next press, and a modifier held down could not be released. Meanwhile the pen's own packet
+stream never breaks — position and pressure arrive continuously, in contact or not, which
+a trace of a real session established (`PenTrace`, enabled by pointing
+`SQLBI_WHITEBOARD_PENTRACE` at a file).
+
+So the window reads that stream directly. `MainWindow.AppendPenInk` owns the contact — it
+begins at the first pressured packet and ends after a run of weightless ones — and applies
+the straight-line constraint and the calligraphy dynamics to each point as it arrives. The
+wet stroke is drawn by `BoardSurface.PendingStroke` rather than by WPF's dynamic renderer.
+The straight-line constraint is then one boolean read per point, which is what makes the
+barrel button behave exactly like the Shift key: neither has any opinion about whether WPF
+thinks the pen is down.
+
+`TouchInkCanvas` keeps the InkCanvas for finger ink, where nothing tears the contact, and
+hosts the laser sampler and the hover tracker. It collects no pen ink; strokes the
+InkCanvas still opens for a pen are discarded on arrival.
+
+The cost is that pen wet ink is drawn on the UI thread rather than WPF's dedicated
+dynamic-rendering thread. Reverting is not attractive: the machinery this replaced —
+a stylus plug-in for the constraint, recovery of ink from in-air packets, splitting a
+collected stroke back into contacts, and a second stroke lifecycle inside the renderer —
+was several hundred lines and never converged.
+
+---
+
 ## Open questions
 
 - arm64 is not built; add it if Surface devices matter for a pen application.

--- a/site/guide.html
+++ b/site/guide.html
@@ -655,7 +655,7 @@
       <div class="toolrow">
         <svg class="glyph" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="m15.87 2.67 4.97 4.97c.88.88.88 2.3 0 3.18l-8.68 8.68h6.1c.37 0 .69.28.74.65v.1c0 .38-.28.7-.64.74l-.1.01H9.83a2.24 2.24 0 0 1-1.71-.65l-4.97-4.97a2.25 2.25 0 0 1 0-3.18l9.53-9.53c.88-.88 2.3-.88 3.18 0Zm-10.16 9.1-1.49 1.49c-.3.29-.3.76 0 1.06l4.97 4.96c.15.15.34.22.53.22h.07a.75.75 0 0 0 .46-.22l1.49-1.48-6.03-6.03Zm8.04-8.04L6.77 10.7l6.03 6.03 6.98-6.98c.29-.3.29-.77 0-1.06L14.8 3.73a.75.75 0 0 0-1.06 0Z"/></svg>
         <span class="name">Eraser</span>
-        <span class="role">Removes whole strokes. The eraser end of a pen does the same, and hovering with it draws a dashed square around what a tap would clear.</span>
+        <span class="role">Removes whole strokes. The eraser end of a pen does the same — and so does the upper side button, because Windows reports the two identically — and hovering with it draws a dashed square around what a tap would clear.</span>
       </div>
       <div class="toolrow">
         <svg class="glyph" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M15.28 6.03c-.3.3-.77.3-1.06 0l-1.47-1.47v3.69a.75.75 0 0 1-1.5 0V4.56L9.78 6.03a.75.75 0 0 1-1.06-1.06l2.75-2.75a.75.75 0 0 1 1.06 0l2.75 2.75c.3.3.3.77 0 1.06Zm-9.25 8.19a.75.75 0 1 1-1.06 1.06l-2.75-2.75a.75.75 0 0 1 0-1.06l2.75-2.75a.75.75 0 0 1 1.06 1.06l-1.47 1.47h3.69a.75.75 0 0 1 0 1.5H4.56l1.47 1.47Zm11.94 1.06a.75.75 0 0 1 0-1.06l1.47-1.47h-3.69a.75.75 0 0 1 0-1.5h3.69l-1.47-1.47a.75.75 0 0 1 1.06-1.06l2.75 2.75a.75.75 0 0 1 0 1.06l-2.75 2.75c-.3.3-.77.3-1.06 0Zm-2.69 2.69a.75.75 0 0 0-1.06 0l-1.47 1.47v-3.69a.75.75 0 0 0-1.5 0v3.69l-1.47-1.47a.75.75 0 0 0-1.06 1.06l2.75 2.75a.75.75 0 0 0 1.06 0l2.75-2.75c.3-.3.3-.77 0-1.06Z"/></svg>
@@ -902,11 +902,11 @@
     </figure>
 
     <h3>Preferences</h3>
-    <p><span class="ui">Help → Preferences</span> is a searchable list: which monitor to open on, start full screen, finger drawing, snippet format order, laser trail timing and weight, toolbar placement, and the daily new-version check. <span class="ui">Help → About</span> shows the version. New settings are more rows in Preferences, not a new dialog.</p>
+    <p><span class="ui">Help → Preferences</span> is a searchable list: which monitor to open on, start full screen, finger drawing, what the pen's barrel button does, snippet format order, laser trail timing and weight, toolbar placement and layout, and the daily new-version check. Settings about how something looks — the trail weight, the barrel button, where the toolbar sits and how it is laid out — draw their options rather than naming them, so the choice is made by looking. <span class="ui">Help → About</span> shows the version. New settings are more rows in Preferences, not a new dialog.</p>
 
     <figure class="fig">
       <div class="figbox">
-        <svg viewBox="0 0 700 340" role="img" aria-label="The Preferences dialog: a search box across the top, the four categories down the left, and the settings of the selected category as rows on the right.">
+        <svg viewBox="0 0 700 340" role="img" aria-label="The Preferences dialog: a search box across the top, the categories down the left, and the settings of the selected category as rows on the right.">
           <title>The Preferences dialog</title>
           <rect width="700" height="340" rx="10" fill="var(--fig-ground)"/>
           <rect x="20" y="14" width="660" height="312" rx="12" fill="var(--fig-surface)" stroke="var(--fig-line)"/>

--- a/site/shortcuts.html
+++ b/site/shortcuts.html
@@ -80,8 +80,9 @@
       <div class="keyrow"><span><kbd class="gesture">Pen tip</kbd></span><span class="act">Current tool. Pen is selected at startup.</span></div>
       <div class="keyrow"><span><kbd class="gesture">Pen hover</kbd></span><span class="act">Show the small red pointer dot and hide the arrow.</span></div>
       <div class="keyrow"><span><kbd class="gesture">Pen contact</kbd></span><span class="act">Hide both the pointer dot and the arrow.</span></div>
-      <div class="keyrow"><span><kbd class="gesture">Pen eraser</kbd></span><span class="act">Erase complete strokes.</span></div>
-      <div class="keyrow"><span><kbd class="gesture">Barrel button</kbd></span><span class="act">Hold the lower barrel button for the laser. Release returns to the previous tool.</span></div>
+      <div class="keyrow"><span><kbd class="gesture">Pen eraser</kbd></span><span class="act">Erase complete strokes. The upper side button erases too: Windows reports it the same way as a pen turned round.</span></div>
+      <div class="keyrow"><span><kbd class="gesture">Barrel button</kbd></span><span class="act">Hold it for the action set in <span class="ui">Preferences</span>: Laser, which returns to the previous tool on release, or Straight line.</span></div>
+      <div class="keyrow"><span><kbd class="gesture">Straight line</kbd></span><span class="act">Hold <kbd>Shift</kbd>, or the barrel button when it is assigned to it, to constrain the stroke to horizontal or vertical at a uniform width. Press or release at any time to start or end the constraint from that point.</span></div>
     </div>
   </section>
 
@@ -142,7 +143,7 @@
       <div class="keyrow"><span><kbd class="gesture">Pen</kbd></span><span class="act">Pressure-aware ink. Selected at startup.</span></div>
       <div class="keyrow"><span><kbd class="gesture">Highlighter</kbd></span><span class="act">Translucent stroke. Marks a line without covering it.</span></div>
       <div class="keyrow"><span><kbd class="gesture">Calligraphy</kbd></span><span class="act">A nib that responds to direction, for labels and arrows.</span></div>
-      <div class="keyrow"><span><kbd class="gesture">Laser pointer</kbd></span><span class="act">Pointer for the projector. Does not write to the file. <kbd>Alt</kbd><span class="plus">+</span><kbd>L</kbd>, or hold the pen barrel button.</span></div>
+      <div class="keyrow"><span><kbd class="gesture">Laser pointer</kbd></span><span class="act">Pointer for the projector. Does not write to the file. <kbd>Alt</kbd><span class="plus">+</span><kbd>L</kbd>, or hold the pen barrel button while it is assigned to Laser.</span></div>
       <div class="keyrow"><span><kbd class="gesture">Eraser / Pan</kbd></span><span class="act">On the toolbar when Finger drawing is On. The rear eraser still removes whole strokes.</span></div>
       <div class="keyrow"><span><kbd class="gesture">File → New</kbd></span><span class="act">Start an empty board. Letter <kbd>N</kbd> when the File strip is open.</span></div>
       <div class="keyrow"><span><kbd class="gesture">View → Full screen</kbd></span><span class="act">Fill the current monitor and hide the title and tabs. <kbd>F11</kbd>.</span></div>

--- a/src/SQLBI.Whiteboard.Core/Geometry/StraightLineSnap.cs
+++ b/src/SQLBI.Whiteboard.Core/Geometry/StraightLineSnap.cs
@@ -1,0 +1,60 @@
+namespace SQLBI.Whiteboard.Core.Geometry;
+
+public enum StraightLineDirection
+{
+    None,
+    Horizontal,
+    Vertical,
+}
+
+public static class StraightLineSnap
+{
+    public const double DefaultActivationDistance = 8;
+    public const double DefaultAngleToleranceDegrees = 15;
+
+    public static bool HasActivationDistance(
+        PointD anchor,
+        PointD current,
+        double activationDistance = DefaultActivationDistance)
+    {
+        var deltaX = current.X - anchor.X;
+        var deltaY = current.Y - anchor.Y;
+        var minimum = Math.Max(0, activationDistance);
+        return (deltaX * deltaX) + (deltaY * deltaY) >= minimum * minimum;
+    }
+
+    public static StraightLineDirection DetectDirection(
+        PointD anchor,
+        PointD current,
+        double angleToleranceDegrees = DefaultAngleToleranceDegrees,
+        double activationDistance = DefaultActivationDistance)
+    {
+        if (!HasActivationDistance(anchor, current, activationDistance))
+        {
+            return StraightLineDirection.None;
+        }
+
+        var deltaX = Math.Abs(current.X - anchor.X);
+        var deltaY = Math.Abs(current.Y - anchor.Y);
+        var tolerance = Math.Clamp(angleToleranceDegrees, 0, 45);
+        var maximumOffAxisRatio = Math.Tan(tolerance * Math.PI / 180);
+        if (deltaY <= deltaX * maximumOffAxisRatio)
+        {
+            return StraightLineDirection.Horizontal;
+        }
+
+        return deltaX <= deltaY * maximumOffAxisRatio
+            ? StraightLineDirection.Vertical
+            : StraightLineDirection.None;
+    }
+
+    public static PointD Apply(
+        PointD point,
+        PointD anchor,
+        StraightLineDirection direction) => direction switch
+        {
+            StraightLineDirection.Horizontal => new PointD(point.X, anchor.Y),
+            StraightLineDirection.Vertical => new PointD(anchor.X, point.Y),
+            _ => point,
+        };
+}

--- a/src/SQLBI.Whiteboard.Core/Geometry/StraightLineSnap.cs
+++ b/src/SQLBI.Whiteboard.Core/Geometry/StraightLineSnap.cs
@@ -7,12 +7,25 @@ public enum StraightLineDirection
     Vertical,
 }
 
+/// <summary>
+/// The straight-line constraint is horizontal or vertical only. Holding the
+/// modifier is the request for one of those two, so a diagonal drag picks the
+/// nearer axis instead of falling back to a free stroke - the modifier would
+/// otherwise do nothing for most of the directions a hand actually moves in.
+/// </summary>
 public static class StraightLineSnap
 {
-    public const double DefaultActivationDistance = 8;
-    public const double DefaultAngleToleranceDegrees = 15;
+    // How far the pen must travel from the anchor before the axis is settled and
+    // kept. Once chosen it is not revisited: a hand drifting off the axis is
+    // still drawing the line it asked for.
+    // Eight pixels was too eager: pressing the button in the middle of a stroke
+    // leaves a few milliseconds of the previous direction still arriving, and
+    // the line committed to that instead of to where the hand then went - a
+    // fourteen-pixel horizontal stub in front of a hundred-pixel vertical
+    // stroke. This is far enough to be a turn rather than the tail of one.
+    public const double DefaultActivationDistance = 24;
 
-    public static bool HasActivationDistance(
+    private static bool HasActivationDistance(
         PointD anchor,
         PointD current,
         double activationDistance = DefaultActivationDistance)
@@ -26,7 +39,6 @@ public static class StraightLineSnap
     public static StraightLineDirection DetectDirection(
         PointD anchor,
         PointD current,
-        double angleToleranceDegrees = DefaultAngleToleranceDegrees,
         double activationDistance = DefaultActivationDistance)
     {
         if (!HasActivationDistance(anchor, current, activationDistance))
@@ -34,18 +46,9 @@ public static class StraightLineSnap
             return StraightLineDirection.None;
         }
 
-        var deltaX = Math.Abs(current.X - anchor.X);
-        var deltaY = Math.Abs(current.Y - anchor.Y);
-        var tolerance = Math.Clamp(angleToleranceDegrees, 0, 45);
-        var maximumOffAxisRatio = Math.Tan(tolerance * Math.PI / 180);
-        if (deltaY <= deltaX * maximumOffAxisRatio)
-        {
-            return StraightLineDirection.Horizontal;
-        }
-
-        return deltaX <= deltaY * maximumOffAxisRatio
-            ? StraightLineDirection.Vertical
-            : StraightLineDirection.None;
+        return Math.Abs(current.X - anchor.X) >= Math.Abs(current.Y - anchor.Y)
+            ? StraightLineDirection.Horizontal
+            : StraightLineDirection.Vertical;
     }
 
     public static PointD Apply(

--- a/src/SQLBI.Whiteboard.Core/Settings/AppSettings.cs
+++ b/src/SQLBI.Whiteboard.Core/Settings/AppSettings.cs
@@ -96,6 +96,8 @@ public sealed class AppSettings
 
     public LaserSettings Laser { get; set; } = new();
 
+    public PenButtonSettings PenButtons { get; set; } = new();
+
     public bool CheckForUpdates { get; set; } = true;
 
     public DateTimeOffset? LastUpdateCheckUtc { get; set; }
@@ -109,7 +111,7 @@ public sealed class AppSettings
 
 public static class AppSettingsSerializer
 {
-    public const int CurrentVersion = 10;
+    public const int CurrentVersion = 11;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -208,6 +210,7 @@ public static class AppSettingsSerializer
         settings.Highlighter = InkPalettes.Normalize(settings.Highlighter, PenKind.Highlighter);
         settings.Calligraphy = InkPalettes.Normalize(settings.Calligraphy, PenKind.Calligraphy);
         settings.Laser = LaserSettings.Normalize(settings.Laser);
+        settings.PenButtons = PenButtonSettings.Normalize(settings.PenButtons);
         settings.SnippetFormatOrder = [.. TextLanguageIds.NormalizeOrder(settings.SnippetFormatOrder)];
         settings.LatestKnownVersion = NormalizeVersionId(settings.LatestKnownVersion);
         settings.LastDismissedVersion = NormalizeVersionId(settings.LastDismissedVersion);

--- a/src/SQLBI.Whiteboard.Core/Settings/PenBarrelButton.cs
+++ b/src/SQLBI.Whiteboard.Core/Settings/PenBarrelButton.cs
@@ -1,0 +1,35 @@
+namespace SQLBI.Whiteboard.Core.Settings;
+
+/// <summary>
+/// Names Windows and tablet drivers put on stylus buttons, used to pick the
+/// barrel button out of the list a device reports. The writing tip is never it,
+/// and neither is the reverse end - which drivers call "Eraser", and sometimes
+/// "Secondary", "Upper" or "2".
+/// </summary>
+public static class PenBarrelButton
+{
+    public static bool IsWritingTipName(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return false;
+        }
+
+        return name.Contains("Tip", StringComparison.OrdinalIgnoreCase) &&
+               !name.Contains("Secondary", StringComparison.OrdinalIgnoreCase) &&
+               !name.Contains("Eraser", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool IsReverseEndName(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return false;
+        }
+
+        return name.Contains("Eraser", StringComparison.OrdinalIgnoreCase) ||
+               name.Contains("Upper", StringComparison.OrdinalIgnoreCase) ||
+               name.Contains("Secondary", StringComparison.OrdinalIgnoreCase) ||
+               name.Contains('2', StringComparison.Ordinal);
+    }
+}

--- a/src/SQLBI.Whiteboard.Core/Settings/PenButtonSettings.cs
+++ b/src/SQLBI.Whiteboard.Core/Settings/PenButtonSettings.cs
@@ -1,0 +1,34 @@
+namespace SQLBI.Whiteboard.Core.Settings;
+
+/// <summary>
+/// What the pen's barrel button does while it is held. The list is meant to
+/// grow: a new action needs an entry here, a choice in the settings catalog,
+/// and a case wherever the window turns a held button into behaviour.
+/// </summary>
+public enum PenButtonAction
+{
+    Laser = 0,
+    StraightLine = 1,
+}
+
+/// <summary>
+/// The barrel button is the only one that can be assigned. Erasing belongs to
+/// the reverse end of the pen, and to the upper side button, because Windows
+/// describes both by inverting the stylus and no pen has been found that tells
+/// the two apart - see TODO.md.
+/// </summary>
+public sealed class PenButtonSettings
+{
+    public PenButtonAction Barrel { get; set; } = PenButtonAction.Laser;
+
+    public static PenButtonSettings Normalize(PenButtonSettings? settings)
+    {
+        var result = settings ?? new PenButtonSettings();
+        if (!Enum.IsDefined(result.Barrel))
+        {
+            result.Barrel = PenButtonAction.Laser;
+        }
+
+        return result;
+    }
+}

--- a/src/SQLBI.Whiteboard/BoardSurface.cs
+++ b/src/SQLBI.Whiteboard/BoardSurface.cs
@@ -28,6 +28,15 @@ internal sealed class BoardSurface : FrameworkElement
 
     public Func<Guid, ImageSource?>? LiveViewImageSourceProvider { get; set; }
 
+    /// <summary>
+    /// The stroke the pen is drawing right now, before it is committed. Pen ink
+    /// is collected here rather than by the InkCanvas, so the wet stroke is
+    /// drawn here too.
+    /// </summary>
+    public IReadOnlyList<InkPoint>? PendingStroke { get; set; }
+
+    public PenStyle PendingStrokeStyle { get; set; }
+
     public void Configure(BoardDocument document, Camera2D camera)
     {
         _document = document;
@@ -50,6 +59,11 @@ internal sealed class BoardSurface : FrameworkElement
         if (_document is null || _camera is null)
         {
             return;
+        }
+
+        if (PendingStroke is { Count: > 1 } pending)
+        {
+            DrawStroke(drawingContext, pending, PendingStrokeStyle, _camera);
         }
 
         foreach (var item in _document.Query(_camera.VisibleWorldBounds))
@@ -98,9 +112,16 @@ internal sealed class BoardSurface : FrameworkElement
     private static void DrawStroke(
         DrawingContext drawingContext,
         InkStrokeObject stroke,
+        Camera2D camera) =>
+        DrawStroke(drawingContext, stroke.Points, stroke.Style, camera);
+
+    private static void DrawStroke(
+        DrawingContext drawingContext,
+        IReadOnlyList<InkPoint> strokePoints,
+        PenStyle style,
         Camera2D camera)
     {
-        var points = new StylusPointCollection(stroke.Points.Select(point =>
+        var points = new StylusPointCollection(strokePoints.Select(point =>
         {
             var screen = camera.WorldToScreen(point.Position);
             return new StylusPoint(
@@ -109,7 +130,7 @@ internal sealed class BoardSurface : FrameworkElement
                 Math.Clamp(point.Pressure, 0f, 1f));
         }));
 
-        var attributes = InkDrawingAttributes.Create(stroke.Style, camera.Zoom);
+        var attributes = InkDrawingAttributes.Create(style, camera.Zoom);
         var wpfStroke = new Stroke(points, attributes);
         wpfStroke.Draw(drawingContext);
     }

--- a/src/SQLBI.Whiteboard/MainWindow.xaml
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml
@@ -51,7 +51,7 @@
                                      IsHitTestVisible="False"
                                      Panel.ZIndex="15" />
 
-            <local:PenOnlyInkCanvas x:Name="InkSurface"
+            <local:TouchInkCanvas x:Name="InkSurface"
                        Background="Transparent"
                        EditingMode="Ink"
                        EditingModeInverted="None"

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -235,6 +235,7 @@ public partial class MainWindow : Window
 
     private void InkSurface_StrokeCollected(object sender, InkCanvasStrokeCollectedEventArgs e)
     {
+        var straightLineDirection = InkSurface.TakeCompletedStraightLineDirection();
         if (EffectiveTool == BoardTool.Laser ||
             _stylusAction == PointerAction.Laser ||
             _discardInkStroke)
@@ -250,12 +251,22 @@ public partial class MainWindow : Window
             return;
         }
 
+        var screenAnchor = new PointD(
+            e.Stroke.StylusPoints[0].X,
+            e.Stroke.StylusPoints[0].Y);
         var firstTimestamp = Stopwatch.GetTimestamp();
         var points = e.Stroke.StylusPoints
-            .Select((point, index) => new InkPoint(
-                _camera.ScreenToWorld(new PointD(point.X, point.Y)),
-                point.PressureFactor,
-                firstTimestamp + index))
+            .Select((point, index) =>
+            {
+                var screenPoint = StraightLineSnap.Apply(
+                    new PointD(point.X, point.Y),
+                    screenAnchor,
+                    straightLineDirection);
+                return new InkPoint(
+                    _camera.ScreenToWorld(screenPoint),
+                    point.PressureFactor,
+                    firstTimestamp + index);
+            })
             .ToArray();
         var stroke = InkStrokeObject.Create(
             points,
@@ -4371,6 +4382,7 @@ public partial class MainWindow : Window
         var controlDown = modifiers.HasFlag(ModifierKeys.Control);
         var shiftDown = modifiers.HasFlag(ModifierKeys.Shift);
         var altDown = modifiers.HasFlag(ModifierKeys.Alt) || e.Key == Key.System;
+        InkSurface.SetStraightLineMode(shiftDown);
 
         if (e.Key == Key.F11 || (e.Key == Key.System && e.SystemKey == Key.F11))
         {
@@ -4641,6 +4653,8 @@ public partial class MainWindow : Window
 
     private void Window_PreviewKeyUp(object sender, KeyEventArgs e)
     {
+        InkSurface.SetStraightLineMode(
+            Keyboard.Modifiers.HasFlag(ModifierKeys.Shift));
         if (e.Key == Key.Space && _spaceTemporaryPan)
         {
             _spaceTemporaryPan = false;
@@ -4667,6 +4681,7 @@ public partial class MainWindow : Window
         _mouseAction = PointerAction.None;
         _penInContact = false;
         _syntheticLaserContact = false;
+        InkSurface.SetStraightLineMode(false);
         ClearTouchNavigation();
         InkSurface.Cursor = Cursors.Arrow;
         HidePointerDot();

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -66,10 +66,17 @@ public partial class MainWindow : Window
     private BoardTool _activeTool = BoardTool.Pen;
     private BoardTool _lastDrawingTool = BoardTool.Pen;
     private BoardTool _toolBeforeSpace = BoardTool.Pen;
-    private BoardTool _toolBeforeLaser = BoardTool.Pen;
-    private bool _laserTemporary;
+    private BoardTool _toolBeforeBarrel = BoardTool.Pen;
+    private bool _barrelToolTemporary;
     private bool _discardInkStroke;
-    private StylusButton? _laserBarrelButton;
+    private StylusButton? _barrelButton;
+    private bool _lastContactWasPen;
+    private readonly List<InkPoint> _penInk = [];
+    private PointD? _penInkAnchor;
+    private StraightLineDirection _penInkDirection;
+    private PointD? _penInkPrevious;
+    private double _penInkSpeed;
+    private int _penInkWeightless;
     private PenStyle _penStyle = InkPalettes.DefaultPen;
     private PointerAction _stylusAction;
     private PointerAction _mouseAction;
@@ -233,41 +240,35 @@ public partial class MainWindow : Window
         SessionBar.SetEditEnabled(_history.CanUndo, _history.CanRedo);
     }
 
+    // Only touch reaches here now. Pen ink is collected from the pen's own
+    // stream instead - see AppendPenInk - because the barrel switch tears the
+    // WPF contact in two on every press and every release, and nothing built on
+    // top of that bookkeeping could be made to behave like the Shift key.
     private void InkSurface_StrokeCollected(object sender, InkCanvasStrokeCollectedEventArgs e)
     {
-        var straightLineDirection = InkSurface.TakeCompletedStraightLineDirection();
+        InkSurface.Strokes.Remove(e.Stroke);
         if (EffectiveTool == BoardTool.Laser ||
             _stylusAction == PointerAction.Laser ||
-            _discardInkStroke)
+            _discardInkStroke ||
+            _lastContactWasPen ||
+            e.Stroke.StylusPoints.Count == 0)
         {
             _discardInkStroke = false;
-            InkSurface.Strokes.Remove(e.Stroke);
             return;
         }
 
-        if (e.Stroke.StylusPoints.Count == 0)
-        {
-            InkSurface.Strokes.Remove(e.Stroke);
-            return;
-        }
-
-        var screenAnchor = new PointD(
-            e.Stroke.StylusPoints[0].X,
-            e.Stroke.StylusPoints[0].Y);
         var firstTimestamp = Stopwatch.GetTimestamp();
-        var points = e.Stroke.StylusPoints
-            .Select((point, index) =>
-            {
-                var screenPoint = StraightLineSnap.Apply(
-                    new PointD(point.X, point.Y),
-                    screenAnchor,
-                    straightLineDirection);
-                return new InkPoint(
-                    _camera.ScreenToWorld(screenPoint),
-                    point.PressureFactor,
-                    firstTimestamp + index);
-            })
-            .ToArray();
+        CommitInkPoints(e.Stroke.StylusPoints
+            .Select((point, index) => new InkPoint(
+                _camera.ScreenToWorld(new PointD(point.X, point.Y)),
+                point.PressureFactor,
+                firstTimestamp + index))
+            .ToArray());
+        SceneSurface.InvalidateVisual();
+    }
+
+    private void CommitInkPoints(IReadOnlyList<InkPoint> points)
+    {
         var stroke = InkStrokeObject.Create(
             points,
             _penStyle,
@@ -278,18 +279,138 @@ public partial class MainWindow : Window
         }
 
         _history.Execute(new AddObjectCommand(stroke), _document);
+    }
 
-        // The DynamicRenderer owns the low-latency wet stroke. Once WPF has
-        // collected it, the same pressure points move into the retained world
-        // model and the temporary InkCanvas copy can be discarded.
-        InkSurface.Strokes.Remove(e.Stroke);
-        SceneSurface.InvalidateVisual();
-        Debug.WriteLine(
-            $"[WpfInk] committed {points.Length} pressure points to world coordinates");
+    // Every packet the pen reports, in contact or not. This is the whole of the
+    // pen ink path: the constraint is one question asked per point, exactly as
+    // it is for Shift, because nothing here depends on WPF believing the pen is
+    // down. It does not believe it for as long as a barrel button is held.
+    private void AppendPenInk(StylusEventArgs e)
+    {
+        if (!IsInkTool || _stylusAction != PointerAction.None || e.StylusDevice.Inverted)
+        {
+            EndPenInk();
+            return;
+        }
+
+        var points = e.GetStylusPoints(InkSurface);
+        var pressed = false;
+        for (var index = 0; index < points.Count; index++)
+        {
+            var point = points[index];
+            if (point.PressureFactor <= 0)
+            {
+                continue;
+            }
+
+            pressed = true;
+            AppendPenInkPoint(new PointD(point.X, point.Y), point.PressureFactor);
+        }
+
+        if (pressed)
+        {
+            _penInkWeightless = 0;
+            _lastContactWasPen = true;
+            _penInContact = true;
+            SceneSurface.PendingStroke = _penInk;
+            SceneSurface.PendingStrokeStyle = _penStyle;
+            SceneSurface.InvalidateVisual();
+            return;
+        }
+
+        // One weightless packet is a dropped reading; a run of them is the pen
+        // off the glass.
+        if (_penInk.Count > 0 && ++_penInkWeightless < LiftedPacketCount)
+        {
+            return;
+        }
+
+        EndPenInk();
+    }
+
+    private void AppendPenInkPoint(PointD screen, float pressure)
+    {
+        var constrained = StraightLineConstraintActive;
+        if (!constrained)
+        {
+            _penInkAnchor = null;
+            _penInkDirection = StraightLineDirection.None;
+        }
+        else if (_penInkAnchor is null)
+        {
+            _penInkAnchor = screen;
+            _penInkDirection = StraightLineDirection.None;
+        }
+
+        if (constrained && _penInkAnchor is PointD anchor)
+        {
+            // The axis is chosen once and kept. A hand that drifts off it is
+            // still drawing the line it asked for, however far away it gets.
+            if (_penInkDirection == StraightLineDirection.None)
+            {
+                _penInkDirection = StraightLineSnap.DetectDirection(anchor, screen);
+            }
+
+            screen = _penInkDirection == StraightLineDirection.None
+                ? anchor
+                : StraightLineSnap.Apply(screen, anchor, _penInkDirection);
+
+            // A straight line is drawn, not written: uniform width.
+            pressure = StraightLinePressure;
+            _penInkPrevious = screen;
+            _penInkSpeed = 0;
+        }
+        else if (_penStyle.Kind == PenKind.Calligraphy)
+        {
+            if (_penInkPrevious is PointD previous)
+            {
+                var deltaX = screen.X - previous.X;
+                var deltaY = screen.Y - previous.Y;
+                var speed = Math.Sqrt((deltaX * deltaX) + (deltaY * deltaY));
+                _penInkSpeed = _penInkSpeed == 0
+                    ? speed
+                    : (_penInkSpeed * 0.65) + (speed * 0.35);
+            }
+
+            pressure = CalligraphyDynamics.AdjustPressure(pressure, _penInkSpeed);
+            _penInkPrevious = screen;
+        }
+        else
+        {
+            _penInkPrevious = screen;
+        }
+
+        _penInk.Add(new InkPoint(
+            _camera.ScreenToWorld(screen),
+            pressure,
+            Stopwatch.GetTimestamp()));
+    }
+
+    private void EndPenInk()
+    {
+        _penInkWeightless = 0;
+        _penInkAnchor = null;
+        _penInkDirection = StraightLineDirection.None;
+        _penInkPrevious = null;
+        _penInkSpeed = 0;
+        SceneSurface.PendingStroke = null;
+        if (_penInk.Count > 1 && !_discardInkStroke)
+        {
+            CommitInkPoints([.. _penInk]);
+        }
+
+        _discardInkStroke = false;
+        if (_penInk.Count > 0)
+        {
+            _penInk.Clear();
+            SceneSurface.InvalidateVisual();
+        }
     }
 
     private void InkSurface_PreviewStylusDown(object sender, StylusDownEventArgs e)
     {
+        PenTrace.Write("stylus-down", e, PenTraceState());
+        _lastContactWasPen = !IsTouchStylus(e);
         CommitTextEdit();
         SessionBar.CollapseIfTransient();
 
@@ -300,7 +421,7 @@ public partial class MainWindow : Window
 
         if (!IsTouchStylus(e) && !IsPenTipDown(e))
         {
-            Debug.WriteLine("[Laser] ignoring the barrel button's synthetic stylus down");
+            Debug.WriteLine("[Pen] barrel button opened a stylus down in mid-air");
 
             // The event still reached the InkCanvas, which restores its own ink
             // cursor on the way past. Nothing else refreshes it until the pen
@@ -311,6 +432,17 @@ public partial class MainWindow : Window
             // Handled so the InkCanvas does not open an editing gesture for a
             // touch we have just decided never happened.
             e.Handled = true;
+            return;
+        }
+
+        // A barrel transition while the tip is already down is delivered as a
+        // stylus down of its own. Our own state is already right for a contact
+        // that never ended, so none of it is redone here - but the event is left
+        // to reach the InkCanvas, which opens the next stroke with it. Held
+        // back, the InkCanvas instead carried the previous stroke across the
+        // pen's absence and drew a line through it.
+        if (!IsTouchStylus(e) && _penInContact && HasTipPressure(e))
+        {
             return;
         }
 
@@ -337,10 +469,11 @@ public partial class MainWindow : Window
         }
 
         var screen = ToPointD(e.GetPosition(InkSurface));
-        if (e.StylusDevice.Inverted || _activeTool == BoardTool.Eraser)
+        if (e.StylusDevice.Inverted || EffectiveTool == BoardTool.Eraser)
         {
             BeginErase(screen);
             _stylusAction = PointerAction.Erase;
+            _discardInkStroke = true;
             InkSurface.CaptureStylus();
             e.Handled = true;
         }
@@ -377,6 +510,7 @@ public partial class MainWindow : Window
     {
         if (IsTouchStylus(e))
         {
+            _lastContactWasPen = false;
             InkSurface.RegisterTouchTablet(e.StylusDevice.TabletDevice.Id);
             if (IsTouchNavigating)
             {
@@ -385,6 +519,11 @@ public partial class MainWindow : Window
             }
 
             TrackTouchPoint(e);
+        }
+        else
+        {
+            PenTrace.Write("stylus-move", e, PenTraceState());
+            AppendPenInk(e);
         }
 
         RecoverLaserContactFromPressure(e);
@@ -458,6 +597,7 @@ public partial class MainWindow : Window
 
     private void InkSurface_PreviewStylusUp(object sender, StylusEventArgs e)
     {
+        PenTrace.Write("stylus-up", e, PenTraceState());
         if (IsTouchStylus(e))
         {
             InkSurface.RegisterTouchTablet(e.StylusDevice.TabletDevice.Id);
@@ -467,6 +607,17 @@ public partial class MainWindow : Window
             {
                 return;
             }
+        }
+        else if (HasTipPressure(e))
+        {
+            // A stylus up still carrying tip pressure is a barrel transition,
+            // not a lift, so the contact state here is left alone - but the
+            // event goes on to the InkCanvas, which ends the stroke with it.
+            // That is the truth of what follows: Windows reports the pen in the
+            // air from here until the next stylus down, so the stroke really
+            // does stop, and joining it to whatever comes next draws a line
+            // through everywhere the pen was not.
+            return;
         }
 
         var screen = ToPointD(e.GetPosition(InkSurface));
@@ -579,9 +730,37 @@ public partial class MainWindow : Window
         TryActivatePaletteFromStylus(e);
     }
 
-    private bool IsPenTipDown(StylusEventArgs e) =>
-        !e.StylusDevice.InAir &&
-        !PhantomStylus.IsBarrelDown(e.GetStylusPoints(InkSurface));
+    // Clicking the barrel button over a hovering pen is delivered as a stylus
+    // down that claims everything a real touch claims - not in air, tip switch
+    // pressed. Only the pressure gives it away, because nothing is pressing on
+    // the tip. Requiring the barrel to be down as well keeps a genuinely light
+    // first packet from being mistaken for one of these.
+    private bool IsPenTipDown(StylusEventArgs e)
+    {
+        if (e.StylusDevice.InAir)
+        {
+            return false;
+        }
+
+        var points = e.GetStylusPoints(InkSurface);
+        if (points.Count == 0)
+        {
+            return true;
+        }
+
+        for (var index = 0; index < points.Count; index++)
+        {
+            var point = points[index];
+            if (point.PressureFactor > 0 ||
+                !point.HasProperty(StylusPointProperties.BarrelButton) ||
+                point.GetPropertyValue(StylusPointProperties.BarrelButton) == 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     // The barrel click opens a stylus down that WPF does not close until well
     // after the pen has touched and left again, so the first real landing is
@@ -591,7 +770,7 @@ public partial class MainWindow : Window
     // coming.
     private void RecoverLaserContactFromPressure(StylusEventArgs e)
     {
-        if (IsTouchStylus(e) || e.StylusDevice.Inverted)
+        if (IsTouchStylus(e))
         {
             return;
         }
@@ -599,13 +778,25 @@ public partial class MainWindow : Window
         var pressed = HasTipPressure(e);
         if (pressed &&
             !_penInContact &&
-            _stylusAction == PointerAction.None &&
-            EffectiveTool == BoardTool.Laser)
+            _stylusAction == PointerAction.None)
         {
             _penInContact = true;
-            _syntheticLaserContact = true;
-            BeginLaserContact(e);
-            _stylusAction = PointerAction.Laser;
+            HidePointerDot();
+            UsePenCursor();
+            if (e.StylusDevice.Inverted || EffectiveTool == BoardTool.Eraser)
+            {
+                BeginErase(ToPointD(e.GetPosition(InkSurface)));
+                InkSurface.CaptureStylus();
+                _stylusAction = PointerAction.Erase;
+                _discardInkStroke = true;
+            }
+            else if (EffectiveTool == BoardTool.Laser)
+            {
+                _syntheticLaserContact = true;
+                BeginLaserContact(e);
+                _stylusAction = PointerAction.Laser;
+            }
+
             return;
         }
 
@@ -715,62 +906,34 @@ public partial class MainWindow : Window
 
     private void InkSurface_PreviewStylusButtonDown(object sender, StylusButtonEventArgs e)
     {
-        if (IsTouchStylus(e) || e.StylusDevice.Inverted)
+        if (IsTouchStylus(e))
         {
             return;
         }
 
-        Debug.WriteLine(
-            $"[Laser] stylus button down '{e.StylusButton.Name}' guid={e.StylusButton.Guid} " +
-            $"inAir={e.StylusDevice.InAir} contact={_penInContact}");
+        PenTrace.Write("button-down", e, PenTraceState());
 
-        if (!IsLowerBarrelButton(e.StylusDevice, e.StylusButton))
+        if (!IsBarrelButton(e.StylusDevice, e.StylusButton))
         {
             return;
         }
 
-        BeginTemporaryLaser(e.StylusButton);
-        if (_penInContact)
-        {
-            InkSurface.AbortWetInk();
-            BeginLaserContact(e);
-            _stylusAction = PointerAction.Laser;
-        }
-
+        _barrelButton = e.StylusButton;
+        RefreshBarrelState(e);
         e.Handled = true;
     }
 
     private void InkSurface_PreviewStylusButtonUp(object sender, StylusButtonEventArgs e)
     {
-        if (_laserBarrelButton is null || !ReferenceEquals(e.StylusButton, _laserBarrelButton))
+        PenTrace.Write("button-up", e, PenTraceState());
+        if (!ReferenceEquals(e.StylusButton, _barrelButton))
         {
             return;
         }
 
-        EndTemporaryLaser();
+        _barrelButton = null;
+        RefreshBarrelState(e);
         e.Handled = true;
-    }
-
-    private void BeginTemporaryLaser(StylusButton button)
-    {
-        if (_laserTemporary)
-        {
-            return;
-        }
-
-        _laserBarrelButton = button;
-        _toolBeforeLaser = _activeTool == BoardTool.Laser
-            ? _lastDrawingTool
-            : _activeTool;
-        _laserTemporary = true;
-        _discardInkStroke = _penInContact;
-        SetActiveTool(BoardTool.Laser);
-        InkSurface.AbortWetInk();
-
-        // Engaging the laser from the barrel button is the one tool change that
-        // can happen without the pen moving, so it cannot wait for the next
-        // pointer event to settle the cursor.
-        UsePenCursor();
     }
 
     private void BeginLaserContact(Point position, float pressure)
@@ -837,46 +1000,121 @@ public partial class MainWindow : Window
         LaserTrail.AddSample(position, pressure, leaveTrail);
     }
 
-    private static bool IsLowerBarrelButton(StylusDevice device, StylusButton button)
+    private bool BarrelHolds(PenButtonAction action) =>
+        _barrelButton is not null && _settings.PenButtons.Barrel == action;
+
+    // Actions that swap the tool for as long as the button is held. A modifier
+    // such as the straight-line constraint has no tool of its own.
+    private static BoardTool? BarrelToolFor(PenButtonAction action) => action switch
     {
-        var name = button.Name ?? string.Empty;
-        if (name.Contains("Tip", StringComparison.OrdinalIgnoreCase) ||
-            name.Contains("Eraser", StringComparison.OrdinalIgnoreCase))
+        PenButtonAction.Laser => BoardTool.Laser,
+        _ => null,
+    };
+
+    private void RefreshBarrelState(StylusEventArgs e)
+    {
+        if (_barrelButton is not null &&
+            BarrelToolFor(_settings.PenButtons.Barrel) is BoardTool tool)
         {
-            return false;
+            ApplyTemporaryBarrelTool(tool, e);
+        }
+        else
+        {
+            EndTemporaryBarrelTool();
         }
 
-        if (name.Contains('2', StringComparison.Ordinal) ||
-            name.Contains("Upper", StringComparison.OrdinalIgnoreCase) ||
-            name.Contains("Secondary", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        var extras = device.StylusButtons
-            .Cast<StylusButton>()
-            .Where(item =>
-            {
-                var itemName = item.Name ?? string.Empty;
-                return !itemName.Contains("Tip", StringComparison.OrdinalIgnoreCase) &&
-                       !itemName.Contains("Eraser", StringComparison.OrdinalIgnoreCase);
-            })
-            .ToArray();
-
-        return extras.Length == 0 || ReferenceEquals(extras[0], button);
     }
 
-    private void EndTemporaryLaser()
+    private void ApplyTemporaryBarrelTool(BoardTool tool, StylusEventArgs e)
     {
-        if (!_laserTemporary)
+        if (!_barrelToolTemporary)
+        {
+            _toolBeforeBarrel = _activeTool == tool ? _lastDrawingTool : _activeTool;
+            _barrelToolTemporary = true;
+            SetActiveTool(tool);
+            InkSurface.AbortWetInk();
+            _discardInkStroke = _penInContact;
+
+            // Engaging a tool from the barrel button is the one tool change that
+            // can happen without the pen moving, so it cannot wait for the next
+            // pointer event to settle the cursor.
+            UsePenCursor();
+        }
+
+        if (_penInContact && tool == BoardTool.Laser && _stylusAction != PointerAction.Laser)
+        {
+            BeginLaserContact(e);
+            _stylusAction = PointerAction.Laser;
+        }
+    }
+
+    private void EndTemporaryBarrelTool()
+    {
+        if (!_barrelToolTemporary)
         {
             return;
         }
 
-        _laserTemporary = false;
-        _laserBarrelButton = null;
+        _barrelToolTemporary = false;
+        if (_stylusAction == PointerAction.Laser)
+        {
+            StopLaserSampling();
+            LaserTrail.Lift();
+            _stylusAction = PointerAction.None;
+        }
+
         LaserTrail.HideHead();
-        SetActiveTool(_toolBeforeLaser);
+        SetActiveTool(_toolBeforeBarrel);
+        UsePenCursor();
+    }
+
+    // WPF's neutral pressure: a constrained segment is drawn at exactly the
+    // configured thickness, with no taper at either end.
+    private const float StraightLinePressure = 0.5f;
+
+    // Packets arrive a few milliseconds apart, so a lift is tens of weightless
+    // ones. A shorter run is the digitizer missing a reading.
+    private const int LiftedPacketCount = 4;
+
+    private bool StraightLineConstraintActive =>
+        Keyboard.Modifiers.HasFlag(ModifierKeys.Shift) ||
+        BarrelHolds(PenButtonAction.StraightLine);
+
+    private bool IsInkTool =>
+        EffectiveTool is BoardTool.Pen or BoardTool.Highlighter or BoardTool.Calligraphy;
+
+    // The barrel button is whichever button is neither the writing tip nor the
+    // reverse end. Both of those raise button events of their own - the tip on
+    // every contact, the reverse end when it lands - and neither is assignable.
+    private static bool IsBarrelButton(StylusDevice device, StylusButton button)
+    {
+        if (button.Guid == StylusPointProperties.TipButton.Id ||
+            PenBarrelButton.IsWritingTipName(button.Name))
+        {
+            return false;
+        }
+
+        if (button.Guid == StylusPointProperties.BarrelButton.Id)
+        {
+            return true;
+        }
+
+        if (button.Guid == StylusPointProperties.SecondaryTipButton.Id ||
+            PenBarrelButton.IsReverseEndName(button.Name))
+        {
+            return false;
+        }
+
+        // A pen that names its buttons something else entirely: take the first
+        // one left after the tip and the reverse end are ruled out.
+        var barrel = device.StylusButtons
+            .Cast<StylusButton>()
+            .FirstOrDefault(item =>
+                item.Guid != StylusPointProperties.TipButton.Id &&
+                item.Guid != StylusPointProperties.SecondaryTipButton.Id &&
+                !PenBarrelButton.IsWritingTipName(item.Name) &&
+                !PenBarrelButton.IsReverseEndName(item.Name));
+        return barrel is not null && ReferenceEquals(barrel, button);
     }
 
     private const float MouseLaserPressure = 0.5f;
@@ -2118,11 +2356,7 @@ public partial class MainWindow : Window
     }
 
     private BoardTool EffectiveTool =>
-        _spaceTemporaryPan
-            ? BoardTool.Pan
-            : _laserTemporary
-                ? BoardTool.Laser
-                : _activeTool;
+        _spaceTemporaryPan ? BoardTool.Pan : _activeTool;
 
     private void LaserToolButton_Click(object sender, RoutedEventArgs e) =>
         SetActiveTool(BoardTool.Laser);
@@ -2199,6 +2433,9 @@ public partial class MainWindow : Window
         }
 
         UpdateDualToolChecks();
+        // Ink here is the finger's; the pen's is collected by AppendPenInk. A
+        // stylus reading as inverted is a pen the wrong way round, and erasing
+        // is ours to do, so the InkCanvas is given nothing to do with it.
         InkSurface.EditingMode =
             tool is BoardTool.Pen or BoardTool.Highlighter or BoardTool.Calligraphy or BoardTool.Laser
             ? InkCanvasEditingMode.Ink
@@ -2644,10 +2881,10 @@ public partial class MainWindow : Window
 
     private void LeaveLaserIfActive()
     {
-        if (_laserTemporary)
+        if (_barrelToolTemporary)
         {
-            _laserTemporary = false;
-            _laserBarrelButton = null;
+            _barrelToolTemporary = false;
+            _barrelButton = null;
         }
 
         if (_activeTool == BoardTool.Laser)
@@ -4382,7 +4619,6 @@ public partial class MainWindow : Window
         var controlDown = modifiers.HasFlag(ModifierKeys.Control);
         var shiftDown = modifiers.HasFlag(ModifierKeys.Shift);
         var altDown = modifiers.HasFlag(ModifierKeys.Alt) || e.Key == Key.System;
-        InkSurface.SetStraightLineMode(shiftDown);
 
         if (e.Key == Key.F11 || (e.Key == Key.System && e.SystemKey == Key.F11))
         {
@@ -4653,8 +4889,6 @@ public partial class MainWindow : Window
 
     private void Window_PreviewKeyUp(object sender, KeyEventArgs e)
     {
-        InkSurface.SetStraightLineMode(
-            Keyboard.Modifiers.HasFlag(ModifierKeys.Shift));
         if (e.Key == Key.Space && _spaceTemporaryPan)
         {
             _spaceTemporaryPan = false;
@@ -4681,16 +4915,14 @@ public partial class MainWindow : Window
         _mouseAction = PointerAction.None;
         _penInContact = false;
         _syntheticLaserContact = false;
-        InkSurface.SetStraightLineMode(false);
+        _barrelButton = null;
+        EndPenInk();
         ClearTouchNavigation();
         InkSurface.Cursor = Cursors.Arrow;
         HidePointerDot();
         StopLaserSampling();
         LaserTrail.HideHead();
-        if (_laserTemporary)
-        {
-            EndTemporaryLaser();
-        }
+        EndTemporaryBarrelTool();
     }
 
     private void Window_Closing(object? sender, CancelEventArgs e)
@@ -4704,6 +4936,11 @@ public partial class MainWindow : Window
 
     private void Window_PreviewStylusInRange(object sender, StylusEventArgs e)
     {
+        if (!IsTouchStylus(e))
+        {
+            PenTrace.Write("in-range", e, PenTraceState());
+        }
+
         if (!_penInContact)
         {
             UpdateHoverPointerDot(e);
@@ -4714,12 +4951,34 @@ public partial class MainWindow : Window
     {
         if (!IsTouchStylus(e))
         {
+            EndPenInk();
             HidePointerDot();
         }
     }
 
-    private void Window_PreviewStylusInAirMove(object sender, StylusEventArgs e) =>
+    // The pen reports the same way in the air as in contact - and while a barrel
+    // button is held it reports in the air the whole time, pressure and all. The
+    // packets are the same packets; only WPF's opinion of them differs.
+    private void Window_PreviewStylusInAirMove(object sender, StylusEventArgs e)
+    {
+        if (!IsTouchStylus(e))
+        {
+            PenTrace.Write("air-move", e, PenTraceState());
+            AppendPenInk(e);
+            if (_penInk.Count > 0)
+            {
+                return;
+            }
+
+            _penInContact = false;
+        }
+
         UpdateHoverPointerDot(e);
+    }
+
+    private string PenTraceState() =>
+        $"contact={_penInContact} barrel={_barrelButton is not null} " +
+        $"temporary={_barrelToolTemporary} action={_stylusAction} tool={EffectiveTool}";
 
     private void HoverTracker_Hovered(Point inkSurfacePoint)
     {

--- a/src/SQLBI.Whiteboard/PenOnlyInkCanvas.cs
+++ b/src/SQLBI.Whiteboard/PenOnlyInkCanvas.cs
@@ -5,6 +5,7 @@ using System.Windows.Input;
 using System.Windows.Input.StylusPlugIns;
 using System.Windows.Media;
 using System.Windows.Threading;
+using SQLBI.Whiteboard.Core.Geometry;
 using SQLBI.Whiteboard.Core.Model;
 
 namespace SQLBI.Whiteboard;
@@ -40,6 +41,12 @@ public sealed class PenOnlyInkCanvas : InkCanvas
 
     public void SetAllowTouchInk(bool allow) =>
         _penOnlyRenderer.SetAllowTouchInk(allow);
+
+    public void SetStraightLineMode(bool active) =>
+        _penOnlyRenderer.SetStraightLineMode(active);
+
+    public StraightLineDirection TakeCompletedStraightLineDirection() =>
+        _penOnlyRenderer.TakeCompletedStraightLineDirection();
 
     public void AbortWetInk()
     {
@@ -208,10 +215,16 @@ internal sealed class PenOnlyDynamicRenderer : DynamicRenderer
     private volatile PenKind _penKind;
     private volatile bool _laserMode;
     private volatile bool _allowTouchInk;
+    private volatile bool _straightLineMode;
     private PenKind _strokeKind;
     private StylusPoint? _lastCalligraphyPoint;
     private int _lastPacketTimestamp;
     private double _smoothedCalligraphySpeed;
+    private bool _straightLineStroke;
+    private bool _straightLineDecisionMade;
+    private StraightLineDirection _straightLineDirection;
+    private StylusPoint? _straightLineAnchor;
+    private int _completedStraightLineDirection;
 
     public PenOnlyDynamicRenderer(IEnumerable<int> touchTabletIds)
     {
@@ -244,8 +257,19 @@ internal sealed class PenOnlyDynamicRenderer : DynamicRenderer
         }
     }
 
+    public void SetStraightLineMode(bool active) => _straightLineMode = active;
+
+    public StraightLineDirection TakeCompletedStraightLineDirection() =>
+        (StraightLineDirection)Interlocked.Exchange(
+            ref _completedStraightLineDirection,
+            (int)StraightLineDirection.None);
+
     public void AbortWetInk()
     {
+        ResetStraightLineStroke();
+        Interlocked.Exchange(
+            ref _completedStraightLineDirection,
+            (int)StraightLineDirection.None);
         Enabled = false;
         Enabled = true;
     }
@@ -264,7 +288,9 @@ internal sealed class PenOnlyDynamicRenderer : DynamicRenderer
 
         _strokeKind = _penKind;
         ResetCalligraphyDynamics();
+        BeginStraightLineStroke(rawStylusInput);
         ApplyCalligraphyDynamics(rawStylusInput);
+        ApplyStraightLine(rawStylusInput);
         base.OnStylusDown(rawStylusInput);
     }
 
@@ -276,6 +302,7 @@ internal sealed class PenOnlyDynamicRenderer : DynamicRenderer
         }
 
         ApplyCalligraphyDynamics(rawStylusInput);
+        ApplyStraightLine(rawStylusInput);
         base.OnStylusMove(rawStylusInput);
     }
 
@@ -287,8 +314,15 @@ internal sealed class PenOnlyDynamicRenderer : DynamicRenderer
         }
 
         ApplyCalligraphyDynamics(rawStylusInput);
+        ApplyStraightLine(rawStylusInput);
+        Interlocked.Exchange(
+            ref _completedStraightLineDirection,
+            (int)(_straightLineStroke
+                ? _straightLineDirection
+                : StraightLineDirection.None));
         base.OnStylusUp(rawStylusInput);
         ResetCalligraphyDynamics();
+        ResetStraightLineStroke();
     }
 
     protected override void OnDraw(
@@ -359,6 +393,97 @@ internal sealed class PenOnlyDynamicRenderer : DynamicRenderer
         _smoothedCalligraphySpeed = 0;
     }
 
+    private void BeginStraightLineStroke(RawStylusInput rawStylusInput)
+    {
+        ResetStraightLineStroke();
+        Interlocked.Exchange(
+            ref _completedStraightLineDirection,
+            (int)StraightLineDirection.None);
+        _straightLineStroke = _straightLineMode && !IsTouchTablet(rawStylusInput);
+        if (!_straightLineStroke)
+        {
+            return;
+        }
+
+        var points = rawStylusInput.GetStylusPoints();
+        if (points.Count > 0)
+        {
+            _straightLineAnchor = points[0];
+        }
+    }
+
+    private void ApplyStraightLine(RawStylusInput rawStylusInput)
+    {
+        if (!_straightLineStroke)
+        {
+            return;
+        }
+
+        var points = rawStylusInput.GetStylusPoints();
+        if (points.Count == 0)
+        {
+            return;
+        }
+
+        _straightLineAnchor ??= points[0];
+        var anchor = _straightLineAnchor.Value;
+        if (!_straightLineDecisionMade)
+        {
+            var latest = points[^1];
+            var anchorPoint = new PointD(anchor.X, anchor.Y);
+            var latestPoint = new PointD(latest.X, latest.Y);
+            if (!StraightLineSnap.HasActivationDistance(anchorPoint, latestPoint))
+            {
+                for (var index = 0; index < points.Count; index++)
+                {
+                    var point = points[index];
+                    point.X = anchor.X;
+                    point.Y = anchor.Y;
+                    points[index] = point;
+                }
+
+                rawStylusInput.SetStylusPoints(points);
+                return;
+            }
+
+            _straightLineDirection = StraightLineSnap.DetectDirection(
+                anchorPoint,
+                latestPoint);
+            _straightLineDecisionMade = true;
+        }
+
+        if (_straightLineDirection == StraightLineDirection.None)
+        {
+            return;
+        }
+
+        var fixedPoint = new PointD(anchor.X, anchor.Y);
+        for (var index = 0; index < points.Count; index++)
+        {
+            var point = points[index];
+            var snapped = StraightLineSnap.Apply(
+                new PointD(point.X, point.Y),
+                fixedPoint,
+                _straightLineDirection);
+            point.X = snapped.X;
+            point.Y = snapped.Y;
+            points[index] = point;
+        }
+
+        rawStylusInput.SetStylusPoints(points);
+    }
+
+    private void ResetStraightLineStroke()
+    {
+        _straightLineStroke = false;
+        _straightLineDecisionMade = false;
+        _straightLineDirection = StraightLineDirection.None;
+        _straightLineAnchor = null;
+    }
+
     private bool IsTouch(RawStylusInput rawStylusInput) =>
         !_allowTouchInk && _touchTabletIds.ContainsKey(rawStylusInput.TabletDeviceId);
+
+    private bool IsTouchTablet(RawStylusInput rawStylusInput) =>
+        _touchTabletIds.ContainsKey(rawStylusInput.TabletDeviceId);
 }

--- a/src/SQLBI.Whiteboard/PenTrace.cs
+++ b/src/SQLBI.Whiteboard/PenTrace.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Windows.Input;
+
+namespace SQLBI.Whiteboard;
+
+/// <summary>
+/// Writes what the digitizer actually reports to a file, so the pen-button code
+/// can be settled from facts rather than from inference. Windows describes the
+/// upper side button and a pen turned round with the same Invert bit, and which
+/// of the two carries a button event turns out to differ between devices - the
+/// only way to know is to look.
+///
+/// Off unless SQLBI_WHITEBOARD_PENTRACE names a file to write to.
+/// </summary>
+internal static class PenTrace
+{
+    private static readonly object Gate = new();
+    private static readonly string? Path =
+        Environment.GetEnvironmentVariable("SQLBI_WHITEBOARD_PENTRACE");
+
+    public static bool Enabled => !string.IsNullOrWhiteSpace(Path);
+
+    public static void Note(string what, string detail)
+    {
+        if (!Enabled)
+        {
+            return;
+        }
+
+        Append($"{Milliseconds()} {what} {detail}");
+    }
+
+    public static void Write(string what, StylusEventArgs e, string state)
+    {
+        if (!Enabled)
+        {
+            return;
+        }
+
+        var device = e.StylusDevice;
+        var line = new StringBuilder();
+        line.Append(Milliseconds());
+        line.Append(' ').Append(what);
+        line.Append(" inverted=").Append(device.Inverted);
+        line.Append(" inAir=").Append(device.InAir);
+        line.Append(" tablet=").Append(device.TabletDevice.Type);
+
+        if (e is StylusButtonEventArgs buttonArgs)
+        {
+            line.Append(" button='").Append(buttonArgs.StylusButton.Name).Append('\'');
+            line.Append(" guid=").Append(buttonArgs.StylusButton.Guid);
+        }
+
+        foreach (StylusButton button in device.StylusButtons)
+        {
+            line.Append(" [").Append(button.Name).Append('=')
+                .Append(button.StylusButtonState).Append(']');
+        }
+
+        var points = e.GetStylusPoints(e.Device.Target as System.Windows.IInputElement);
+        if (points.Count > 0)
+        {
+            var point = points[^1];
+            line.Append(" at=").Append(point.X.ToString("0")).Append(',')
+                .Append(point.Y.ToString("0"));
+            line.Append(" n=").Append(points.Count);
+            line.Append(" pressure=").Append(point.PressureFactor.ToString("0.###"));
+            Append(line, point, "tip", StylusPointProperties.TipButton);
+            Append(line, point, "barrel", StylusPointProperties.BarrelButton);
+            Append(line, point, "secondary", StylusPointProperties.SecondaryTipButton);
+        }
+
+        line.Append(' ').Append(state);
+        Append(line.ToString());
+    }
+
+    private static long Milliseconds() =>
+        Stopwatch.GetTimestamp() / (Stopwatch.Frequency / 1000);
+
+    private static void Append(string line)
+    {
+        lock (Gate)
+        {
+            try
+            {
+                File.AppendAllText(Path!, line + Environment.NewLine);
+            }
+            catch (IOException)
+            {
+                // A trace that cannot be written must not take the session with it.
+            }
+        }
+    }
+
+    private static void Append(
+        StringBuilder line,
+        StylusPoint point,
+        string name,
+        StylusPointProperty property)
+    {
+        if (point.HasProperty(property))
+        {
+            line.Append(' ').Append(name).Append('=')
+                .Append(point.GetPropertyValue(property));
+        }
+    }
+}

--- a/src/SQLBI.Whiteboard/PreferencesWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/PreferencesWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Shapes;
 using SQLBI.Whiteboard.Core.Model;
 using SQLBI.Whiteboard.Core.Settings;
 
@@ -173,7 +174,12 @@ public partial class PreferencesWindow : Window
             body.Children.Add(value);
             body.Children.Add(slider);
         }
-        else if (setting.Editor is SettingEditorKind.OrderedList or SettingEditorKind.LaserWeightChoice)
+        else if (setting.Editor is
+                 SettingEditorKind.OrderedList or
+                 SettingEditorKind.LaserWeightChoice or
+                 SettingEditorKind.PenButtonChoice or
+                 SettingEditorKind.ToolbarPlacementChoice or
+                 SettingEditorKind.ToolbarLayoutChoice)
         {
             body.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
             body.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
@@ -208,17 +214,21 @@ public partial class PreferencesWindow : Window
             SettingEditorKind.MonitorChoice => CreateMonitorCombo(),
             SettingEditorKind.OrderedList => CreateOrderedList(setting),
             SettingEditorKind.LaserWeightChoice => CreateLaserWeightChoice(setting),
+            SettingEditorKind.PenButtonChoice =>
+                CreateSampleChoice(setting, CreatePenButtonSample),
+            SettingEditorKind.ToolbarPlacementChoice =>
+                CreateSampleChoice(setting, CreateToolbarPlacementSample),
+            SettingEditorKind.ToolbarLayoutChoice =>
+                CreateSampleChoice(setting, CreateToolbarLayoutSample),
             _ => CreateEnumCombo(setting),
         };
 
-    // Each option is drawn as the strokes it produces, at the same width and
-    // opacity the trail itself would use, so the choice is made by looking
-    // rather than by imagining what a word means.
-    private FrameworkElement CreateLaserWeightChoice(SettingDescriptor setting)
+    // Options that are drawn rather than named: each is a sample under its own
+    // label, and the row of them behaves as one choice.
+    private FrameworkElement CreateSampleChoice(
+        SettingDescriptor setting,
+        Func<string, FrameworkElement?> sampleFor)
     {
-        const float LightTouch = 0.08f;
-        const float FirmTouch = 0.6f;
-
         var host = new UniformGrid
         {
             Rows = 1,
@@ -228,28 +238,31 @@ public partial class PreferencesWindow : Window
         var segments = new List<ToggleButton>();
         foreach (var choice in setting.Choices)
         {
-            if (!Enum.TryParse<LaserTrailWeight>(choice.Id, out var weight))
+            if (sampleFor(choice.Id) is not { } sample)
             {
                 continue;
             }
 
-            var samples = new StackPanel { HorizontalAlignment = HorizontalAlignment.Center };
-            samples.Children.Add(CreateLaserSample(weight, LightTouch));
-            samples.Children.Add(CreateLaserSample(weight, FirmTouch));
-            samples.Children.Add(new TextBlock
+            var content = new StackPanel { HorizontalAlignment = HorizontalAlignment.Center };
+            sample.HorizontalAlignment = HorizontalAlignment.Center;
+            content.Children.Add(sample);
+            content.Children.Add(new TextBlock
             {
                 Style = (Style)FindResource("SettingsValueLabel"),
                 Text = choice.Title,
                 Margin = new Thickness(0, 8, 0, 0),
+                TextWrapping = TextWrapping.Wrap,
+                TextAlignment = TextAlignment.Center,
                 HorizontalAlignment = HorizontalAlignment.Center,
             });
 
             var segment = new ToggleButton
             {
                 Style = (Style)FindResource("SettingsSampleSegment"),
-                Content = samples,
+                Content = content,
                 IsChecked = choice.Id == CurrentEnumId(setting),
                 Tag = choice.Id,
+                ToolTip = choice.Title,
             };
             segment.Click += (_, _) =>
             {
@@ -266,6 +279,238 @@ public partial class PreferencesWindow : Window
 
         return host;
     }
+
+    private static readonly Brush SampleInkBrush = Frozen(0xFF374151);
+    private static readonly Brush SampleGhostBrush = Frozen(0x59374151);
+    private static readonly Brush SampleBoardBrush = Frozen(0xFFFFFFFF);
+    private static readonly Brush SampleEdgeBrush = Frozen(0xFFD1D5DB);
+    private static readonly Brush SampleAccentBrush = Frozen(0xFF2563EB);
+
+    private static Brush Frozen(uint argb)
+    {
+        var brush = new SolidColorBrush(Color.FromArgb(
+            (byte)(argb >> 24),
+            (byte)(argb >> 16),
+            (byte)(argb >> 8),
+            (byte)argb));
+        brush.Freeze();
+        return brush;
+    }
+
+    // The laser lays a fading trail behind a bright head; the straight line
+    // takes the same wandering hand and rules it flat.
+    private FrameworkElement? CreatePenButtonSample(string id)
+    {
+        if (!Enum.TryParse<PenButtonAction>(id, out var action))
+        {
+            return null;
+        }
+
+        var canvas = new Canvas { Width = 84, Height = 34 };
+        if (action == PenButtonAction.Laser)
+        {
+            for (var step = 0; step < 7; step++)
+            {
+                var fraction = step / 6d;
+                var size = 3 + (7 * fraction);
+                var trail = new Ellipse
+                {
+                    Width = size,
+                    Height = size,
+                    Fill = Frozen((uint)((byte)(40 + (190 * fraction)) << 24) |
+                                  ((uint)LaserSettings.TrailRed << 16) |
+                                  ((uint)LaserSettings.TrailGreen << 8) |
+                                  LaserSettings.TrailBlue),
+                };
+                Canvas.SetLeft(trail, 8 + (fraction * 60) - (size / 2));
+                Canvas.SetTop(trail, 17 - (size / 2) - (Math.Sin(fraction * 3) * 5));
+                canvas.Children.Add(trail);
+            }
+
+            return canvas;
+        }
+
+        canvas.Children.Add(new Polyline
+        {
+            Points = [
+                new Point(6, 24), new Point(20, 12), new Point(34, 22),
+                new Point(48, 10), new Point(62, 20), new Point(78, 12),
+            ],
+            Stroke = SampleGhostBrush,
+            StrokeThickness = 2,
+            StrokeStartLineCap = PenLineCap.Round,
+            StrokeEndLineCap = PenLineCap.Round,
+            StrokeLineJoin = PenLineJoin.Round,
+        });
+
+        var ruled = new Rectangle
+        {
+            Width = 72,
+            Height = 4,
+            RadiusX = 2,
+            RadiusY = 2,
+            Fill = SampleInkBrush,
+        };
+        Canvas.SetLeft(ruled, 6);
+        Canvas.SetTop(ruled, 15);
+        canvas.Children.Add(ruled);
+        return canvas;
+    }
+
+    // A board with the toolbar in it, so the corner is seen rather than read.
+    private FrameworkElement? CreateToolbarPlacementSample(string id)
+    {
+        if (!Enum.TryParse<ToolbarPlacement>(id, out var placement))
+        {
+            return null;
+        }
+
+        var bar = new Border
+        {
+            Width = placement == ToolbarPlacement.BottomCenter ? 30 : 24,
+            Height = 7,
+            CornerRadius = new CornerRadius(3.5),
+            Background = SampleAccentBrush,
+            Margin = new Thickness(5),
+            HorizontalAlignment = placement switch
+            {
+                ToolbarPlacement.TopLeft or ToolbarPlacement.BottomLeft =>
+                    HorizontalAlignment.Left,
+                ToolbarPlacement.BottomCenter => HorizontalAlignment.Center,
+                _ => HorizontalAlignment.Right,
+            },
+            VerticalAlignment = placement is ToolbarPlacement.TopLeft or ToolbarPlacement.TopRight
+                ? VerticalAlignment.Top
+                : VerticalAlignment.Bottom,
+        };
+
+        return new Border
+        {
+            Width = 76,
+            Height = 46,
+            CornerRadius = new CornerRadius(6),
+            Background = SampleBoardBrush,
+            BorderBrush = SampleEdgeBrush,
+            BorderThickness = new Thickness(1),
+            Child = bar,
+        };
+    }
+
+    // A miniature of the ink flyout each layout produces.
+    private FrameworkElement? CreateToolbarLayoutSample(string id)
+    {
+        if (!Enum.TryParse<CalligraphyAccess>(id, out var access))
+        {
+            return null;
+        }
+
+        var rows = new StackPanel
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        switch (access)
+        {
+            case CalligraphyAccess.DualPalette:
+                // Two tools' colors and sizes, both on show at once.
+                rows.Children.Add(SampleChipRow(4, chevron: false, nibs: false));
+                rows.Children.Add(SampleChipRow(4, chevron: false, nibs: false));
+                break;
+            case CalligraphyAccess.Chevron:
+                // One compact bar, the second tool behind a chevron.
+                rows.Children.Add(SampleChipRow(4, chevron: true, nibs: false));
+                break;
+            default:
+                // One bar, the nibs trailing the size chips.
+                rows.Children.Add(SampleChipRow(3, chevron: false, nibs: true));
+                break;
+        }
+
+        return new Border
+        {
+            Width = 76,
+            Height = 46,
+            CornerRadius = new CornerRadius(6),
+            Background = SampleBoardBrush,
+            BorderBrush = SampleEdgeBrush,
+            BorderThickness = new Thickness(1),
+            Child = rows,
+        };
+    }
+
+    private static StackPanel SampleChipRow(int chips, bool chevron, bool nibs)
+    {
+        var row = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Margin = new Thickness(0, 2, 0, 2),
+        };
+
+        for (var index = 0; index < chips; index++)
+        {
+            var size = nibs ? 5 + (index * 2) : 8;
+            row.Children.Add(new Ellipse
+            {
+                Width = size,
+                Height = size,
+                Margin = new Thickness(2, 0, 2, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+                Fill = index == 0 ? SampleAccentBrush : SampleGhostBrush,
+            });
+        }
+
+        if (chevron)
+        {
+            row.Children.Add(new Polyline
+            {
+                Points = [new Point(0, 0), new Point(4, 4), new Point(8, 0)],
+                Stroke = SampleInkBrush,
+                StrokeThickness = 1.6,
+                Margin = new Thickness(3, 0, 0, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+        }
+
+        if (nibs)
+        {
+            for (var index = 0; index < 2; index++)
+            {
+                row.Children.Add(new Rectangle
+                {
+                    Width = 7,
+                    Height = index == 0 ? 7 : 3,
+                    RadiusX = 1.5,
+                    RadiusY = 1.5,
+                    Margin = new Thickness(3, 0, 0, 0),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Fill = SampleInkBrush,
+                });
+            }
+        }
+
+        return row;
+    }
+
+    // Each option is drawn as the strokes it produces, at the same width and
+    // opacity the trail itself would use, so the choice is made by looking
+    // rather than by imagining what a word means.
+    private FrameworkElement CreateLaserWeightChoice(SettingDescriptor setting) =>
+        CreateSampleChoice(setting, id =>
+        {
+            const float LightTouch = 0.08f;
+            const float FirmTouch = 0.6f;
+            if (!Enum.TryParse<LaserTrailWeight>(id, out var weight))
+            {
+                return null;
+            }
+
+            var samples = new StackPanel();
+            samples.Children.Add(CreateLaserSample(weight, LightTouch));
+            samples.Children.Add(CreateLaserSample(weight, FirmTouch));
+            return samples;
+        });
 
     private Border CreateLaserSample(LaserTrailWeight weight, float pressure)
     {
@@ -547,6 +792,7 @@ public partial class PreferencesWindow : Window
             SettingsCatalog.Ids.ToolbarPlacement => _settings.ToolbarPlacement.ToString(),
             SettingsCatalog.Ids.ToolbarLayout => _settings.CalligraphyAccess.ToString(),
             SettingsCatalog.Ids.FingerMode => _settings.FingerMode.ToString(),
+            SettingsCatalog.Ids.PenButton => _settings.PenButtons.Barrel.ToString(),
             _ => string.Empty,
         };
 
@@ -621,6 +867,10 @@ public partial class PreferencesWindow : Window
             case SettingsCatalog.Ids.FingerMode
                 when Enum.TryParse<FingerMode>(id, out var fingerMode):
                 _settings.FingerMode = fingerMode;
+                break;
+            case SettingsCatalog.Ids.PenButton
+                when Enum.TryParse<PenButtonAction>(id, out var penButton):
+                _settings.PenButtons.Barrel = penButton;
                 break;
             default:
                 return;

--- a/src/SQLBI.Whiteboard/SettingsCatalog.cs
+++ b/src/SQLBI.Whiteboard/SettingsCatalog.cs
@@ -16,6 +16,23 @@ internal enum SettingEditorKind
     /// is a setting about how something looks.
     /// </summary>
     LaserWeightChoice,
+
+    /// <summary>
+    /// What the pen's barrel button does, drawn as what it draws: a laser trail
+    /// or a wobble ruled straight.
+    /// </summary>
+    PenButtonChoice,
+
+    /// <summary>
+    /// Where the toolbar sits, drawn as a board with the toolbar in it. A corner
+    /// is a place, and a picture of the place beats the name of it.
+    /// </summary>
+    ToolbarPlacementChoice,
+
+    /// <summary>
+    /// How the ink flyout is arranged, drawn as a miniature of the flyout.
+    /// </summary>
+    ToolbarLayoutChoice,
 }
 
 internal sealed class SettingChoice
@@ -66,6 +83,7 @@ internal static class SettingsCatalog
         public const string ToolbarPlacement = "toolbar.placement";
         public const string ToolbarLayout = "toolbar.layout";
         public const string FingerMode = "input.fingerMode";
+        public const string PenButton = "input.penButton";
         public const string SnippetFormatOrder = "input.snippetFormatOrder";
         public const string CheckForUpdates = "updates.check";
     }
@@ -112,6 +130,20 @@ internal static class SettingsCatalog
                 new() { Id = nameof(Core.Settings.FingerMode.WhenNoPen), Title = "When no pen is detected" },
                 new() { Id = nameof(Core.Settings.FingerMode.Off), Title = "Off" },
                 new() { Id = nameof(Core.Settings.FingerMode.On), Title = "On" },
+            ],
+        },
+        new()
+        {
+            Id = Ids.PenButton,
+            Category = Input,
+            Title = "Pen button",
+            Description = "The barrel button on the side of the pen. Hold it for the assigned action: Laser lasts only while the button is down, Straight line is the same constraint as holding Shift. The reverse end of the pen always erases, and so does the upper button, because Windows reports the two the same way.",
+            Keywords = ["pen", "barrel", "button", "laser", "straight", "line", "shift", "stylus", "eraser", "wacom", "cintiq"],
+            Editor = SettingEditorKind.PenButtonChoice,
+            Choices =
+            [
+                new() { Id = nameof(PenButtonAction.Laser), Title = "Laser" },
+                new() { Id = nameof(PenButtonAction.StraightLine), Title = "Straight line" },
             ],
         },
         new()
@@ -181,7 +213,7 @@ internal static class SettingsCatalog
             Title = "Position",
             Description = "Top right keeps the toolbar under a typical presenter picture-in-picture during recording.",
             Keywords = ["toolbar", "position", "placement", "pip"],
-            Editor = SettingEditorKind.EnumChoice,
+            Editor = SettingEditorKind.ToolbarPlacementChoice,
             Choices =
             [
                 new() { Id = nameof(ToolbarPlacement.TopRight), Title = "Top right" },
@@ -198,7 +230,7 @@ internal static class SettingsCatalog
             Title = "Layout",
             Description = "Dual palette keeps both tools’ colors and sizes visible. The other layouts use a compact bar and a single-tool panel.",
             Keywords = ["toolbar", "layout", "calligraphy", "palette", "chevron"],
-            Editor = SettingEditorKind.EnumChoice,
+            Editor = SettingEditorKind.ToolbarLayoutChoice,
             Choices =
             [
                 new() { Id = nameof(CalligraphyAccess.DualPalette), Title = "Dual palette" },

--- a/src/SQLBI.Whiteboard/TouchInkCanvas.cs
+++ b/src/SQLBI.Whiteboard/TouchInkCanvas.cs
@@ -10,87 +10,50 @@ using SQLBI.Whiteboard.Core.Model;
 
 namespace SQLBI.Whiteboard;
 
-public sealed class PenOnlyInkCanvas : InkCanvas
+/// <summary>
+/// The finger's ink surface, and the host for the laser sampler and the hover
+/// tracker. It collects no pen ink: the pen's packets are read directly by the
+/// window - see MainWindow.AppendPenInk - because a barrel button tears the WPF
+/// contact in two every time it is pressed or released, and no stroke built on
+/// that bookkeeping could be made to behave like the Shift key.
+/// </summary>
+public sealed class TouchInkCanvas : InkCanvas
 {
-    private readonly PenOnlyDynamicRenderer _penOnlyRenderer;
+    private readonly TouchOnlyDynamicRenderer _touchRenderer;
 
     public LaserSamplePlugIn LaserSamples { get; } = new();
 
     public HoverTrackerPlugIn HoverTracker { get; } = new();
 
-    public PenOnlyInkCanvas()
+    public TouchInkCanvas()
     {
         var touchTabletIds = Tablet.TabletDevices
             .Cast<TabletDevice>()
             .Where(device => device.Type == TabletDeviceType.Touch)
             .Select(device => device.Id);
-        _penOnlyRenderer = new PenOnlyDynamicRenderer(touchTabletIds);
-        DynamicRenderer = _penOnlyRenderer;
+        _touchRenderer = new TouchOnlyDynamicRenderer(touchTabletIds);
+        DynamicRenderer = _touchRenderer;
         StylusPlugIns.Add(LaserSamples);
         StylusPlugIns.Add(HoverTracker);
     }
 
     public void RegisterTouchTablet(int tabletDeviceId) =>
-        _penOnlyRenderer.RegisterTouchTablet(tabletDeviceId);
+        _touchRenderer.RegisterTouchTablet(tabletDeviceId);
 
-    public void SetPenKind(PenKind kind) =>
-        _penOnlyRenderer.SetPenKind(kind);
+    public void SetPenKind(PenKind kind) => _touchRenderer.SetPenKind(kind);
 
-    public void SetLaserMode(bool laser) =>
-        _penOnlyRenderer.SetLaserMode(laser);
+    public void SetLaserMode(bool laser) => _touchRenderer.SetLaserMode(laser);
 
-    public void SetAllowTouchInk(bool allow) =>
-        _penOnlyRenderer.SetAllowTouchInk(allow);
-
-    public void SetStraightLineMode(bool active) =>
-        _penOnlyRenderer.SetStraightLineMode(active);
-
-    public StraightLineDirection TakeCompletedStraightLineDirection() =>
-        _penOnlyRenderer.TakeCompletedStraightLineDirection();
+    public void SetAllowTouchInk(bool allow) => _touchRenderer.SetAllowTouchInk(allow);
 
     public void AbortWetInk()
     {
-        _penOnlyRenderer.AbortWetInk();
+        _touchRenderer.AbortWetInk();
         Strokes.Clear();
     }
 
-    public void DrainLaserSamples(Action<Point, float> consume)
-    {
+    public void DrainLaserSamples(Action<Point, float> consume) =>
         LaserSamples.Drain(consume);
-    }
-}
-
-// Clicking the barrel button over a hovering pen is delivered as a stylus down
-// that claims everything a real touch claims - not in air, tip switch pressed.
-// Only the pressure gives it away, because nothing is pressing on the tip.
-// Requiring the barrel to be down as well keeps a genuinely light first packet
-// from being mistaken for one of these.
-internal static class PhantomStylus
-{
-    public static bool IsBarrelDown(StylusPointCollection points)
-    {
-        if (points.Count == 0)
-        {
-            return false;
-        }
-
-        for (var index = 0; index < points.Count; index++)
-        {
-            var point = points[index];
-            if (point.PressureFactor > 0)
-            {
-                return false;
-            }
-
-            if (!point.HasProperty(StylusPointProperties.BarrelButton) ||
-                point.GetPropertyValue(StylusPointProperties.BarrelButton) == 0)
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
 }
 
 public sealed class LaserSamplePlugIn : StylusPlugIn
@@ -209,24 +172,24 @@ public sealed class HoverTrackerPlugIn : StylusPlugIn
     }
 }
 
-internal sealed class PenOnlyDynamicRenderer : DynamicRenderer
+/// <summary>
+/// Wet ink for the finger only. Pen ink is collected and drawn by the window
+/// from the pen's own packet stream, because a barrel button tears the WPF
+/// contact in two every time it is pressed or released - see TODO.md - and a
+/// wet stroke driven by that bookkeeping cannot match the stroke that results.
+/// </summary>
+internal sealed class TouchOnlyDynamicRenderer : DynamicRenderer
 {
     private readonly ConcurrentDictionary<int, byte> _touchTabletIds = new();
-    private volatile PenKind _penKind;
     private volatile bool _laserMode;
     private volatile bool _allowTouchInk;
-    private volatile bool _straightLineMode;
+    private volatile PenKind _penKind;
     private PenKind _strokeKind;
     private StylusPoint? _lastCalligraphyPoint;
     private int _lastPacketTimestamp;
     private double _smoothedCalligraphySpeed;
-    private bool _straightLineStroke;
-    private bool _straightLineDecisionMade;
-    private StraightLineDirection _straightLineDirection;
-    private StylusPoint? _straightLineAnchor;
-    private int _completedStraightLineDirection;
 
-    public PenOnlyDynamicRenderer(IEnumerable<int> touchTabletIds)
+    public TouchOnlyDynamicRenderer(IEnumerable<int> touchTabletIds)
     {
         foreach (var tabletId in touchTabletIds)
         {
@@ -257,72 +220,51 @@ internal sealed class PenOnlyDynamicRenderer : DynamicRenderer
         }
     }
 
-    public void SetStraightLineMode(bool active) => _straightLineMode = active;
-
-    public StraightLineDirection TakeCompletedStraightLineDirection() =>
-        (StraightLineDirection)Interlocked.Exchange(
-            ref _completedStraightLineDirection,
-            (int)StraightLineDirection.None);
-
     public void AbortWetInk()
     {
-        ResetStraightLineStroke();
-        Interlocked.Exchange(
-            ref _completedStraightLineDirection,
-            (int)StraightLineDirection.None);
         Enabled = false;
         Enabled = true;
     }
 
+    private bool Ignore(RawStylusInput rawStylusInput) =>
+        _laserMode ||
+        !_allowTouchInk ||
+        !_touchTabletIds.ContainsKey(rawStylusInput.TabletDeviceId);
+
     protected override void OnStylusDown(RawStylusInput rawStylusInput)
     {
-        // Without this the barrel click opens a wet stroke for a pen that never
-        // touched the glass, which is then torn down mid-flight when the button
-        // switches to the laser a moment later.
-        if (IsTouch(rawStylusInput) ||
-            _laserMode ||
-            PhantomStylus.IsBarrelDown(rawStylusInput.GetStylusPoints()))
+        if (Ignore(rawStylusInput))
         {
             return;
         }
 
         _strokeKind = _penKind;
         ResetCalligraphyDynamics();
-        BeginStraightLineStroke(rawStylusInput);
         ApplyCalligraphyDynamics(rawStylusInput);
-        ApplyStraightLine(rawStylusInput);
         base.OnStylusDown(rawStylusInput);
     }
 
     protected override void OnStylusMove(RawStylusInput rawStylusInput)
     {
-        if (IsTouch(rawStylusInput) || _laserMode)
+        if (Ignore(rawStylusInput))
         {
             return;
         }
 
         ApplyCalligraphyDynamics(rawStylusInput);
-        ApplyStraightLine(rawStylusInput);
         base.OnStylusMove(rawStylusInput);
     }
 
     protected override void OnStylusUp(RawStylusInput rawStylusInput)
     {
-        if (IsTouch(rawStylusInput) || _laserMode)
+        if (Ignore(rawStylusInput))
         {
             return;
         }
 
         ApplyCalligraphyDynamics(rawStylusInput);
-        ApplyStraightLine(rawStylusInput);
-        Interlocked.Exchange(
-            ref _completedStraightLineDirection,
-            (int)(_straightLineStroke
-                ? _straightLineDirection
-                : StraightLineDirection.None));
         base.OnStylusUp(rawStylusInput);
         ResetCalligraphyDynamics();
-        ResetStraightLineStroke();
     }
 
     protected override void OnDraw(
@@ -392,98 +334,4 @@ internal sealed class PenOnlyDynamicRenderer : DynamicRenderer
         _lastPacketTimestamp = 0;
         _smoothedCalligraphySpeed = 0;
     }
-
-    private void BeginStraightLineStroke(RawStylusInput rawStylusInput)
-    {
-        ResetStraightLineStroke();
-        Interlocked.Exchange(
-            ref _completedStraightLineDirection,
-            (int)StraightLineDirection.None);
-        _straightLineStroke = _straightLineMode && !IsTouchTablet(rawStylusInput);
-        if (!_straightLineStroke)
-        {
-            return;
-        }
-
-        var points = rawStylusInput.GetStylusPoints();
-        if (points.Count > 0)
-        {
-            _straightLineAnchor = points[0];
-        }
-    }
-
-    private void ApplyStraightLine(RawStylusInput rawStylusInput)
-    {
-        if (!_straightLineStroke)
-        {
-            return;
-        }
-
-        var points = rawStylusInput.GetStylusPoints();
-        if (points.Count == 0)
-        {
-            return;
-        }
-
-        _straightLineAnchor ??= points[0];
-        var anchor = _straightLineAnchor.Value;
-        if (!_straightLineDecisionMade)
-        {
-            var latest = points[^1];
-            var anchorPoint = new PointD(anchor.X, anchor.Y);
-            var latestPoint = new PointD(latest.X, latest.Y);
-            if (!StraightLineSnap.HasActivationDistance(anchorPoint, latestPoint))
-            {
-                for (var index = 0; index < points.Count; index++)
-                {
-                    var point = points[index];
-                    point.X = anchor.X;
-                    point.Y = anchor.Y;
-                    points[index] = point;
-                }
-
-                rawStylusInput.SetStylusPoints(points);
-                return;
-            }
-
-            _straightLineDirection = StraightLineSnap.DetectDirection(
-                anchorPoint,
-                latestPoint);
-            _straightLineDecisionMade = true;
-        }
-
-        if (_straightLineDirection == StraightLineDirection.None)
-        {
-            return;
-        }
-
-        var fixedPoint = new PointD(anchor.X, anchor.Y);
-        for (var index = 0; index < points.Count; index++)
-        {
-            var point = points[index];
-            var snapped = StraightLineSnap.Apply(
-                new PointD(point.X, point.Y),
-                fixedPoint,
-                _straightLineDirection);
-            point.X = snapped.X;
-            point.Y = snapped.Y;
-            points[index] = point;
-        }
-
-        rawStylusInput.SetStylusPoints(points);
-    }
-
-    private void ResetStraightLineStroke()
-    {
-        _straightLineStroke = false;
-        _straightLineDecisionMade = false;
-        _straightLineDirection = StraightLineDirection.None;
-        _straightLineAnchor = null;
-    }
-
-    private bool IsTouch(RawStylusInput rawStylusInput) =>
-        !_allowTouchInk && _touchTabletIds.ContainsKey(rawStylusInput.TabletDeviceId);
-
-    private bool IsTouchTablet(RawStylusInput rawStylusInput) =>
-        _touchTabletIds.ContainsKey(rawStylusInput.TabletDeviceId);
 }

--- a/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
+++ b/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
@@ -34,19 +34,43 @@ var lineAnchor = new PointD(100, 100);
 Assert(
     StraightLineSnap.DetectDirection(lineAnchor, new PointD(200, 120)) ==
     StraightLineDirection.Horizontal,
-    "A Shift stroke within 15 degrees of horizontal should snap horizontally.");
+    "A mostly horizontal constrained stroke should snap horizontally.");
 Assert(
     StraightLineSnap.DetectDirection(lineAnchor, new PointD(85, 200)) ==
     StraightLineDirection.Vertical,
-    "A Shift stroke within 15 degrees of vertical should snap vertically in either direction.");
+    "A mostly vertical constrained stroke should snap vertically in either direction.");
 Assert(
     StraightLineSnap.DetectDirection(lineAnchor, new PointD(200, 130)) ==
-    StraightLineDirection.None,
-    "A Shift stroke outside the axis tolerance should remain free.");
+    StraightLineDirection.Horizontal &&
+    StraightLineSnap.DetectDirection(lineAnchor, new PointD(130, 200)) ==
+    StraightLineDirection.Vertical,
+    "A diagonal constrained stroke should take the nearer axis, never fall back to free ink.");
+Assert(
+    StraightLineSnap.DetectDirection(lineAnchor, new PointD(160, 160)) ==
+    StraightLineDirection.Horizontal,
+    "An exactly diagonal constrained stroke should settle on one axis rather than none.");
 Assert(
     StraightLineSnap.DetectDirection(lineAnchor, new PointD(105, 102)) ==
+    StraightLineDirection.None &&
+    StraightLineSnap.DetectDirection(lineAnchor, new PointD(115, 108)) ==
     StraightLineDirection.None,
     "Straight-line direction should wait for enough movement to establish intent.");
+Assert(
+    StraightLineSnap.DetectDirection(lineAnchor, new PointD(100, 130)) ==
+    StraightLineDirection.Vertical,
+    "Once the pen has clearly turned, the axis should follow the turn.");
+Assert(
+    StraightLineSnap.Apply(
+        new PointD(180, 116),
+        lineAnchor,
+        StraightLineDirection.None) == new PointD(180, 116),
+    "Releasing the constraint should leave the remaining points exactly where the pen went.");
+Assert(
+    StraightLineSnap.Apply(
+        new PointD(300, 400),
+        lineAnchor,
+        StraightLineDirection.Horizontal) == new PointD(300, 100),
+    "A settled axis keeps its line however far off it the hand drifts.");
 Assert(
     StraightLineSnap.Apply(
         new PointD(180, 116),
@@ -850,6 +874,42 @@ Assert(
 Assert(
     AppSettingsSerializer.Parse("{ }").SnippetFormatOrder is ["plain", "dax", "sqlserver"],
     "Partial settings should fill the default snippet format order.");
+Assert(
+    defaultSettings.PenButtons.Barrel == PenButtonAction.Laser,
+    "Missing settings should assign Laser to the pen barrel button.");
+Assert(
+    AppSettingsSerializer.Parse("{ \"penButtons\": { \"barrel\": \"Sideways\" } }")
+        .PenButtons.Barrel == PenButtonAction.Laser,
+    "An unknown pen button action should fall back to Laser.");
+Assert(
+    AppSettingsSerializer.Parse("{ \"penButtons\": { \"barrel\": \"StraightLine\" } }")
+        .PenButtons.Barrel == PenButtonAction.StraightLine,
+    "A saved pen button assignment should still load.");
+Assert(
+    AppSettingsSerializer.Parse("{ \"penButtons\": { \"lower\": \"Eraser\", \"upper\": \"Laser\" } }")
+        .PenButtons.Barrel == PenButtonAction.Laser,
+    "Settings written before the upper button was dropped should load, not reset the file.");
+Assert(
+    AppSettingsSerializer.Parse(
+        AppSettingsSerializer.Format(new AppSettings
+        {
+            PenButtons = new PenButtonSettings { Barrel = PenButtonAction.StraightLine },
+        })).PenButtons.Barrel == PenButtonAction.StraightLine,
+    "Settings JSON should round-trip the pen button assignment.");
+Assert(
+    PenBarrelButton.IsWritingTipName("Tip") &&
+    PenBarrelButton.IsWritingTipName("TipButton") &&
+    !PenBarrelButton.IsWritingTipName("Eraser") &&
+    !PenBarrelButton.IsWritingTipName("Secondary Tip"),
+    "The writing tip is not the barrel button; an Eraser or Secondary name is not the tip.");
+Assert(
+    PenBarrelButton.IsReverseEndName("Eraser") &&
+    PenBarrelButton.IsReverseEndName("Barrel Button 2") &&
+    PenBarrelButton.IsReverseEndName("Upper") &&
+    PenBarrelButton.IsReverseEndName("Secondary") &&
+    !PenBarrelButton.IsReverseEndName("Barrel") &&
+    !PenBarrelButton.IsReverseEndName("Tip"),
+    "Windows names the reverse end Eraser, or the second/upper/secondary barrel.");
 
 var daxSource = """
 Tricky :=

--- a/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
+++ b/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
@@ -30,6 +30,34 @@ var framedTopLeft = camera.WorldToScreen(
 Assert(framedTopLeft.X >= 49.999999, "Framing must preserve the horizontal margin.");
 Assert(framedTopLeft.Y >= 49.999999, "Framing must preserve the vertical margin.");
 
+var lineAnchor = new PointD(100, 100);
+Assert(
+    StraightLineSnap.DetectDirection(lineAnchor, new PointD(200, 120)) ==
+    StraightLineDirection.Horizontal,
+    "A Shift stroke within 15 degrees of horizontal should snap horizontally.");
+Assert(
+    StraightLineSnap.DetectDirection(lineAnchor, new PointD(85, 200)) ==
+    StraightLineDirection.Vertical,
+    "A Shift stroke within 15 degrees of vertical should snap vertically in either direction.");
+Assert(
+    StraightLineSnap.DetectDirection(lineAnchor, new PointD(200, 130)) ==
+    StraightLineDirection.None,
+    "A Shift stroke outside the axis tolerance should remain free.");
+Assert(
+    StraightLineSnap.DetectDirection(lineAnchor, new PointD(105, 102)) ==
+    StraightLineDirection.None,
+    "Straight-line direction should wait for enough movement to establish intent.");
+Assert(
+    StraightLineSnap.Apply(
+        new PointD(180, 116),
+        lineAnchor,
+        StraightLineDirection.Horizontal) == new PointD(180, 100) &&
+    StraightLineSnap.Apply(
+        new PointD(88, 210),
+        lineAnchor,
+        StraightLineDirection.Vertical) == new PointD(100, 210),
+    "Snapping should preserve travel along the chosen axis and remove only off-axis movement.");
+
 var originalLiveViewBounds = new RectD(100, 50, 400, 200);
 var reconnectedLiveViewBounds = originalLiveViewBounds.WithCenteredAspectRatio(9d / 16d);
 AssertNear(


### PR DESCRIPTION
Straight-line strokes on Shift and on the pen's barrel button, and the ink path
that had to change for the button to work at all.

## Straight lines

Holding Shift, or the barrel button when it is assigned to Straight line,
constrains the stroke to horizontal or vertical — whichever the first 24 px of
travel is nearer — at a uniform width. The axis is settled once and kept for the
whole segment, however far off it the hand drifts. Press or release at any time:
the part already drawn stays straight and the rest goes freehand from there.

## Why the ink path changed

On a pen whose barrel switch shares its report with the tip switch, pressing or
releasing that button fabricates a stylus up followed by a stylus down, and
between a release and the next press the driver reports the tip as open while it
is still pressing. WPF tears the contact in two on every click and calls the pen
airborne in between, so an `InkCanvas` stroke joined stretches the pen never drew
and lost the ones it did. Several attempts to repair that from inside the
InkCanvas each moved the fault rather than removing it.

The pen's own packet stream never breaks — a trace of a real session established
that — so `MainWindow.AppendPenInk` now reads it directly and owns the contact,
the straight-line constraint and the calligraphy dynamics, with
`BoardSurface.PendingStroke` drawing the wet stroke. The constraint is then one
boolean read per point, which is what makes the button behave exactly like Shift:
neither has any opinion about whether WPF thinks the pen is down. Recorded as
decision 22.

`PenOnlyInkCanvas` becomes `TouchInkCanvas` and keeps the InkCanvas for finger
ink only, where nothing tears the contact.

## Pen buttons

One configurable barrel button, Laser (default) or Straight line. Erasing is not
assignable: the reverse end of the pen erases, and so does the upper side button,
because Windows describes both by inverting the stylus and the trace shows the
two producing identical events on this hardware. `PenTrace` — off unless
`SQLBI_WHITEBOARD_PENTRACE` names a file — is what settled that, and is kept for
the next pen question.

## Preferences

Pen button, Toolbar position and Toolbar layout now draw their options instead of
naming them, sharing one builder with the laser trail weights.

## Also

Version 1.1.1. README architecture notes, `site/shortcuts.html` and
`site/guide.html` brought up to date; TODO records the hardware findings and the
two constants that stand in for signals the hardware does not give.

Release build clean with `TreatWarningsAsErrors`, smoke tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
