### PR TITLE
Bring the winget seed manifests up to 1.2.2

### DIFF
--- a/installer/winget/SQLBI.Whiteboard.installer.yaml
+++ b/installer/winget/SQLBI.Whiteboard.installer.yaml
@@ -16,7 +16,7 @@
 # release except the one it was copied from. `wingetcreate update` reads it out of the
 # downloaded MSI at submission time, which is the only way it can be right.
 PackageIdentifier: SQLBI.Whiteboard
-PackageVersion: 0.9.2
+PackageVersion: 1.2.2
 MinimumOSVersion: 10.0.19041.0
 InstallerType: wix
 InstallModes:
@@ -24,15 +24,15 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
-ReleaseDate: '2026-08-19'
+ReleaseDate: '2026-09-02'
 Installers:
 - Architecture: x64
   Scope: machine
-  InstallerUrl: https://github.com/sql-bi/SQLBI-Whiteboard/releases/download/v0.9.2/SQLBI.Whiteboard.0.9.2.x64.msi
-  InstallerSha256: CF7AC4C5F4AED82382811CE00B606D13E99BA08AB9804FD05E68D23E0689CBE9
+  InstallerUrl: https://github.com/sql-bi/SQLBI-Whiteboard/releases/download/v1.2.2/SQLBI.Whiteboard.1.2.2.x64.msi
+  InstallerSha256: 10574E89368DA3E56A4C739C44096A2570F8C1FB9355344BAED197F1E1AA9A21
 - Architecture: x64
   Scope: user
-  InstallerUrl: https://github.com/sql-bi/SQLBI-Whiteboard/releases/download/v0.9.2/SQLBI.Whiteboard.0.9.2.x64-userinstaller.msi
-  InstallerSha256: 9885733D3E0AAEBC39ABC0F142C7461EEA7DE0B5F20CD184A50EACAE19D5BE9B
+  InstallerUrl: https://github.com/sql-bi/SQLBI-Whiteboard/releases/download/v1.2.2/SQLBI.Whiteboard.1.2.2.x64-userinstaller.msi
+  InstallerSha256: 2D5E25F28AA9820DA6D20DDFB640456FB4F6D5034E1F932A6DD0637EB816B3ED
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/installer/winget/SQLBI.Whiteboard.locale.en-US.yaml
+++ b/installer/winget/SQLBI.Whiteboard.locale.en-US.yaml
@@ -4,7 +4,7 @@
 # describing the same application differently is a difference a reader has to resolve,
 # and there is nothing here worth resolving.
 PackageIdentifier: SQLBI.Whiteboard
-PackageVersion: 0.9.2
+PackageVersion: 1.2.2
 PackageLocale: en-US
 Publisher: SQLBI Corp
 PublisherUrl: https://www.sqlbi.com

--- a/installer/winget/SQLBI.Whiteboard.yaml
+++ b/installer/winget/SQLBI.Whiteboard.yaml
@@ -8,7 +8,7 @@
 # They are kept here anyway: a submission is a pull request against someone else's
 # repository, and the version of it that was sent needs to be reviewable in this one.
 PackageIdentifier: SQLBI.Whiteboard
-PackageVersion: 0.9.2
+PackageVersion: 1.2.2
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
The seed manifests still described 0.9.2, the version of the first submission. `microsoft/winget-pkgs#421386` has been open since 20 August and has never merged, so `SQLBI.Whiteboard` does not exist in winget-pkgs at all — which is also why **Publish to winget** fails on every release: `wingetcreate update` reads the previous version's manifests out of winget-pkgs, and there are none.

This updates only what a version bump requires: `PackageVersion`, `ReleaseDate`, the two `InstallerUrl`s and the two `InstallerSha256`s. Eight lines.

The hashes and the date are taken from the release's own asset digests via the API rather than transcribed, and both URLs were checked to resolve with a `content-length` matching the release assets. `ProductCode` stays absent, for the reason the manifest already records.

The description is deliberately untouched. Its comment ties it to `installer/msix/STORE-LISTING.md`, and the two still match word for word — though both are now behind the product, describing neither Mouse drawing, Finger drawing, nor the Eraser option. Bringing them forward is a separate change that should move both together.

`installer/winget` is excluded from the Azure pipeline trigger, so merging this publishes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)