### PR TITLE
Draw the pen's wet stroke over containers, not under them

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.1.2</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@ The delivery chain works end to end: a merge to `main` builds, signs, and publis
 pre-release to GitHub Releases, and one approval promotes that same build to a release.
 <https://whiteboard.sqlbi.com> reads its download links from the release manifest
 deployed beside it and needs no edit per release. The current product version is `VersionPrefix` in `Directory.Build.props`
-(1.1.1). Identity version for the Store package is `VersionPrefix.0` (`1.1.1.0`).
+(1.1.2). Identity version for the Store package is `VersionPrefix.0` (`1.1.2.0`).
 
 Declaring that number is decision 20 in [docs/decisions.md](docs/decisions.md). What 1.0
 was waiting on shipped during 0.9.x: Preferences, `.wimport`, Explorer and VS Code

--- a/src/SQLBI.Whiteboard/BoardSurface.cs
+++ b/src/SQLBI.Whiteboard/BoardSurface.cs
@@ -61,11 +61,6 @@ internal sealed class BoardSurface : FrameworkElement
             return;
         }
 
-        if (PendingStroke is { Count: > 1 } pending)
-        {
-            DrawStroke(drawingContext, pending, PendingStrokeStyle, _camera);
-        }
-
         foreach (var item in _document.Query(_camera.VisibleWorldBounds))
         {
             if (item.Id == HiddenObjectId)
@@ -93,6 +88,14 @@ internal sealed class BoardSurface : FrameworkElement
                         LanguageChipTitleReserve(text));
                     break;
             }
+        }
+
+        // Over the containers, not under them: the stroke is committed with the
+        // topmost z-index, so drawing it first made the wet ink disappear behind
+        // whatever it crossed and reappear only once the pen lifted.
+        if (PendingStroke is { Count: > 1 } pending)
+        {
+            DrawStroke(drawingContext, pending, PendingStrokeStyle, _camera);
         }
 
         if (HoveredObjectId is Guid hoveredId &&


### PR DESCRIPTION
Fixes a regression from #73.

Pen ink moved out of the `InkCanvas` and into `BoardSurface.OnRender`, where draw
order matters — and the pending stroke was drawn *before* the loop over document
objects. Images, text and LiveViews therefore painted straight over the wet ink,
so a stroke crossing a container was invisible exactly where it overlapped and
appeared all at once on lift, when it commits with the topmost z-index.

It is now drawn after the objects and before the hover and selection chrome,
which is where it will sit once committed.

Version 1.1.2. Release build clean with `TreatWarningsAsErrors`, smoke tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
