### PR TITLE
Default a new setup to an editable 16:9 deck in reading order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ to be read by zooming, for a board that is one drawing.
 ### A deck you can rework
 **Slide content → Editable** puts images and text containers on the slide as PowerPoint
 objects, keeps the DAX and SQL colors as text runs, and lays all the ink over them as one
-transparent picture. Picture, the default, stays exact; Editable is for a deck that will be
-edited after the session.
+transparent picture. It is the default; Picture, one choice away, is the exact rendering
+for a deck that will be shown as is.
 
 ### PDF pages that stay sharp
 **Page content → Vector** draws the ink as paths and the text as text, so a page stays

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -606,8 +606,11 @@ containers go in the speaker notes so DAX and SQL can still be copied. **Editabl
 other slide content: images as pictures, text containers as text boxes carrying the
 syntax colors the screen shows, and all the ink as one transparent picture on top, placed
 through the same camera the picture would have used. It is best effort where the picture
-is exact, which is why the picture stays the default. Ink as freeform shapes was left
-out: it would be a second stroke renderer to keep in step with the first.
+is exact, and it is nonetheless the default for a new setup, because a deck is exported to
+be reworked more often than to be shown as is; the picture is one choice away. Slides are
+in reading order by default, for the same reason it is the order a reader would guess.
+Ink as freeform shapes was left out: it would be a second stroke renderer to keep in step
+with the first.
 
 `DocumentFormat.OpenXml` writes the deck and `PdfSharp` the PDF: Microsoft's own SDK and
 a long-lived MIT library, both managed-only, so they pass the tests decision 21 set for a

--- a/docs/export-decisions.md
+++ b/docs/export-decisions.md
@@ -73,7 +73,9 @@ which phase made it and why.
 ## E3 — Editable deck
 
 - **Slide content is a choice on the dialog, Picture or Editable**, shown for PowerPoint
-  only. Picture stays the default: it is exact, and Editable is best effort by design.
+  only. Editable is the default for a new setup, by the maintainers' call after trying
+  both: a deck is exported to be reworked more often than to be shown as is. Picture stays
+  one choice away for the exact rendering.
 - **Elements are placed in the picture's own pixel space.** The rasterizer exposes the
   camera it would have used, and every image, text box, and the ink overlay is mapped
   through it, so switching between the two modes moves nothing.

--- a/docs/export.md
+++ b/docs/export.md
@@ -102,11 +102,13 @@ PowerPoint can zoom.
 
 Two orders are offered:
 
-- **Drawing order** (default): areas sorted by the smallest z-index they contain. Since
-  z-index is creation order, this is the order in which the author started each area — the
-  order of the lecture. Bring to front and Send to back disturb it only for the container
-  they touched, which is rare and visible in the preview.
-- **Reading order**: the cut-tree order, top-left to bottom-right.
+- **Drawing order**: areas sorted by the smallest z-index they contain. Since z-index is
+  creation order, this is the order in which the author started each area — the order of
+  the lecture. Bring to front and Send to back disturb it only for the container they
+  touched, which is rare and visible in the preview.
+- **Reading order** (default): the cut-tree order, top-left to bottom-right. The plan
+  proposed drawing order as the default; the maintainers chose reading order after using
+  both, because it is predictable from the board alone.
 
 ### Alternatives considered
 

--- a/src/SQLBI.Whiteboard.Core/Settings/ExportSettings.cs
+++ b/src/SQLBI.Whiteboard.Core/Settings/ExportSettings.cs
@@ -73,7 +73,7 @@ public sealed class ExportSettings
 
     public ExportPageModel PageModel { get; set; } = ExportPageModel.OnePerArea;
 
-    public AreaOrder Order { get; set; } = AreaOrder.Drawing;
+    public AreaOrder Order { get; set; } = AreaOrder.Reading;
 
     public double GapThreshold { get; set; } = ExportLayoutOptions.DefaultGapThreshold;
 
@@ -85,7 +85,7 @@ public sealed class ExportSettings
 
     public ExportSlideAspect SlideAspect { get; set; } = ExportSlideAspect.Wide;
 
-    public ExportSlideContent SlideContent { get; set; } = ExportSlideContent.Picture;
+    public ExportSlideContent SlideContent { get; set; } = ExportSlideContent.Editable;
 
     public ExportPageSize PageSize { get; set; } = ExportPageSize.A4;
 
@@ -116,7 +116,7 @@ public sealed class ExportSettings
 
         if (!Enum.IsDefined(result.Order))
         {
-            result.Order = AreaOrder.Drawing;
+            result.Order = AreaOrder.Reading;
         }
 
         if (!Enum.IsDefined(result.SlideAspect))
@@ -131,7 +131,7 @@ public sealed class ExportSettings
 
         if (!Enum.IsDefined(result.SlideContent))
         {
-            result.SlideContent = ExportSlideContent.Picture;
+            result.SlideContent = ExportSlideContent.Editable;
         }
 
         if (!Enum.IsDefined(result.PageContent))

--- a/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
+++ b/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
@@ -1306,12 +1306,20 @@ Assert(
         "Hit testing reaches a frame only by its edge.");
     exportBoard.RemoveObject(frame.Id);
 
-    var exportSettings = AppSettingsSerializer.Parse("""{ "export": { "gapThreshold": 9999, "smallestTextPoints": 11, "order": "Reading" } }""");
+    var exportSettings = AppSettingsSerializer.Parse("""{ "export": { "gapThreshold": 9999, "smallestTextPoints": 11, "order": "Drawing" } }""");
     Assert(
         exportSettings.Export.GapThreshold == ExportLayoutOptions.MaximumGapThreshold &&
         exportSettings.Export.SmallestTextPoints == ExportLayoutOptions.DefaultSmallestTextPoints &&
-        exportSettings.Export.Order == AreaOrder.Reading,
+        exportSettings.Export.Order == AreaOrder.Drawing,
         "Export settings are clamped to what the dialog offers.");
+    var freshExport = new AppSettings().Export;
+    Assert(
+        freshExport.Format == ExportFormat.PowerPoint &&
+        freshExport.PageModel == ExportPageModel.OnePerArea &&
+        freshExport.Order == AreaOrder.Reading &&
+        freshExport.SlideAspect == ExportSlideAspect.Wide &&
+        freshExport.SlideContent == ExportSlideContent.Editable,
+        "A new setup exports an editable 16:9 deck, one slide per area, in reading order.");
 }
 
 // PowerPoint deck: one slide per page, a notes slide only where there are notes,


### PR DESCRIPTION
## Why

The maintainers tried both orders and both slide contents and settled the defaults for a setup that has never opened the Export dialog: PowerPoint, one slide per area, reading order, widescreen 16:9, Editable slides.

## What changes

- `ExportSettings` defaults and their fallbacks: `Order` from Drawing to Reading, `SlideContent` from Picture to Editable. Format, page model, and slide size were already the requested values.
- Settings already saved are not touched; the dialog keeps remembering the last choice.
- The plan, decision 26, the E3 note in `export-decisions.md`, and the 1.3.0 release notes say what the defaults are and why they moved.
- A smoke test pins the five defaults for a fresh `AppSettings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
