### PR TITLE
Cut the 1.5.0 notes to three entries and draw the restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,29 +21,19 @@ and **bold**.
 
 ### The board you had open comes back
 Close SQLBI Whiteboard and the board you were working on is there again the next time you
-start, at the zoom and position you left it. A board you had saved reopens from its file; an
-untitled one is kept beside your settings and comes back as it was. **Reopen the last board**
-in **Preferences → Startup** turns this off.
+start, at the zoom and position you left it. **Reopen the last board** in
+**Preferences → Startup** turns this off.
 
 ### Closing a board with unsaved changes asks first
-If the board has a name and has changed since you saved it, closing the window now offers
-**Save**, **Keep for next time**, **Discard changes**, and **Cancel**. Keep leaves the file
-untouched and brings the board back at the next start. Cancel is the only answer that keeps a
-LiveView feed connected.
+If the board has a name and has changed since you saved it, closing offers **Save**,
+**Keep for next time**, **Discard changes**, or **Cancel**. Keep leaves the file untouched and
+brings the board back at the next start; Cancel is the one answer that keeps a LiveView feed
+connected. The title bar now names the board, with an asterisk while it differs from the file.
 
-### Work is recoverable after a crash
-The board is copied beside your settings every thirty seconds while you work. If SQLBI
-Whiteboard stops unexpectedly, the next start offers to recover it. This copy is only ever a
-safety net — nothing here writes to your `.wboard` file without being asked.
-
-### Opening a board offers changes a crash left for it
-If SQLBI Whiteboard stopped unexpectedly while you had unsaved changes to a board, opening
-that board again offers those changes instead of the saved file. This works however you open
-it — **File → Open**, a drop, or a double-click in Explorer.
-
-### The title bar says which board, and whether it is saved
-The window title now shows the file name, with an asterisk while the board differs from what
-is on disk. An untitled board reads as **Untitled board**.
+### Work survives a crash
+The board is copied beside your settings every thirty seconds. If SQLBI Whiteboard stops
+unexpectedly, the next start offers it back, and so does opening that board again. Nothing
+here writes to your `.wboard` without being asked.
 
 ## 1.4.0 - 8 September 2026
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,8 +110,15 @@ mechanism belong, at whatever length they need. The other two are short:
   not the diagnosis. Link to `docs/` for anything longer.
 
 The test is the neighbours: if a new paragraph is noticeably longer than the ones beside
-it, cut it. This has been asked for twice; the 1.3.0 notes as first written are what it
-looks like when it slips, and their shortened form is what was wanted.
+it, cut it. This has been asked for three times; the 1.3.0 notes as first written are what
+it looks like when it slips, and their shortened form is what was wanted.
+
+It slips the same way each time: one entry per piece of work that was built, rather than
+per thing a person notices. The 1.5.0 notes went in with five entries where the change
+deserved three — the title bar marker belongs in the entry about closing a board, where a
+person meets it, and being offered recovered work when reopening a board is the same story
+to a reader as being offered it at startup. So count the entries in the two versions below
+yours before writing: that is the shape to match, not a ceiling to approach.
 
 ## Code style
 

--- a/site/guide.html
+++ b/site/guide.html
@@ -540,7 +540,60 @@
     <section class="story">
       <h3>Pick up where you left off</h3>
       <p>Close SQLBI Whiteboard and the board you had open is there again the next time you start, at the zoom and position you left it. Turn that off under <span class="ui">Preferences → Startup</span> if you would rather begin on a blank board every time.</p>
-      <p>Closing a saved board that has changed asks what to do first: <span class="ui">Keep for next time</span> leaves the file alone and brings the board back as it stands, and <span class="ui">Cancel</span> is the answer that keeps a LiveView feed connected. The board is also copied every thirty seconds while you work, so one lost to a crash is offered back at the next start rather than gone. Nothing on this path writes to your <code>.wboard</code> file — only <span class="ui">Save</span> does that.</p>
+      <p>Closing a saved board that has changed asks first: <span class="ui">Keep for next time</span> leaves the file alone and brings the board back as it stands, and <span class="ui">Cancel</span> is the answer that keeps a LiveView feed connected. The board is also copied aside every thirty seconds, so one lost to a crash is offered back — at the next start, or when you next open that board. Only <span class="ui">Save</span> writes to your <code>.wboard</code>.</p>
+
+      <figure class="fig">
+        <div class="figbox">
+          <svg viewBox="0 0 700 244" role="img" aria-label="The same board drawn twice: as it stood when the window was closed, and unchanged after the application was started again, with the same ink in the same place and the same unsaved marker in the title.">
+            <title>A board across a restart</title>
+            <defs>
+              <g id="restore-board">
+                <path d="M26 54c22-32 40 14 58-10s34 6 52-14" fill="none" stroke="var(--fig-ink)" stroke-width="3" stroke-linecap="round"/>
+                <path d="M28 88h104" fill="none" stroke="var(--fig-danger)" stroke-width="5" stroke-linecap="round" opacity=".55"/>
+                <rect x="160" y="34" width="98" height="62" rx="7" fill="var(--fig-surface-2)" stroke="var(--fig-line)"/>
+                <g fill="var(--fig-line)">
+                  <rect x="172" y="48" width="62" height="6" rx="3"/>
+                  <rect x="172" y="62" width="74" height="6" rx="3"/>
+                  <rect x="172" y="76" width="44" height="6" rx="3"/>
+                </g>
+              </g>
+              <pattern id="f13grid" width="34" height="34" patternUnits="userSpaceOnUse"><path d="M34 0H0v34" fill="none" stroke="var(--fig-grid)" stroke-width="1"/></pattern>
+              <clipPath id="f13left"><rect x="24" y="30" width="286" height="166" rx="12"/></clipPath>
+              <clipPath id="f13right"><rect x="390" y="30" width="286" height="166" rx="12"/></clipPath>
+            </defs>
+
+            <rect width="700" height="244" rx="10" fill="var(--fig-ground)"/>
+
+            <g clip-path="url(#f13left)">
+              <rect x="24" y="30" width="286" height="166" fill="var(--fig-surface)"/>
+              <rect x="24" y="58" width="286" height="138" fill="url(#f13grid)"/>
+              <rect x="24" y="30" width="286" height="28" fill="var(--fig-surface-2)"/>
+              <use href="#restore-board" x="24" y="58"/>
+            </g>
+            <rect x="24" y="30" width="286" height="166" rx="12" fill="none" stroke="var(--fig-line)"/>
+            <text x="40" y="49" font-size="11.5" fill="var(--fig-muted)">demo.wboard *</text>
+            <path d="M288 39l12 10M300 39l-12 10" stroke="var(--fig-muted)" stroke-width="1.6" stroke-linecap="round"/>
+
+            <path d="M326 113h42" fill="none" stroke="var(--fig-muted)" stroke-width="2" stroke-linecap="round"/>
+            <path d="M362 107l8 6-8 6" fill="none" stroke="var(--fig-muted)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+
+            <g clip-path="url(#f13right)">
+              <rect x="390" y="30" width="286" height="166" fill="var(--fig-surface)"/>
+              <rect x="390" y="58" width="286" height="138" fill="url(#f13grid)"/>
+              <rect x="390" y="30" width="286" height="28" fill="var(--fig-surface-2)"/>
+              <use href="#restore-board" x="390" y="58"/>
+            </g>
+            <rect x="390" y="30" width="286" height="166" rx="12" fill="none" stroke="var(--fig-line)"/>
+            <text x="406" y="49" font-size="11.5" fill="var(--fig-muted)">demo.wboard *</text>
+
+            <g font-size="12.5" fill="var(--fig-muted)" text-anchor="middle">
+              <text x="167" y="222">when you close</text>
+              <text x="533" y="222">when you start again</text>
+            </g>
+          </svg>
+        </div>
+        <figcaption>The same ink in the same place, and the same zoom. A board you chose to keep rather than save comes back unsaved, so the asterisk in the title comes back with it.</figcaption>
+      </figure>
     </section>
 
     <section class="story">


### PR DESCRIPTION
The 1.5.0 notes went in at five entries where 1.4.0 has two and 1.3.1 has three, several of
them four and five lines. CONTRIBUTING asks for one heading per thing a person notices, two
to four lines each, and says the test is the neighbours — these were noticeably longer than
the ones beside them. That file records this having been asked for twice; this is the third.

## The notes

Three entries: **the board comes back**, **closing asks first**, **work survives a crash**.

Two of the five were not separate things a person notices. Being offered your changes when
you reopen the board is the same story as being offered them at startup, so it folds into
the crash entry as a clause. The title bar naming the board is how you *see* that it has
unsaved changes, so it folds into the closing entry, which is where you meet it.

Lengths are now 3, 4 and 3 lines, against 1.4.0's 4 and 3.

## The guide

`Pick up where you left off` was the only section in its run without a figure, so it gains
one: the same board before and after a restart, with the same ink in the same place and the
same unsaved marker in the title. Two panels and an arrow — the point being that nothing
changed across the restart, so the two halves are the same drawing, emitted once in `defs`
and placed twice.

It is drawn from the `--fig-*` variables rather than fixed colors, and carries the same faint
canvas grid the other figures use. Checked in both light and dark.

The prose also picks up the case it was missing — reopening a board offers what a crash left
for it — and loses a sentence in the process.

No code changes; `VersionPrefix` is untouched at 1.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)