### PR TITLE
Size the export dialog to its options and to the monitor it opens on

### DIFF
--- a/src/SQLBI.Whiteboard/Export/ExportWindow.xaml
+++ b/src/SQLBI.Whiteboard/Export/ExportWindow.xaml
@@ -3,15 +3,17 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Export"
         Width="1000"
-        Height="720"
+        SizeToContent="Height"
         MinWidth="760"
-        MinHeight="560"
+        MinHeight="420"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
         ShowInTaskbar="False"
         Background="{DynamicResource ToolbarBackgroundBrush}"
         Stylus.IsPressAndHoldEnabled="False"
         PreviewKeyDown="Window_PreviewKeyDown"
+        SourceInitialized="Window_SourceInitialized"
+        SizeChanged="Window_SizeChanged"
         Loaded="Window_Loaded"
         Closing="Window_Closing">
     <Window.Resources>
@@ -70,9 +72,12 @@
                 <ColumnDefinition Width="300" />
             </Grid.ColumnDefinitions>
 
+            <!-- The options decide the height; the preview takes what they leave,
+                 so a tall board does not make a tall dialog. -->
             <Border Background="White"
                     BorderBrush="{DynamicResource ToolbarBorderBrush}"
-                    BorderThickness="1">
+                    BorderThickness="1"
+                    MaxHeight="{Binding ActualHeight, ElementName=Options}">
                 <Grid>
                     <Image x:Name="PreviewImage"
                            Margin="8"

--- a/src/SQLBI.Whiteboard/Export/ExportWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/Export/ExportWindow.xaml.cs
@@ -57,13 +57,23 @@ public partial class ExportWindow : Window
         _persistSettings = persistSettings;
         _content = document.ContentBounds ?? new RectD(0, 0, 1, 1);
         InitializeComponent();
-
-        // Tall enough for every option to show without scrolling, on any screen
-        // that has the room; a small screen keeps the scrollbar.
-        Height = Math.Max(MinHeight, Math.Min(820, SystemParameters.WorkArea.Height - 60));
         PopulateOptions();
         _suppressChange = false;
         Rebuild();
+    }
+
+    // The height follows the options, up to the working area of the monitor the
+    // board is on; past that the options scroll. A change of format regrows the
+    // window in place, downward, so it is moved back inside the screen after.
+    private void Window_SourceInitialized(object sender, EventArgs e) =>
+        MaxHeight = Math.Max(MinHeight, MonitorStartupPlacement.WorkAreaHeight(this) - 24);
+
+    private void Window_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (e.HeightChanged && IsLoaded)
+        {
+            MonitorStartupPlacement.KeepWithinWorkArea(this);
+        }
     }
 
     private void Window_Loaded(object sender, RoutedEventArgs e)

--- a/src/SQLBI.Whiteboard/MonitorStartupPlacement.cs
+++ b/src/SQLBI.Whiteboard/MonitorStartupPlacement.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows;
 using System.Windows.Interop;
+using System.Windows.Media;
 using Microsoft.Win32;
 using SQLBI.Whiteboard.Core.Settings;
 
@@ -22,6 +23,7 @@ internal static class MonitorStartupPlacement
     private const uint SwpNoZOrder = 0x0004;
     private const uint SwpNoActivate = 0x0010;
     private const uint SwpFrameChanged = 0x0020;
+    private const uint SwpNoSize = 0x0001;
 
     public static IReadOnlyList<DisplayMonitor> Enumerate() =>
         EnumerateMonitors()
@@ -115,6 +117,79 @@ internal static class MonitorStartupPlacement
             Math.Max(1, area.Right - area.Left),
             Math.Max(1, area.Bottom - area.Top),
             SwpNoZOrder | SwpNoActivate | SwpFrameChanged);
+    }
+
+    /// <summary>
+    /// The height of the working area, in this window's device-independent
+    /// units, of the monitor the window (or, before it has a handle, its owner)
+    /// is on. A dialog sizes itself against this rather than the primary
+    /// monitor's, which is the wrong screen whenever the board is on another.
+    /// </summary>
+    public static double WorkAreaHeight(Window window)
+    {
+        ArgumentNullException.ThrowIfNull(window);
+
+        var anchor = new WindowInteropHelper(window).Handle == 0 && window.Owner is { } owner ? owner : window;
+        if (!TryGetWorkArea(anchor, out var area))
+        {
+            return SystemParameters.WorkArea.Height;
+        }
+
+        var scale = VisualTreeHelper.GetDpi(anchor).DpiScaleY;
+        return (area.Bottom - area.Top) / Math.Max(scale, 0.01);
+    }
+
+    /// <summary>
+    /// Moves the window up or left as far as needed for the whole of it to sit
+    /// inside its monitor's working area. Called after a window grows in place,
+    /// which WPF does downward from wherever it was centred.
+    /// </summary>
+    public static void KeepWithinWorkArea(Window window)
+    {
+        ArgumentNullException.ThrowIfNull(window);
+
+        var windowHandle = new WindowInteropHelper(window).Handle;
+        if (windowHandle == 0 ||
+            !TryGetWorkArea(window, out var area) ||
+            !GetWindowRect(windowHandle, out var bounds))
+        {
+            return;
+        }
+
+        var left = Math.Max(area.Left, Math.Min(bounds.Left, area.Right - (bounds.Right - bounds.Left)));
+        var top = Math.Max(area.Top, Math.Min(bounds.Top, area.Bottom - (bounds.Bottom - bounds.Top)));
+        if (left != bounds.Left || top != bounds.Top)
+        {
+            SetWindowPos(windowHandle, 0, left, top, 0, 0, SwpNoZOrder | SwpNoActivate | SwpNoSize);
+        }
+    }
+
+    private static bool TryGetWorkArea(Window window, out NativeRectangle area)
+    {
+        area = default;
+        var windowHandle = new WindowInteropHelper(window).Handle;
+        if (windowHandle == 0)
+        {
+            return false;
+        }
+
+        var monitorHandle = MonitorFromWindow(windowHandle, MonitorDefaultToNearest);
+        if (monitorHandle == 0)
+        {
+            return false;
+        }
+
+        var monitorInfo = new NativeMonitorInfo
+        {
+            Size = (uint)Marshal.SizeOf<NativeMonitorInfo>(),
+        };
+        if (!GetMonitorInfo(monitorHandle, ref monitorInfo))
+        {
+            return false;
+        }
+
+        area = monitorInfo.WorkingArea;
+        return true;
     }
 
     private static IReadOnlyList<MonitorDescriptor> EnumerateMonitors()
@@ -326,6 +401,10 @@ internal static class MonitorStartupPlacement
         uint deviceNumber,
         ref NativeDisplayDevice displayDevice,
         uint flags);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowRect(nint windowHandle, out NativeRectangle rectangle);
 
     [DllImport("user32.dll")]
     private static extern nint MonitorFromWindow(


### PR DESCRIPTION
## Why

The Export dialog opened at a fixed height. With the PowerPoint options that left a band of nothing under the switches, and on a monitor shorter than the dialog the buttons were off the screen, because the cap was taken from the primary monitor's work area, which is the wrong screen whenever the board is on another.

## What changes

- **The height follows the options.** The window sizes itself to the options column, and the preview takes that height rather than driving it, so a tall board does not make a tall dialog.
- **The cap is the monitor the board is on.** `MonitorStartupPlacement.WorkAreaHeight` reads the work area of the monitor under the owner window, in the window's own units, and the dialog never exceeds it; past that the options scroll.
- **A regrown window stays on screen.** Switching to PDF adds controls and WPF grows the window downward from where it was centred; `KeepWithinWorkArea` moves it back inside the work area.

Verified by opening the built application, pasting a board, and opening the dialog: it ends where the options end, with no scrollbar and no empty band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
