### PR TITLE
Autosave the board and restore it at the next start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ The board is copied beside your settings every thirty seconds while you work. If
 Whiteboard stops unexpectedly, the next start offers to recover it. This copy is only ever a
 safety net — nothing here writes to your `.wboard` file without being asked.
 
+### Opening a board offers changes a crash left for it
+If SQLBI Whiteboard stopped unexpectedly while you had unsaved changes to a board, opening
+that board again offers those changes instead of the saved file. This works however you open
+it — **File → Open**, a drop, or a double-click in Explorer.
+
 ### The title bar says which board, and whether it is saved
 The window title now shows the file name, with an asterisk while the board differs from what
 is on disk. An untitled board reads as **Untitled board**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ broke. The heading is parsed by `scripts/release-notes.ps1`, so keep its shape; 
 under it is ordinary Markdown, and the renderer handles paragraphs, lists, links, `code`
 and **bold**.
 
+## 1.5.0 - 11 September 2026
+
+### The board you had open comes back
+Close SQLBI Whiteboard and the board you were working on is there again the next time you
+start, at the zoom and position you left it. A board you had saved reopens from its file; an
+untitled one is kept beside your settings and comes back as it was. **Reopen the last board**
+in **Preferences → Startup** turns this off.
+
+### Closing a board with unsaved changes asks first
+If the board has a name and has changed since you saved it, closing the window now offers
+**Save**, **Keep for next time**, **Discard changes**, and **Cancel**. Keep leaves the file
+untouched and brings the board back at the next start. Cancel is the only answer that keeps a
+LiveView feed connected.
+
+### Work is recoverable after a crash
+The board is copied beside your settings every thirty seconds while you work. If SQLBI
+Whiteboard stops unexpectedly, the next start offers to recover it. This copy is only ever a
+safety net — nothing here writes to your `.wboard` file without being asked.
+
+### The title bar says which board, and whether it is saved
+The window title now shows the file name, with an asterisk while the board differs from what
+is on disk. An untitled board reads as **Untitled board**.
+
 ## 1.4.0 - 8 September 2026
 
 ### Eleven more languages in a text container

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
       scripts/build-installer.ps1 both read it from here, so releasing is a reviewed change
       to this line rather than an edit in a pipeline variable group.
     -->
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -787,10 +787,21 @@ below follows from that.
   copy — it may have been edited elsewhere since — so a slot that matched its file reopens
   the file. Only a board that never matched one carries its own copy.
 
-What is not built, and would be worth building: opening a `.wboard` does not yet notice
-that an abandoned slot is holding unsaved changes for that same file. The sidecar already
-records the path, so it is a lookup rather than a new model. It is
-[issue 122](https://github.com/sql-bi/SQLBI-Whiteboard/issues/122).
+- **Opening a board asks the slots whether anything newer is waiting for it**
+  ([issue 122](https://github.com/sql-bi/SQLBI-Whiteboard/issues/122)). Without this, the
+  moment somebody is most likely to want their recovered work — opening the very board they
+  lost — is the moment the application says nothing, because the recovery offer only appears
+  at startup and only for the newest slot. The sidecar already records the path, so it is a
+  lookup. Three calls inside it:
+  - **Every route into a board goes through one place.** The Open dialog, a drop, and a
+    double-click in Explorer all arrive at `OpenPathAsync`, so the question is asked there
+    rather than three times over.
+  - **The answer is Yes, No, or Cancel, and No discards.** Opening the saved file by name is
+    an answer about those changes, not a postponement of the question; leaving the slot would
+    bring the same prompt back on the next open of the same file. Cancel opens neither and
+    keeps the slot, which is what an accidental Yes-or-No needs to be recoverable from.
+  - **Only a slot left by a crash is offered.** One that exited cleanly is either restored at
+    startup or dropped there, and offering it here as well would ask twice about one board.
 
 ---
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -724,6 +724,76 @@ levers those languages have, and can come as yes-or-no settings when someone ask
 
 ---
 
+## 30. Autosave is a safety net, and never the save
+
+**Implemented** in 1.5.0, answering
+[issue 121](https://github.com/sql-bi/SQLBI-Whiteboard/issues/121).
+
+The board is copied into a session slot every thirty seconds and again on the way out, and
+the next start brings it back. **Nothing on this path ever writes to the `.wboard` the
+person named.** A file changes when they ask for it to change, and an application that
+saved on their behalf would eventually overwrite something they meant to keep. Everything
+below follows from that.
+
+- **A board with a name is asked about; a board without one is not.** An untitled board has
+  no file to disagree with, so interrupting someone on the way out to protect it would be
+  asking a question with no stakes. It goes into the session and comes back. A named board
+  has somewhere its changes belong, and only the person can say whether they belong there.
+
+- **The exit question has four answers and a default, where decision 24 refused one.**
+  Save, **Keep for next time**, Discard changes, Cancel. Keep is `IsDefault` because it is
+  the one answer that decides nothing: the file is untouched, the board returns at the next
+  start, and Enter landing on it can never be the wrong outcome. That is exactly what the
+  mouse mode offer did not have — there, both answers changed something, so neither could
+  be primed. A default is a property of the answers, not a habit to apply or refuse
+  everywhere.
+
+- **Cancel stays, and LiveView is why.** Keep and Cancel look interchangeable — both end
+  with the board in front of you — but a restored LiveView container comes back as its last
+  frame and has to be reconnected by hand, because Windows cannot save the capture
+  permission. Cancel is the only answer that keeps a feed live, which matters most in the
+  situation where the window gets closed by accident: mid-recording, in front of an
+  audience. The camera position is carried in the session for the same reason, to narrow
+  what is left of the gap.
+
+- **Modified means two things, because one signal cannot cover it.** The command history
+  carries a save point — the command on top of the undo stack when the file was written —
+  so a board undone back to what was saved stops counting as changed, and one undone *past*
+  it starts counting again. A counter cannot express that, since undo moves it the same way
+  drawing does. The dozen places that change the document without going through a command
+  set a flag instead. The LiveView paths deliberately set neither: a frame arriving on its
+  own is not somebody changing the board, and would otherwise put an unasked question in
+  front of anyone who left the application running beside a feed.
+
+- **One slot per running copy, not one file.** Each copy takes a slot named by a GUID and
+  holds a lock file open for as long as it runs. Two windows therefore never write to the
+  same files, which is what makes running two of them safe without the application having
+  to forbid it — and forbidding it was considered and rejected, because two boards side by
+  side is a real thing to want. A slot whose lock can be taken belonged to a copy that has
+  gone; its sidecar says whether it went on purpose. One start restores one slot, the most
+  recent; the others keep their slots and are offered again rather than being discarded,
+  and anything abandoned for thirty days is pruned.
+
+- **A clean exit restores silently; a crash asks.** Coming back to where you were is
+  ordinary and needs no ceremony, and **Reopen the last board** in Preferences turns it off
+  for anyone who wants a blank board every time. Recovering after a crash is not ordinary,
+  so it is offered rather than done — and it is offered whatever that setting says, because
+  the setting is about how the application starts, not about whether work lost to a crash
+  should be retrievable. Declining discards that slot, and the question says so: the only
+  alternative is putting the same question in front of the same person at every start for
+  thirty days, which is how a safety net turns into a nuisance people learn to dismiss.
+
+- **An unmodified session keeps the file name and not the board.** The file is the better
+  copy — it may have been edited elsewhere since — so a slot that matched its file reopens
+  the file. Only a board that never matched one carries its own copy.
+
+What is not built, and would be worth building: opening a `.wboard` does not yet notice
+that an abandoned slot is holding unsaved changes for that same file. The sidecar already
+records the path, so it is a lookup rather than a new model. It is
+[issue 122](https://github.com/sql-bi/SQLBI-Whiteboard/issues/122).
+
+---
+
 ## Open questions
 
 - arm64 is not built; add it if Surface devices matter for a pen application.

--- a/site/guide.html
+++ b/site/guide.html
@@ -538,6 +538,12 @@
     </section>
 
     <section class="story">
+      <h3>Pick up where you left off</h3>
+      <p>Close SQLBI Whiteboard and the board you had open is there again the next time you start, at the zoom and position you left it. Turn that off under <span class="ui">Preferences → Startup</span> if you would rather begin on a blank board every time.</p>
+      <p>Closing a saved board that has changed asks what to do first: <span class="ui">Keep for next time</span> leaves the file alone and brings the board back as it stands, and <span class="ui">Cancel</span> is the answer that keeps a LiveView feed connected. The board is also copied every thirty seconds while you work, so one lost to a crash is offered back at the next start rather than gone. Nothing on this path writes to your <code>.wboard</code> file — only <span class="ui">Save</span> does that.</p>
+    </section>
+
+    <section class="story">
       <h3>Keep boards next to the material they document</h3>
       <p>A saved board carries a picture of itself, so you can tell one board from another without opening any of them. Windows Explorer shows that picture as the thumbnail.</p>
       <p>VS Code shows it too, once <a href="https://marketplace.visualstudio.com/items?itemName=sqlbi.sqlbi-whiteboard">SQLBI Whiteboard for VS Code</a> is installed. VS Code offers that extension on its own the first time you open a folder holding a <code>.wboard</code> file, so a board checked in beside the material it explains stays readable in the editor.</p>

--- a/src/SQLBI.Whiteboard.Core/Commands/CommandHistory.cs
+++ b/src/SQLBI.Whiteboard.Core/Commands/CommandHistory.cs
@@ -12,11 +12,38 @@ public sealed class CommandHistory
 {
     private readonly Stack<IBoardCommand> _undo = [];
     private readonly Stack<IBoardCommand> _redo = [];
+    private IBoardCommand? _savePoint;
 
     public event EventHandler? Changed;
 
     public bool CanUndo => _undo.Count > 0;
     public bool CanRedo => _redo.Count > 0;
+
+    /// <summary>
+    /// Whether the document stands where it stood when <see cref="MarkSaved"/> was last
+    /// called - which is what makes a board that has been undone back to its saved state
+    /// count as unmodified, and a board that has been undone <em>past</em> it count as
+    /// modified again.
+    /// </summary>
+    /// <remarks>
+    /// The mark is the command on top of the undo stack rather than the stack's depth: an
+    /// undo followed by a different action returns to the same depth by a different route,
+    /// and only the identity of the command tells the two apart. Reference equality is
+    /// deliberate, since commands are records and two structurally identical ones are still
+    /// two separate steps.
+    /// </remarks>
+    public bool IsAtSavePoint => ReferenceEquals(Top, _savePoint);
+
+    private IBoardCommand? Top => _undo.Count > 0 ? _undo.Peek() : null;
+
+    /// <summary>
+    /// Records that the document as it stands now is what the file on disk contains.
+    /// </summary>
+    public void MarkSaved()
+    {
+        _savePoint = Top;
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
 
     public void Execute(IBoardCommand command, BoardDocument document)
     {
@@ -57,10 +84,17 @@ public sealed class CommandHistory
         Changed?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <summary>
+    /// Drops both stacks and puts the save point at the empty history, so a board that has
+    /// just been opened or created counts as unmodified. A caller that clears the history
+    /// around content the file on disk does not contain - an import opened as a new board -
+    /// has to say so itself.
+    /// </summary>
     public void Clear()
     {
         _undo.Clear();
         _redo.Clear();
+        _savePoint = null;
         Changed?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/SQLBI.Whiteboard.Core/Model/BoardDocument.cs
+++ b/src/SQLBI.Whiteboard.Core/Model/BoardDocument.cs
@@ -102,6 +102,24 @@ public sealed class BoardDocument
         Changed?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <summary>
+    /// A shallow copy that shares this document's objects and assets but none of its
+    /// mutability. Autosave takes one on the UI thread and writes it on another: objects are
+    /// records and an asset's bytes are never rewritten once it exists, so what the writer
+    /// sees cannot change underneath it while the board carries on being drawn.
+    /// </summary>
+    public BoardDocument Snapshot()
+    {
+        var copy = new BoardDocument();
+        copy._objects.AddRange(_objects);
+        foreach (var asset in _assets)
+        {
+            copy._assets[asset.Key] = asset.Value;
+        }
+
+        return copy;
+    }
+
     public bool RemoveAsset(string id)
     {
         var removed = _assets.Remove(id);

--- a/src/SQLBI.Whiteboard.Core/Persistence/SessionState.cs
+++ b/src/SQLBI.Whiteboard.Core/Persistence/SessionState.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SQLBI.Whiteboard.Core.Persistence;
+
+/// <summary>
+/// What a session slot knows about the board it is holding, written beside the board copy
+/// itself. One slot belongs to one running copy of the application, so two windows never
+/// write to the same pair of files.
+/// </summary>
+public sealed class SessionState
+{
+    public const int CurrentVersion = 1;
+
+    public int Version { get; set; } = CurrentVersion;
+
+    /// <summary>
+    /// The <c>.wboard</c> this session was editing, or null for a board that has never been
+    /// saved. A restored session takes this back, so Save still writes where it used to.
+    /// </summary>
+    public string? BoardPath { get; set; }
+
+    /// <summary>
+    /// Whether the board copy beside this file differs from <see cref="BoardPath"/>. False
+    /// means the file on disk is the better copy and the board beside this file is stale -
+    /// which is how Discard and a plain Save both leave the slot.
+    /// </summary>
+    public bool Modified { get; set; }
+
+    /// <summary>
+    /// False until the window closes through its own closing path. A slot still reading
+    /// false when nothing holds its lock any more belonged to a copy that crashed, and is
+    /// what turns a silent restore into an offer of recovery.
+    /// </summary>
+    public bool ExitedCleanly { get; set; }
+
+    public DateTimeOffset WrittenUtc { get; set; } = DateTimeOffset.UtcNow;
+
+    public double CameraCenterX { get; set; }
+
+    public double CameraCenterY { get; set; }
+
+    public double CameraZoom { get; set; } = 1;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+        AllowTrailingCommas = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public static string Format(SessionState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        return JsonSerializer.Serialize(state, JsonOptions);
+    }
+
+    /// <summary>
+    /// Reads a sidecar, returning null for anything that cannot be understood. A slot that
+    /// will not parse is a slot to leave alone, never one to throw over: the application is
+    /// starting up, and a damaged recovery file must not be what stops it.
+    /// </summary>
+    public static SessionState? Parse(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            var state = JsonSerializer.Deserialize<SessionState>(json, JsonOptions);
+            if (state is null || state.Version is < 1 or > CurrentVersion)
+            {
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(state.BoardPath))
+            {
+                state.BoardPath = null;
+            }
+
+            return state;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/SQLBI.Whiteboard.Core/Settings/AppSettings.cs
+++ b/src/SQLBI.Whiteboard.Core/Settings/AppSettings.cs
@@ -159,6 +159,14 @@ public sealed class AppSettings
     /// </summary>
     public bool WarnWhenNoDigitizer { get; set; } = true;
 
+    /// <summary>
+    /// Whether a board left open at the last exit comes back at the next start. It governs
+    /// the silent restore only: a board left behind by a copy that crashed is always
+    /// offered, because losing work to a crash is the thing the session copy exists to
+    /// prevent and is not a preference about how the application starts.
+    /// </summary>
+    public bool RestoreLastSession { get; set; } = true;
+
     public bool CheckForUpdates { get; set; } = true;
 
     public DateTimeOffset? LastUpdateCheckUtc { get; set; }
@@ -172,7 +180,7 @@ public sealed class AppSettings
 
 public static class AppSettingsSerializer
 {
-    public const int CurrentVersion = 16;
+    public const int CurrentVersion = 17;
 
     /// <summary>
     /// The version that moved plain text to the end of the default snippet

--- a/src/SQLBI.Whiteboard.Core/Viewport/Camera2D.cs
+++ b/src/SQLBI.Whiteboard.Core/Viewport/Camera2D.cs
@@ -77,4 +77,19 @@ public sealed class Camera2D
         Center = new PointD(0, 0);
         Zoom = 1;
     }
+
+    /// <summary>
+    /// Puts the camera back where a restored session left it. The zoom is clamped rather
+    /// than trusted, because it arrives from a file that anything could have written.
+    /// </summary>
+    public void Restore(PointD center, double zoom)
+    {
+        if (double.IsNaN(center.X) || double.IsNaN(center.Y) || double.IsNaN(zoom))
+        {
+            return;
+        }
+
+        Center = center;
+        Zoom = Math.Clamp(zoom, MinimumZoom, MaximumZoom);
+    }
 }

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -65,6 +65,33 @@ public partial class MainWindow : Window
 
     private BoardDocument _document = new();
     private string? _currentBoardPath;
+
+    // The history save point answers for everything that arrives as a command, undo
+    // included. It cannot answer for the dozen places that change the document directly -
+    // a container gesture settling, an asset arriving with a pasted image - so those say so
+    // here. The LiveView paths deliberately do not: a frame turning up on its own is not
+    // somebody changing the board, and would otherwise put an unasked question on the way
+    // out of an application left running beside a feed.
+    private bool _dirtyOutsideHistory;
+
+    private readonly SessionStore? _session = SessionStore.Acquire();
+    private readonly DispatcherTimer _autosaveTimer;
+    private bool _closeConfirmed;
+    private bool _autosaveRunning;
+
+    /// <summary>
+    /// Whether anything has changed since the last autosave. Without it the timer would
+    /// rewrite the same board every interval for as long as the application is open, since
+    /// an autosave deliberately does not make the board count as saved.
+    /// </summary>
+    private bool _autosaveDirty;
+
+    /// <summary>
+    /// How often the board is copied into the session slot while it is being worked on. The
+    /// copy exists for a crash and for nothing else, so this is set by how much ink somebody
+    /// would mind redrawing rather than by what the disk could keep up with.
+    /// </summary>
+    private static readonly TimeSpan AutosaveInterval = TimeSpan.FromSeconds(30);
     private BoardTool _activeTool = BoardTool.Pen;
     private BoardTool _lastDrawingTool = BoardTool.Pen;
     private BoardTool _toolBeforeSpace = BoardTool.Pen;
@@ -151,7 +178,7 @@ public partial class MainWindow : Window
         SessionBar.ViewOpened += UpdateLiveViewMenuItems;
         SessionBar.UpdateDownloadRequested += _ => OpenUpdateDownload();
         SessionBar.UpdateDismissed += SessionBar_UpdateDismissed;
-        Title += AppChannel.WindowTitleSuffix;
+        UpdateWindowTitle();
         _initialBoardPath = initialBoardPath;
         TextEditorLanguageCombo.ItemsSource = TextLanguageRegistry.All;
         LanguageChipCombo.ItemsSource = TextLanguageRegistry.All;
@@ -168,6 +195,11 @@ public partial class MainWindow : Window
             Interval = TimeSpan.FromMilliseconds(50),
         };
         _hoverWatch.Tick += HoverWatch_Tick;
+        _autosaveTimer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = AutosaveInterval,
+        };
+        _autosaveTimer.Tick += AutosaveTimer_Tick;
         InkSurface.HoverTracker.Hovered += HoverTracker_Hovered;
         SourceInitialized += MainWindow_SourceInitialized;
         Loaded += MainWindow_Loaded;
@@ -206,7 +238,175 @@ public partial class MainWindow : Window
         _ = CheckForUpdatesAsync();
         if (_initialBoardPath is not null)
         {
+            // A file named on the command line is what the person asked for, and outranks
+            // whatever the last session happened to be holding.
             await OpenPathAsync(_initialBoardPath, confirmDiscard: false);
+        }
+        else
+        {
+            await RestoreSessionAsync();
+        }
+
+        SessionStore.Prune();
+        _autosaveTimer.Start();
+    }
+
+    /// <summary>
+    /// Brings back what the last copy of the application to close was holding: silently when
+    /// it closed on purpose, and by asking when it did not.
+    /// </summary>
+    private async Task RestoreSessionAsync()
+    {
+        IReadOnlyList<AbandonedSession> abandoned = SessionStore.FindAbandoned();
+        if (abandoned.Count == 0)
+        {
+            return;
+        }
+
+        // Newest first, and one window holds one board. A slot left behind by a crash keeps
+        // its place and is offered again at the next start; one that exited cleanly will
+        // never be the newest again, so it is dropped rather than left to pile up a board
+        // copy per start until the thirty days run out.
+        AbandonedSession candidate = abandoned[0];
+        foreach (AbandonedSession stale in abandoned.Skip(1).Where(item => item.State.ExitedCleanly))
+        {
+            SessionStore.Forget(stale.SlotId);
+        }
+
+        if (candidate.State.ExitedCleanly)
+        {
+            if (!_settings.RestoreLastSession)
+            {
+                SessionStore.Forget(candidate.SlotId);
+                return;
+            }
+        }
+        else if (!ConfirmRecovery(abandoned))
+        {
+            // Declined, so it goes. Keeping it would put the same question in front of the
+            // same person at every start until the thirty days ran out, and the question
+            // says plainly what No means.
+            SessionStore.Forget(candidate.SlotId);
+            return;
+        }
+
+        if (!await AdoptSessionAsync(candidate))
+        {
+            return;
+        }
+
+        // Take a copy into this copy's own slot before letting go of the old one, so a
+        // second crash before the first autosave cannot lose what was just recovered.
+        await WriteSessionAsync(candidate.State.Modified, exitedCleanly: false);
+        SessionStore.Forget(candidate.SlotId);
+    }
+
+    private bool ConfirmRecovery(IReadOnlyList<AbandonedSession> abandoned)
+    {
+        var crashed = abandoned.Count(item => !item.State.ExitedCleanly);
+        var message = crashed > 1
+            ? $"SQLBI Whiteboard closed unexpectedly with {crashed} boards open. The most " +
+              "recent one can be recovered now, and the others are offered the next time " +
+              "you start.\n\nRecover it? Choosing No discards it."
+            : "SQLBI Whiteboard closed unexpectedly while a board was open.\n\n" +
+              "Recover it? Choosing No discards it.";
+
+        return MessageBox.Show(
+            this,
+            message,
+            "SQLBI Whiteboard",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question) == MessageBoxResult.Yes;
+    }
+
+    /// <summary>
+    /// Opens what a slot was holding. An unmodified slot kept only a file name, because the
+    /// file is the better copy of a board that matched it - and may have been edited
+    /// elsewhere since.
+    /// </summary>
+    private async Task<bool> AdoptSessionAsync(AbandonedSession session)
+    {
+        SessionState state = session.State;
+        var fileStillThere = state.BoardPath is not null && File.Exists(state.BoardPath);
+        if (!state.Modified)
+        {
+            if (!fileStillThere)
+            {
+                return false;
+            }
+
+            await LoadBoardAsync(state.BoardPath!);
+            RestoreCamera(state);
+            return true;
+        }
+
+        if (session.BoardPath is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            await using var stream = new FileStream(
+                session.BoardPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                81920,
+                useAsync: true);
+            var loaded = await BoardArchive.LoadAsync(stream);
+            ReplaceDocument(loaded);
+            _currentBoardPath = fileStillThere ? state.BoardPath : null;
+            ResetBoardView();
+            MarkSaved();
+
+            // It never matched the file it came from, and both the title marker and the
+            // question asked on the way out have to go on saying so.
+            MarkDirtyOutsideHistory();
+            RestoreCamera(state);
+            return true;
+        }
+        catch (Exception exception)
+        {
+            ShowError("Could not restore the previous session", exception);
+            return false;
+        }
+    }
+
+    private void RestoreCamera(SessionState state)
+    {
+        _camera.Restore(new PointD(state.CameraCenterX, state.CameraCenterY), state.CameraZoom);
+        CameraChanged();
+    }
+
+    // Only ever writes to the session slot. The board the person named is theirs, and
+    // nothing here is allowed to write to it without being asked.
+    private async void AutosaveTimer_Tick(object? sender, EventArgs e)
+    {
+        if (_autosaveRunning || !_autosaveDirty || !IsModified)
+        {
+            return;
+        }
+
+        // Not while anything is in contact with the glass. The zip runs on a worker, but
+        // the snapshot does not, and a stroke is the one thing that must never stutter.
+        if (_penInContact ||
+            _stylusAction != PointerAction.None ||
+            _mouseAction != PointerAction.None ||
+            _touchPoints.Count > 0)
+        {
+            return;
+        }
+
+        _autosaveRunning = true;
+        try
+        {
+            _autosaveDirty = false;
+            await WriteSessionAsync(keepBoard: true, exitedCleanly: false);
+        }
+        finally
+        {
+            _autosaveRunning = false;
         }
     }
 
@@ -241,6 +441,7 @@ public partial class MainWindow : Window
 
     private void Document_Changed(object? sender, EventArgs e)
     {
+        _autosaveDirty = true;
         var liveViewIds = _document.Objects.OfType<LiveViewBoardObject>()
             .Select(item => item.Id)
             .ToHashSet();
@@ -266,6 +467,7 @@ public partial class MainWindow : Window
     private void History_Changed(object? sender, EventArgs e)
     {
         SessionBar.SetEditEnabled(_history.CanUndo, _history.CanRedo);
+        UpdateWindowTitle();
     }
 
     // Only touch reaches here now. Pen ink is collected from the pen's own
@@ -4034,16 +4236,59 @@ public partial class MainWindow : Window
         ReplaceDocument(new BoardDocument());
         _currentBoardPath = null;
         ResetBoardView();
+        MarkSaved();
+    }
+
+    /// <summary>
+    /// Whether the board differs from what the file on disk holds - or, for a board that
+    /// has never been saved, from the empty board it started as.
+    /// </summary>
+    private bool IsModified => !_history.IsAtSavePoint || _dirtyOutsideHistory;
+
+    /// <summary>
+    /// Records a change the command history will not see. See <see cref="_dirtyOutsideHistory"/>.
+    /// </summary>
+    private void MarkDirtyOutsideHistory()
+    {
+        if (_dirtyOutsideHistory)
+        {
+            return;
+        }
+
+        _dirtyOutsideHistory = true;
+        UpdateWindowTitle();
+    }
+
+    /// <summary>
+    /// Records that the board as it stands is what <see cref="_currentBoardPath"/> holds.
+    /// </summary>
+    private void MarkSaved()
+    {
+        _history.MarkSaved();
+        _dirtyOutsideHistory = false;
+        UpdateWindowTitle();
     }
 
     private bool ConfirmDiscardUnsaved(string message) =>
-        _document.Objects.Count == 0 && _document.Assets.Count == 0 ||
+        !IsModified ||
         MessageBox.Show(
             this,
             message,
             "SQLBI Whiteboard",
             MessageBoxButton.YesNo,
             MessageBoxImage.Warning) == MessageBoxResult.Yes;
+
+    // The board's name and whether it has strayed from the file, in the one place every
+    // window already shows what it is holding. Without it the question asked on the way out
+    // arrives with nothing on screen to explain what prompted it.
+    private void UpdateWindowTitle()
+    {
+        var name = _currentBoardPath is null
+            ? "Untitled board"
+            : Path.GetFileName(_currentBoardPath);
+        var marker = IsModified ? " *" : string.Empty;
+        Title = $"{name}{marker} - SQLBI Whiteboard{AppChannel.WindowTitleSuffix}";
+    }
 
     private async void SaveAsMenuItem_Click(object sender, RoutedEventArgs e) =>
         await SaveBoardAsync(saveAs: true);
@@ -4737,6 +4982,7 @@ public partial class MainWindow : Window
                 stream,
                 previewPng: preview is null ? default : preview);
             _currentBoardPath = filePath;
+            MarkSaved();
         }
         catch (Exception exception)
         {
@@ -4800,6 +5046,7 @@ public partial class MainWindow : Window
             ReplaceDocument(loaded);
             _currentBoardPath = filePath;
             ResetBoardView();
+            MarkSaved();
         }
         catch (Exception exception)
         {
@@ -5133,8 +5380,11 @@ public partial class MainWindow : Window
         }
         else
         {
+            // The recipe built a board no file holds, and clearing the history has just
+            // said the opposite. Nothing else reaches the save point, so say it here.
             command.Execute(_document);
             _history.Clear();
+            MarkDirtyOutsideHistory();
         }
 
         SceneSurface.InvalidateAssets();
@@ -5481,13 +5731,134 @@ public partial class MainWindow : Window
         EndTemporaryBarrelTool();
     }
 
-    private void Window_Closing(object? sender, CancelEventArgs e)
+    private async void Window_Closing(object? sender, CancelEventArgs e)
     {
         CommitTextEdit();
+        if (!_closeConfirmed)
+        {
+            // Closing runs synchronously, while asking about unsaved changes and writing
+            // the session do not. So the first pass always calls the close off, finishes
+            // the work, and closes again - and nothing below this is reached until it has.
+            e.Cancel = true;
+            bool proceed;
+            try
+            {
+                proceed = await PrepareToCloseAsync();
+            }
+            catch (Exception exception)
+            {
+                // Whatever went wrong, it must not be what leaves somebody unable to close
+                // the window. The session is the thing being given up here, not the board.
+                Debug.WriteLine($"[Session] Could not prepare to close: {exception.Message}");
+                proceed = true;
+            }
+
+            if (proceed)
+            {
+                _closeConfirmed = true;
+                Close();
+            }
+
+            return;
+        }
+
+        _autosaveTimer.Stop();
         // Unregister Vortice's retained Window.Closed callbacks and unload the
         // D3D surfaces before the Closed event begins. This guarantees one
         // native teardown path for both live and already-paused presenters.
         DisposeAllLiveViewPresenters();
+        _session?.Dispose();
+    }
+
+    /// <summary>
+    /// Asks about unsaved changes where there is something to ask about, then records what
+    /// the next start should come back to. False calls the close off.
+    /// </summary>
+    private async Task<bool> PrepareToCloseAsync()
+    {
+        var keepBoard = IsModified;
+        if (_currentBoardPath is not null && IsModified)
+        {
+            var dialog = new UnsavedChangesWindow(Path.GetFileName(_currentBoardPath))
+            {
+                Owner = this,
+            };
+            dialog.ShowDialog();
+            switch (dialog.Result)
+            {
+                case UnsavedChangesAnswer.Cancel:
+                    return false;
+
+                case UnsavedChangesAnswer.Save:
+                    await SaveBoardAsync();
+                    if (IsModified)
+                    {
+                        // Nothing was written - the save failed, or the file dialog was
+                        // dismissed - so closing now would lose what was being saved.
+                        return false;
+                    }
+
+                    keepBoard = false;
+                    break;
+
+                case UnsavedChangesAnswer.Discard:
+                    keepBoard = false;
+                    break;
+            }
+        }
+
+        if (keepBoard)
+        {
+            // Worth the one pass on the way out, so a restored LiveView container shows
+            // the frame it was showing rather than the one it started with.
+            RefreshLiveViewSnapshots();
+        }
+
+        await WriteSessionAsync(keepBoard, exitedCleanly: true);
+        return true;
+    }
+
+    /// <summary>
+    /// Copies the board into this copy's session slot, or clears the slot when there is
+    /// nothing worth coming back to.
+    /// </summary>
+    private async Task WriteSessionAsync(bool keepBoard, bool exitedCleanly)
+    {
+        if (_session is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!keepBoard && _currentBoardPath is null)
+            {
+                // An untitled board nobody has drawn on. Restoring it would be
+                // indistinguishable from starting normally.
+                _session.Clear();
+                return;
+            }
+
+            var state = new SessionState
+            {
+                BoardPath = _currentBoardPath,
+                Modified = keepBoard,
+                ExitedCleanly = exitedCleanly,
+                CameraCenterX = _camera.Center.X,
+                CameraCenterY = _camera.Center.Y,
+                CameraZoom = _camera.Zoom,
+            };
+
+            // Snapshotting here and writing on a worker keeps the zip off the pen's thread.
+            BoardDocument? snapshot = keepBoard ? _document.Snapshot() : null;
+            await Task.Run(() => _session.WriteAsync(snapshot, state));
+        }
+        catch (Exception exception)
+        {
+            // Never in the way of closing, and never a dialog: this is the safety net
+            // rather than the save, and the file the person asked for is already written.
+            Debug.WriteLine($"[Session] Could not write the session: {exception.Message}");
+        }
     }
 
     private void Window_PreviewStylusInRange(object sender, StylusEventArgs e)

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -5028,7 +5028,93 @@ public partial class MainWindow : Window
             return;
         }
 
+        // Every way into a board arrives here - the Open dialog, a drop, and a double-click
+        // in Explorer by way of the command line - so this is the one place that has to ask
+        // whether something newer than the file is waiting for it.
+        if (await TryOpenRecoveredAsync(filePath))
+        {
+            return;
+        }
+
         await LoadBoardAsync(filePath);
+    }
+
+    /// <summary>
+    /// Offers what a copy that closed unexpectedly was holding for this exact file. True
+    /// when the open has been dealt with and the file itself should not be loaded.
+    /// </summary>
+    private async Task<bool> TryOpenRecoveredAsync(string filePath)
+    {
+        AbandonedSession? match = SessionStore.FindAbandoned().FirstOrDefault(item =>
+            item.State.Modified &&
+            !item.State.ExitedCleanly &&
+            item.BoardPath is not null &&
+            item.State.BoardPath is not null &&
+            IsSameFile(item.State.BoardPath, filePath));
+
+        if (match is null)
+        {
+            return false;
+        }
+
+        var when = match.State.WrittenUtc.ToLocalTime().ToString("f");
+        MessageBoxResult answer = MessageBox.Show(
+            this,
+            $"{Path.GetFileName(filePath)} has unsaved changes from {when}, left behind when " +
+            "SQLBI Whiteboard closed unexpectedly.\n\n" +
+            "Open those changes instead of the saved file? Choosing No opens the saved file " +
+            "and discards them.",
+            "SQLBI Whiteboard",
+            MessageBoxButton.YesNoCancel,
+            MessageBoxImage.Question);
+
+        if (answer == MessageBoxResult.Cancel)
+        {
+            // Neither the changes nor the file: the slot keeps its place and the board on
+            // screen is left alone.
+            return true;
+        }
+
+        if (answer != MessageBoxResult.Yes)
+        {
+            // The saved file was asked for by name, so the changes it was offered against
+            // have been answered and must not be offered again.
+            SessionStore.Forget(match.SlotId);
+            return false;
+        }
+
+        if (!await AdoptSessionAsync(match))
+        {
+            return false;
+        }
+
+        await WriteSessionAsync(keepBoard: true, exitedCleanly: false);
+        SessionStore.Forget(match.SlotId);
+        return true;
+    }
+
+    /// <summary>
+    /// Whether two paths name the same file on this machine. Compared after expansion, since
+    /// the same board reaches the application as a full path from Explorer and as whatever
+    /// was typed from everywhere else.
+    /// </summary>
+    private static bool IsSameFile(string left, string right)
+    {
+        try
+        {
+            return string.Equals(
+                Path.GetFullPath(left),
+                Path.GetFullPath(right),
+                StringComparison.OrdinalIgnoreCase);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
     }
 
     private async Task LoadBoardAsync(string filePath)
@@ -5779,7 +5865,9 @@ public partial class MainWindow : Window
         var keepBoard = IsModified;
         if (_currentBoardPath is not null && IsModified)
         {
-            var dialog = new UnsavedChangesWindow(Path.GetFileName(_currentBoardPath))
+            var dialog = new UnsavedChangesWindow(
+                Path.GetFileName(_currentBoardPath),
+                _document.Objects.OfType<LiveViewBoardObject>().Any())
             {
                 Owner = this,
             };

--- a/src/SQLBI.Whiteboard/PreferencesWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/PreferencesWindow.xaml.cs
@@ -895,6 +895,7 @@ public partial class PreferencesWindow : Window
             {
                 SettingsCatalog.Ids.StartFullScreen => _settings.StartFullScreen,
                 SettingsCatalog.Ids.WarnWhenNoDigitizer => _settings.WarnWhenNoDigitizer,
+                SettingsCatalog.Ids.RestoreLastSession => _settings.RestoreLastSession,
                 SettingsCatalog.Ids.SuggestMouseMode => _settings.SuggestMouseMode,
                 SettingsCatalog.Ids.CheckForUpdates => _settings.CheckForUpdates,
                 _ => false,
@@ -1080,6 +1081,10 @@ public partial class PreferencesWindow : Window
         else if (setting.Id == SettingsCatalog.Ids.WarnWhenNoDigitizer)
         {
             _settings.WarnWhenNoDigitizer = value;
+        }
+        else if (setting.Id == SettingsCatalog.Ids.RestoreLastSession)
+        {
+            _settings.RestoreLastSession = value;
         }
         else if (setting.Id == SettingsCatalog.Ids.SuggestMouseMode)
         {

--- a/src/SQLBI.Whiteboard/SessionStore.cs
+++ b/src/SQLBI.Whiteboard/SessionStore.cs
@@ -1,0 +1,325 @@
+using System.IO;
+using SQLBI.Whiteboard.Core.Model;
+using SQLBI.Whiteboard.Core.Persistence;
+
+namespace SQLBI.Whiteboard;
+
+/// <summary>
+/// A session slot abandoned by a copy of the application that is no longer running, found
+/// at startup and offered back.
+/// </summary>
+/// <param name="SlotId">Identifies the slot's three files.</param>
+/// <param name="State">What the slot's sidecar said.</param>
+/// <param name="BoardPath">The board copy, or null when the slot kept only a file name.</param>
+internal sealed record AbandonedSession(string SlotId, SessionState State, string? BoardPath);
+
+/// <summary>
+/// Where a running copy of the application keeps the board it is holding, so that a crash or
+/// an ordinary exit both leave something to come back to.
+/// </summary>
+/// <remarks>
+/// Each running copy takes its own slot, named by a GUID and pinned by a lock file it holds
+/// open until it exits. Two windows therefore never write to the same files, which is what
+/// makes running two of them safe without the application having to forbid it. A slot whose
+/// lock can be taken belonged to a copy that is gone; its sidecar says whether it left on
+/// purpose.
+/// </remarks>
+internal sealed class SessionStore : IDisposable
+{
+    private const string BoardExtension = ".wboard";
+    private const string StateExtension = ".json";
+    private const string LockExtension = ".lock";
+
+    /// <summary>
+    /// How long an abandoned slot is kept. Long enough that a board lost to a crash is still
+    /// there after a holiday, short enough that the folder does not grow without end.
+    /// </summary>
+    private static readonly TimeSpan AbandonedSlotLifetime = TimeSpan.FromDays(30);
+
+    public static string FolderPath { get; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "SQLBI",
+        AppChannel.SettingsFolderName,
+        "sessions");
+
+    private readonly FileStream _lockStream;
+
+    private SessionStore(string slotId, FileStream lockStream)
+    {
+        SlotId = slotId;
+        _lockStream = lockStream;
+    }
+
+    public string SlotId { get; }
+
+    private string BoardPath => PathFor(SlotId, BoardExtension);
+
+    private string StatePath => PathFor(SlotId, StateExtension);
+
+    /// <summary>
+    /// Takes a fresh slot, or returns null when the folder cannot be written - a read-only
+    /// profile, a locked-down machine. Autosave is a convenience, so failing to get one is
+    /// never a reason to refuse to start.
+    /// </summary>
+    public static SessionStore? Acquire()
+    {
+        try
+        {
+            Directory.CreateDirectory(FolderPath);
+            var slotId = Guid.NewGuid().ToString("n");
+            var lockStream = new FileStream(
+                PathFor(slotId, LockExtension),
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None);
+            return new SessionStore(slotId, lockStream);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes the sidecar, and the board beside it when <paramref name="document"/> is given.
+    /// Passing null keeps the slot pointing at a file without carrying a copy of it, which is
+    /// what an unmodified board and a discarded one both want.
+    /// </summary>
+    public async Task WriteAsync(
+        BoardDocument? document,
+        SessionState state,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        if (document is null)
+        {
+            Delete(BoardPath);
+        }
+        else
+        {
+            // Written beside the destination and moved over it, so a copy interrupted
+            // half way through cannot be what a recovery later reads.
+            var temporaryPath = BoardPath + ".tmp";
+            await using (var stream = new FileStream(
+                temporaryPath,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None,
+                81920,
+                useAsync: true))
+            {
+                await BoardArchive.SaveAsync(document, stream, cancellationToken);
+            }
+
+            File.Move(temporaryPath, BoardPath, overwrite: true);
+        }
+
+        state.WrittenUtc = DateTimeOffset.UtcNow;
+        var temporaryStatePath = StatePath + ".tmp";
+        await File.WriteAllTextAsync(
+            temporaryStatePath,
+            SessionState.Format(state),
+            cancellationToken);
+        File.Move(temporaryStatePath, StatePath, overwrite: true);
+    }
+
+    /// <summary>
+    /// Every slot no copy of the application is holding any more, newest first.
+    /// </summary>
+    public static IReadOnlyList<AbandonedSession> FindAbandoned()
+    {
+        var found = new List<AbandonedSession>();
+        try
+        {
+            if (!Directory.Exists(FolderPath))
+            {
+                return found;
+            }
+
+            foreach (var statePath in Directory.EnumerateFiles(FolderPath, "*" + StateExtension))
+            {
+                var slotId = Path.GetFileNameWithoutExtension(statePath);
+                if (!IsAbandoned(slotId))
+                {
+                    continue;
+                }
+
+                var state = ReadState(statePath);
+                if (state is null)
+                {
+                    continue;
+                }
+
+                var boardPath = PathFor(slotId, BoardExtension);
+                found.Add(new AbandonedSession(
+                    slotId,
+                    state,
+                    File.Exists(boardPath) ? boardPath : null));
+            }
+        }
+        catch (IOException)
+        {
+            return found;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return found;
+        }
+
+        found.Sort(static (left, right) => right.State.WrittenUtc.CompareTo(left.State.WrittenUtc));
+        return found;
+    }
+
+    /// <summary>
+    /// Removes abandoned slots that have outlived <see cref="AbandonedSlotLifetime"/>, and
+    /// any whose sidecar could not be read at all.
+    /// </summary>
+    public static void Prune()
+    {
+        try
+        {
+            if (!Directory.Exists(FolderPath))
+            {
+                return;
+            }
+
+            var cutoff = DateTimeOffset.UtcNow - AbandonedSlotLifetime;
+            foreach (var statePath in Directory.EnumerateFiles(FolderPath, "*" + StateExtension))
+            {
+                var slotId = Path.GetFileNameWithoutExtension(statePath);
+                if (!IsAbandoned(slotId))
+                {
+                    continue;
+                }
+
+                var state = ReadState(statePath);
+                if (state is null || state.WrittenUtc < cutoff)
+                {
+                    Forget(slotId);
+                }
+            }
+
+            // A lock with no sidecar beside it is a slot that held nothing worth keeping.
+            // Dispose tries to take its own away on the way out and cannot always be sure
+            // of it, so the next start sweeps up whatever was left - one empty file per
+            // launch otherwise accumulates for as long as the application is installed.
+            foreach (var lockPath in Directory.EnumerateFiles(FolderPath, "*" + LockExtension))
+            {
+                var slotId = Path.GetFileNameWithoutExtension(lockPath);
+                if (!File.Exists(PathFor(slotId, StateExtension)) && IsAbandoned(slotId))
+                {
+                    Delete(lockPath);
+                }
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    /// <summary>Deletes a slot's three files.</summary>
+    public static void Forget(string slotId)
+    {
+        Delete(PathFor(slotId, BoardExtension));
+        Delete(PathFor(slotId, StateExtension));
+        Delete(PathFor(slotId, LockExtension));
+    }
+
+    /// <summary>
+    /// Drops what this slot was holding while keeping the slot itself, for a session with
+    /// nothing worth coming back to. The lock file cannot be removed here because this copy
+    /// still has it open; <see cref="Dispose"/> clears it up on the way out.
+    /// </summary>
+    public void Clear()
+    {
+        Delete(BoardPath);
+        Delete(StatePath);
+    }
+
+    /// <summary>
+    /// Releases the lock. A slot still holding a sidecar keeps its files on purpose - they
+    /// are what the next start reads, whether this exit was an orderly one or not - and one
+    /// that was cleared takes its lock file with it rather than leaving it behind.
+    /// </summary>
+    public void Dispose()
+    {
+        _lockStream.Dispose();
+        if (!File.Exists(StatePath))
+        {
+            Delete(PathFor(SlotId, LockExtension));
+        }
+    }
+
+    private static string PathFor(string slotId, string extension) =>
+        Path.Combine(FolderPath, slotId + extension);
+
+    /// <summary>
+    /// Whether the slot's lock can be taken, which is the only reliable way to ask whether
+    /// the copy of the application that owned it is still running. A process id would not
+    /// survive the id being reused.
+    /// </summary>
+    private static bool IsAbandoned(string slotId)
+    {
+        var lockPath = PathFor(slotId, LockExtension);
+        if (!File.Exists(lockPath))
+        {
+            return true;
+        }
+
+        try
+        {
+            using var stream = new FileStream(
+                lockPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.None);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static SessionState? ReadState(string statePath)
+    {
+        try
+        {
+            return SessionState.Parse(File.ReadAllText(statePath));
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    private static void Delete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/src/SQLBI.Whiteboard/SettingsCatalog.cs
+++ b/src/SQLBI.Whiteboard/SettingsCatalog.cs
@@ -105,6 +105,7 @@ internal static class SettingsCatalog
         public const string ToolbarLayout = "toolbar.layout";
         public const string ShowEraserButton = "toolbar.eraserButton";
         public const string WarnWhenNoDigitizer = "startup.noDigitizerNotice";
+        public const string RestoreLastSession = "startup.restoreLastSession";
         public const string FingerMode = "input.fingerMode";
         public const string MouseMode = "input.mouseMode";
         public const string SuggestMouseMode = "input.mouseModeOffer";
@@ -152,6 +153,16 @@ internal static class SettingsCatalog
             Summary = "Fill the monitor and hide the chrome at launch",
             Description = "Fill the current monitor and hide the title and tabs the next time the application starts. F11 still toggles this session. Ctrl+F11 hides chrome without filling the monitor.",
             Keywords = ["fullscreen", "full screen", "f11", "maximize"],
+            Editor = SettingEditorKind.BooleanSwitch,
+        },
+        new()
+        {
+            Id = Ids.RestoreLastSession,
+            Category = Startup,
+            Title = "Reopen the last board",
+            Summary = "Come back to whatever was open when you last closed",
+            Description = "Come back to the board that was open the last time the application closed, at the zoom and position you left it. A board you had saved is reopened from its file; one you had not is kept beside the settings and restored as it was, still unsaved. This covers an ordinary exit only: a board left behind by a copy that stopped unexpectedly is always offered back, whatever this is set to. A LiveView container returns as its last frame and needs Reconnect, because Windows cannot save the capture permission.",
+            Keywords = ["session", "restore", "reopen", "autosave", "recover", "crash", "startup", "last"],
             Editor = SettingEditorKind.BooleanSwitch,
         },
         new()

--- a/src/SQLBI.Whiteboard/UnsavedChangesWindow.xaml
+++ b/src/SQLBI.Whiteboard/UnsavedChangesWindow.xaml
@@ -1,0 +1,63 @@
+<Window x:Class="SQLBI.Whiteboard.UnsavedChangesWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Unsaved changes"
+        Width="560"
+        SizeToContent="Height"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        Background="{DynamicResource ToolbarBackgroundBrush}">
+    <StackPanel Margin="28,24">
+        <TextBlock x:Name="HeadingText"
+                   FontFamily="Segoe UI"
+                   FontSize="16"
+                   FontWeight="SemiBold"
+                   Foreground="#FF1F2937"
+                   TextWrapping="Wrap" />
+        <TextBlock Margin="0,12,0,0"
+                   FontFamily="Segoe UI"
+                   FontSize="13"
+                   Foreground="#FF374151"
+                   TextWrapping="Wrap"
+                   Text="Save writes them to the file. Keep for next time leaves the file as it is and reopens this board, exactly as it stands now, the next time you start SQLBI Whiteboard." />
+        <TextBlock Margin="0,10,0,0"
+                   FontFamily="Segoe UI"
+                   FontSize="13"
+                   Foreground="#FF374151"
+                   TextWrapping="Wrap"
+                   Text="Discard changes throws them away and reopens the file as it was last saved. Cancel returns to the board, and is the only answer that keeps a LiveView feed connected." />
+        <!-- Keep for next time is the default because it is the one answer that
+             decides nothing: the file is untouched and the board comes back. That
+             is what makes a default acceptable here where decision 24 refused one
+             for the mouse mode offer, whose two answers were not interchangeable. -->
+        <StackPanel Margin="0,20,0,0"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right">
+            <Button x:Name="SaveButton"
+                    MinWidth="96"
+                    MinHeight="30"
+                    Margin="0,0,8,0"
+                    Content="Save"
+                    Click="SaveButton_Click" />
+            <Button x:Name="KeepButton"
+                    MinWidth="140"
+                    MinHeight="30"
+                    Margin="0,0,8,0"
+                    IsDefault="True"
+                    Content="Keep for next time"
+                    Click="KeepButton_Click" />
+            <Button x:Name="DiscardButton"
+                    MinWidth="130"
+                    MinHeight="30"
+                    Margin="0,0,8,0"
+                    Content="Discard changes"
+                    Click="DiscardButton_Click" />
+            <Button x:Name="CancelButton"
+                    MinWidth="96"
+                    MinHeight="30"
+                    IsCancel="True"
+                    Content="Cancel" />
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/src/SQLBI.Whiteboard/UnsavedChangesWindow.xaml
+++ b/src/SQLBI.Whiteboard/UnsavedChangesWindow.xaml
@@ -2,62 +2,82 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Unsaved changes"
-        Width="560"
+        Width="470"
         SizeToContent="Height"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
         Background="{DynamicResource ToolbarBackgroundBrush}">
-    <StackPanel Margin="28,24">
+    <Window.Resources>
+        <!-- Each answer carries its own consequence, so there is nothing to read
+             first and nothing to map onto a row of buttons afterwards. -->
+        <Style x:Key="AnswerButton" TargetType="Button">
+            <Setter Property="MinHeight" Value="52" />
+            <Setter Property="Margin" Value="0,0,0,8" />
+            <Setter Property="Padding" Value="14,9" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+        </Style>
+        <Style x:Key="AnswerTitle" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="Segoe UI" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="#FF1F2937" />
+        </Style>
+        <Style x:Key="AnswerDetail" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="Segoe UI" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="Margin" Value="0,2,0,0" />
+            <Setter Property="Foreground" Value="#FF4B5563" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+    </Window.Resources>
+    <StackPanel Margin="24,20,24,20">
         <TextBlock x:Name="HeadingText"
+                   Margin="0,0,0,16"
                    FontFamily="Segoe UI"
                    FontSize="16"
                    FontWeight="SemiBold"
                    Foreground="#FF1F2937"
                    TextWrapping="Wrap" />
-        <TextBlock Margin="0,12,0,0"
-                   FontFamily="Segoe UI"
-                   FontSize="13"
-                   Foreground="#FF374151"
-                   TextWrapping="Wrap"
-                   Text="Save writes them to the file. Keep for next time leaves the file as it is and reopens this board, exactly as it stands now, the next time you start SQLBI Whiteboard." />
-        <TextBlock Margin="0,10,0,0"
-                   FontFamily="Segoe UI"
-                   FontSize="13"
-                   Foreground="#FF374151"
-                   TextWrapping="Wrap"
-                   Text="Discard changes throws them away and reopens the file as it was last saved. Cancel returns to the board, and is the only answer that keeps a LiveView feed connected." />
-        <!-- Keep for next time is the default because it is the one answer that
-             decides nothing: the file is untouched and the board comes back. That
-             is what makes a default acceptable here where decision 24 refused one
-             for the mouse mode offer, whose two answers were not interchangeable. -->
-        <StackPanel Margin="0,20,0,0"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right">
-            <Button x:Name="SaveButton"
-                    MinWidth="96"
-                    MinHeight="30"
-                    Margin="0,0,8,0"
-                    Content="Save"
-                    Click="SaveButton_Click" />
-            <Button x:Name="KeepButton"
-                    MinWidth="140"
-                    MinHeight="30"
-                    Margin="0,0,8,0"
-                    IsDefault="True"
-                    Content="Keep for next time"
-                    Click="KeepButton_Click" />
-            <Button x:Name="DiscardButton"
-                    MinWidth="130"
-                    MinHeight="30"
-                    Margin="0,0,8,0"
-                    Content="Discard changes"
-                    Click="DiscardButton_Click" />
-            <Button x:Name="CancelButton"
-                    MinWidth="96"
-                    MinHeight="30"
-                    IsCancel="True"
-                    Content="Cancel" />
-        </StackPanel>
+
+        <Button x:Name="SaveButton" Style="{StaticResource AnswerButton}" Click="SaveButton_Click">
+            <StackPanel>
+                <TextBlock Style="{StaticResource AnswerTitle}" Text="Save" />
+                <TextBlock x:Name="SaveDetail" Style="{StaticResource AnswerDetail}" />
+            </StackPanel>
+        </Button>
+
+        <!-- The default, because it is the one answer that decides nothing: the file
+             is untouched and the board comes back. Decision 30 says why that is what
+             makes a default acceptable here and not on the mouse mode offer. -->
+        <Button x:Name="KeepButton"
+                Style="{StaticResource AnswerButton}"
+                IsDefault="True"
+                Click="KeepButton_Click">
+            <StackPanel>
+                <TextBlock Style="{StaticResource AnswerTitle}" Text="Keep for next time" />
+                <TextBlock Style="{StaticResource AnswerDetail}"
+                           Text="Leave the file alone. This board comes back the next time you start." />
+            </StackPanel>
+        </Button>
+
+        <Button x:Name="DiscardButton" Style="{StaticResource AnswerButton}" Click="DiscardButton_Click">
+            <StackPanel>
+                <TextBlock Style="{StaticResource AnswerTitle}" Text="Discard changes" />
+                <TextBlock Style="{StaticResource AnswerDetail}"
+                           Text="Throw them away and keep the file as it was last saved." />
+            </StackPanel>
+        </Button>
+
+        <Button x:Name="CancelButton"
+                Style="{StaticResource AnswerButton}"
+                Margin="0"
+                IsCancel="True">
+            <StackPanel>
+                <TextBlock Style="{StaticResource AnswerTitle}" Text="Cancel" />
+                <TextBlock x:Name="CancelDetail" Style="{StaticResource AnswerDetail}" />
+            </StackPanel>
+        </Button>
     </StackPanel>
 </Window>

--- a/src/SQLBI.Whiteboard/UnsavedChangesWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/UnsavedChangesWindow.xaml.cs
@@ -1,0 +1,58 @@
+using System.Windows;
+
+namespace SQLBI.Whiteboard;
+
+/// <summary>
+/// What to do with a named board that has unsaved changes when the window is closing.
+/// </summary>
+public enum UnsavedChangesAnswer
+{
+    /// <summary>Closing was called off; the board stays open.</summary>
+    Cancel,
+
+    /// <summary>Write the changes to the file, then close.</summary>
+    Save,
+
+    /// <summary>Leave the file alone and restore this board at the next start.</summary>
+    Keep,
+
+    /// <summary>Throw the changes away; the next start reopens the file as it is on disk.</summary>
+    Discard,
+}
+
+/// <summary>
+/// Asked on the way out of a board that has a name and has strayed from it. A board with no
+/// name is never asked about - it is carried into the session and comes back on its own,
+/// which is the whole reason an untitled board does not need to interrupt anybody.
+/// </summary>
+public partial class UnsavedChangesWindow : Window
+{
+    public UnsavedChangesWindow(string boardName)
+    {
+        InitializeComponent();
+        HeadingText.Text = $"{boardName} has unsaved changes";
+    }
+
+    /// <summary>
+    /// Cancel until a button says otherwise, so closing the dialog by the title bar or by
+    /// Escape leaves the board where it is.
+    /// </summary>
+    public UnsavedChangesAnswer Result { get; private set; } = UnsavedChangesAnswer.Cancel;
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e) =>
+        Answer(UnsavedChangesAnswer.Save);
+
+    private void KeepButton_Click(object sender, RoutedEventArgs e) =>
+        Answer(UnsavedChangesAnswer.Keep);
+
+    private void DiscardButton_Click(object sender, RoutedEventArgs e) =>
+        Answer(UnsavedChangesAnswer.Discard);
+
+    // Setting DialogResult is what closes the window. Cancel is not answered here: its
+    // button is IsCancel, so WPF closes on it and on Escape, and Result is already Cancel.
+    private void Answer(UnsavedChangesAnswer answer)
+    {
+        Result = answer;
+        DialogResult = true;
+    }
+}

--- a/src/SQLBI.Whiteboard/UnsavedChangesWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/UnsavedChangesWindow.xaml.cs
@@ -27,10 +27,18 @@ public enum UnsavedChangesAnswer
 /// </summary>
 public partial class UnsavedChangesWindow : Window
 {
-    public UnsavedChangesWindow(string boardName)
+    public UnsavedChangesWindow(string boardName, bool hasLiveView)
     {
         InitializeComponent();
         HeadingText.Text = $"{boardName} has unsaved changes";
+        SaveDetail.Text = $"Write the changes to {boardName}.";
+
+        // Only worth saying where there is a feed to lose. On a board without one it would
+        // be a sentence about a feature the reader is not using, in the row they are most
+        // likely to want when they have hit the wrong thing.
+        CancelDetail.Text = hasLiveView
+            ? "Go back to the board. The only answer that keeps a LiveView feed connected."
+            : "Go back to the board and carry on.";
     }
 
     /// <summary>

--- a/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
+++ b/tests/SQLBI.Whiteboard.Core.SmokeTests/Program.cs
@@ -1728,6 +1728,115 @@ Assert(
     }
 }
 
+// The save point is what tells a board that matches its file from one that does not, and
+// every one of these is a case somebody hits in an afternoon's drawing.
+{
+    var savedDocument = new BoardDocument();
+    var savedHistory = new CommandHistory();
+    Assert(savedHistory.IsAtSavePoint, "A board nobody has drawn on matches the empty file it is not.");
+
+    savedHistory.Execute(new AddObjectCommand(ExportStroke(0, 0, 10, 10, 0)), savedDocument);
+    Assert(!savedHistory.IsAtSavePoint, "A stroke drawn before any save must count as a change.");
+
+    savedHistory.MarkSaved();
+    Assert(savedHistory.IsAtSavePoint, "Saving must make the board match the file.");
+
+    savedHistory.Undo(savedDocument);
+    Assert(
+        !savedHistory.IsAtSavePoint,
+        "Undoing after a save rolls back what the file holds, so it must count as a change.");
+
+    savedHistory.Redo(savedDocument);
+    Assert(savedHistory.IsAtSavePoint, "Redoing back onto the save point must match the file again.");
+
+    savedHistory.Execute(new AddObjectCommand(ExportStroke(20, 20, 10, 10, 1)), savedDocument);
+    Assert(!savedHistory.IsAtSavePoint, "A stroke drawn after a save must count as a change.");
+
+    savedHistory.Undo(savedDocument);
+    Assert(
+        savedHistory.IsAtSavePoint,
+        "Undoing that stroke returns to what was saved, so it must stop counting as a change.");
+
+    // Same depth, different history: the save point is the command, never the count.
+    savedHistory.Execute(new AddObjectCommand(ExportStroke(40, 40, 10, 10, 2)), savedDocument);
+    Assert(
+        !savedHistory.IsAtSavePoint,
+        "A different action at the depth that was saved is still a change.");
+
+    savedHistory.Clear();
+    Assert(savedHistory.IsAtSavePoint, "Clearing the history puts the save point at the empty board.");
+}
+
+// A snapshot is what autosave writes while the board carries on being drawn, so it has to
+// hold what the document held and stop hearing about it afterwards.
+{
+    var snapshotDocument = new BoardDocument();
+    snapshotDocument.AddAsset(new BoardAsset("asset-1", "picture.png", "image/png", [1, 2, 3]));
+    snapshotDocument.AddObject(ExportStroke(0, 0, 10, 10, 3));
+    snapshotDocument.AddObject(ExportStroke(30, 30, 10, 10, 1));
+
+    var snapshot = snapshotDocument.Snapshot();
+    Assert(snapshot.Objects.Count == 2, "A snapshot keeps every object.");
+    Assert(snapshot.Assets.Count == 1, "A snapshot keeps every asset.");
+    Assert(
+        snapshot.Objects[0].ZIndex == 1 && snapshot.Objects[1].ZIndex == 3,
+        "A snapshot keeps the document's z order.");
+
+    snapshotDocument.AddObject(ExportStroke(60, 60, 10, 10, 4));
+    Assert(
+        snapshot.Objects.Count == 2,
+        "A stroke drawn after the snapshot must not reach the copy being written.");
+}
+
+// The session sidecar is read while the application is starting, so nothing it can contain
+// is allowed to be what stops it.
+{
+    var state = new SessionState
+    {
+        BoardPath = @"C:\decks\demo.wboard",
+        Modified = true,
+        ExitedCleanly = false,
+        CameraCenterX = 120.5,
+        CameraCenterY = -40.25,
+        CameraZoom = 2.5,
+    };
+
+    var parsed = SessionState.Parse(SessionState.Format(state));
+    Assert(parsed is not null, "A sidecar this version wrote must read back.");
+    Assert(parsed!.BoardPath == state.BoardPath, "A sidecar keeps the board it was editing.");
+    Assert(parsed.Modified && !parsed.ExitedCleanly, "A sidecar keeps how the session ended.");
+    AssertNear(120.5, parsed.CameraCenterX, "A sidecar keeps where the camera was.");
+    AssertNear(2.5, parsed.CameraZoom, "A sidecar keeps the zoom.");
+
+    Assert(SessionState.Parse("{ not json") is null, "Damaged sidecars are skipped, not thrown over.");
+    Assert(SessionState.Parse(string.Empty) is null, "An empty sidecar is skipped.");
+    Assert(
+        SessionState.Parse("{\"version\":9999}") is null,
+        "A sidecar from a later version is skipped rather than half understood.");
+    Assert(
+        SessionState.Parse("{\"version\":1,\"boardPath\":\"  \"}")?.BoardPath is null,
+        "A blank board path reads as no board path.");
+}
+
+// A restored camera comes from a file, so what it carries is checked rather than trusted.
+{
+    var restored = new Camera2D();
+    restored.Resize(1000, 800);
+    restored.Restore(new PointD(50, -30), 3);
+    AssertNear(50, restored.Center.X, "A restored camera takes the center it was given.");
+    AssertNear(3, restored.Zoom, "A restored camera takes the zoom it was given.");
+
+    restored.Restore(new PointD(0, 0), 9999);
+    AssertNear(Camera2D.MaximumZoom, restored.Zoom, "A restored zoom is clamped, not trusted.");
+
+    restored.Restore(new PointD(0, 0), 0);
+    AssertNear(Camera2D.MinimumZoom, restored.Zoom, "A zero zoom clamps rather than blanking the board.");
+
+    restored.Restore(new PointD(10, 10), 2);
+    restored.Restore(new PointD(double.NaN, 0), 2);
+    AssertNear(10, restored.Center.X, "A sidecar carrying NaN leaves the camera where it was.");
+}
+
 Console.WriteLine("SQLBI.Whiteboard.Core smoke tests passed.");
 
 static InkStrokeObject ExportStroke(double x, double y, double width, double height, int zIndex, Guid? containerId = null) =>


### PR DESCRIPTION
Closes #121. Closes #122.

The board is copied into a session slot every thirty seconds and again on the way out, and
the next start brings it back. **Nothing on this path writes to the `.wboard` the person
named** — that file changes when they ask for it to change, and every call below follows
from it. The reasoning is decision 30 in `docs/decisions.md`.

## Knowing whether the board has changed came first

All three parts of #121 need it, and the application could not answer it.
`ConfirmDiscardUnsaved` stood in by asking whether the board was empty, so it nagged right
after a save and said nothing when everything had just been erased.

It is two signals, because one cannot cover it:

- **`CommandHistory` carries a save point** — the command on top of the undo stack when the
  file was written. Undoing back to what was saved stops counting as a change; undoing
  *past* it starts counting again. A counter cannot express that, since undo moves it the
  same way drawing does.
- **A flag covers what never reaches a command.** In practice only one caller survived the
  audit: a `.wimport` opened as a new board, which clears the history around content no file
  holds. The LiveView paths deliberately set neither signal, so a frame arriving on its own
  cannot put an unasked question in front of someone who left the application running beside
  a feed.

The window title now shows the board and an asterisk, so the question asked on the way out
has something on screen explaining it.

## The exit question

Four answers, each a row carrying its own one-line consequence: Save, **Keep for next time**,
Discard changes, Cancel. There is no prose above them — an earlier draft explained the four
in two paragraphs, which made the reader map sentences onto buttons before they could act.
The LiveView line appears only on a board that has a LiveView container.

Keep is `IsDefault`, which decision 24 refused for the mouse mode offer. The difference is
that there both answers changed something, so neither could be primed; here Keep decides
nothing — the file is untouched and the board returns — so Enter landing on it is never the
wrong outcome. Decision 30 records this so it does not read as an oversight to be tidied up.

**Cancel stays, and LiveView is the reason.** Keep and Cancel look interchangeable, but a
restored LiveView container comes back as its last frame and has to be reconnected by hand.
Cancel is the only answer that keeps a feed live — which matters most in the case where the
window gets closed by accident, mid-recording. The camera position is carried in the session
to narrow what is left of the gap.

## One slot per running copy

Each copy takes a slot named by a GUID and holds a lock file open while it runs, so two
windows never write to the same files. Forbidding a second window was considered and
rejected: two boards side by side is a real thing to want. A slot whose lock can be taken
belonged to a copy that has gone, and its sidecar says whether it went on purpose — which is
what separates a silent restore from an offer of recovery.

Declining a recovery discards that slot, and the question says so. The alternative is asking
the same person the same thing at every start for thirty days.

## Opening a board asks the slots too (#122)

The startup offer only covers the newest slot, so without this the moment somebody most wants
their recovered work — opening the very board they lost — is the moment the application says
nothing. Every route into a board goes through `OpenPathAsync`, so the Open dialog, a drop,
and a double-click in Explorer are covered once rather than three times. Yes takes the
changes, No opens the saved file and discards them, Cancel opens neither and keeps the slot.

## Checks

`dotnet build Whiteboard.sln -c Release` clean, both smoke harnesses pass. The Core harness
covers the save point through the cases that actually come up — save, undo, redo, undo back
onto the point, a different action at the same depth — plus the snapshot autosave writes, the
sidecar round-trip and what it does with damaged input, and the clamping on a restored camera.

Also walked through the built application rather than trusting the tests:

- A crafted session slot restored on launch with the title reading `Untitled board *`, the
  camera where the sidecar put it, the slot re-homed into this copy's own before the old one
  was released, and the sidecar flipping to `exitedCleanly` on the way out.
- For #122: a saved board holding one stroke, and a crashed slot holding five for that same
  file. Opening the file offered the changes; answering Yes gave `demo.wboard *` in the title
  and a board of five strokes, while **the file on disk still held one**. Killing the process
  then left a slot that correctly read as a crash.
- One thing only that found: an empty lock file survived each launch, so `Prune` now sweeps
  orphans.

`VersionPrefix` moves to 1.5.0 with the matching `CHANGELOG.md` section, and `site/guide.html`
gets one paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)