### PR TITLE
Animate the restart figure, and pin down the path matching

### DIFF
--- a/site/guide.html
+++ b/site/guide.html
@@ -564,31 +564,34 @@
 
             <rect width="700" height="244" rx="10" fill="var(--fig-ground)"/>
 
-            <g clip-path="url(#f13left)">
-              <rect x="24" y="30" width="286" height="166" fill="var(--fig-surface)"/>
-              <rect x="24" y="58" width="286" height="138" fill="url(#f13grid)"/>
-              <rect x="24" y="30" width="286" height="28" fill="var(--fig-surface-2)"/>
-              <use href="#restore-board" x="24" y="58"/>
+            <g class="f13-before">
+              <g clip-path="url(#f13left)">
+                <rect x="24" y="30" width="286" height="166" fill="var(--fig-surface)"/>
+                <rect x="24" y="58" width="286" height="138" fill="url(#f13grid)"/>
+                <rect x="24" y="30" width="286" height="28" fill="var(--fig-surface-2)"/>
+                <use href="#restore-board" x="24" y="58"/>
+              </g>
+              <rect x="24" y="30" width="286" height="166" rx="12" fill="none" stroke="var(--fig-line)"/>
+              <text x="40" y="49" font-size="11.5" fill="var(--fig-muted)">demo.wboard *</text>
+              <path d="M288 39l12 10M300 39l-12 10" stroke="var(--fig-muted)" stroke-width="1.6" stroke-linecap="round"/>
+              <text x="167" y="222" font-size="12.5" fill="var(--fig-muted)" text-anchor="middle">when you close</text>
             </g>
-            <rect x="24" y="30" width="286" height="166" rx="12" fill="none" stroke="var(--fig-line)"/>
-            <text x="40" y="49" font-size="11.5" fill="var(--fig-muted)">demo.wboard *</text>
-            <path d="M288 39l12 10M300 39l-12 10" stroke="var(--fig-muted)" stroke-width="1.6" stroke-linecap="round"/>
 
-            <path d="M326 113h42" fill="none" stroke="var(--fig-muted)" stroke-width="2" stroke-linecap="round"/>
-            <path d="M362 107l8 6-8 6" fill="none" stroke="var(--fig-muted)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-
-            <g clip-path="url(#f13right)">
-              <rect x="390" y="30" width="286" height="166" fill="var(--fig-surface)"/>
-              <rect x="390" y="58" width="286" height="138" fill="url(#f13grid)"/>
-              <rect x="390" y="30" width="286" height="28" fill="var(--fig-surface-2)"/>
-              <use href="#restore-board" x="390" y="58"/>
+            <g class="f13-restart">
+              <path d="M326 113h42" fill="none" stroke="var(--fig-muted)" stroke-width="2" stroke-linecap="round"/>
+              <path d="M362 107l8 6-8 6" fill="none" stroke="var(--fig-muted)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </g>
-            <rect x="390" y="30" width="286" height="166" rx="12" fill="none" stroke="var(--fig-line)"/>
-            <text x="406" y="49" font-size="11.5" fill="var(--fig-muted)">demo.wboard *</text>
 
-            <g font-size="12.5" fill="var(--fig-muted)" text-anchor="middle">
-              <text x="167" y="222">when you close</text>
-              <text x="533" y="222">when you start again</text>
+            <g class="f13-after">
+              <g clip-path="url(#f13right)">
+                <rect x="390" y="30" width="286" height="166" fill="var(--fig-surface)"/>
+                <rect x="390" y="58" width="286" height="138" fill="url(#f13grid)"/>
+                <rect x="390" y="30" width="286" height="28" fill="var(--fig-surface-2)"/>
+                <use href="#restore-board" x="390" y="58"/>
+              </g>
+              <rect x="390" y="30" width="286" height="166" rx="12" fill="none" stroke="var(--fig-line)"/>
+              <text x="406" y="49" font-size="11.5" fill="var(--fig-muted)">demo.wboard *</text>
+              <text x="533" y="222" font-size="12.5" fill="var(--fig-muted)" text-anchor="middle">when you start again</text>
             </g>
           </svg>
         </div>

--- a/site/styles.css
+++ b/site/styles.css
@@ -990,6 +990,12 @@ footer a:hover { color: var(--ink); text-decoration: underline; }
   .fig.is-visible .f12-a { animation: fig-swap 6s ease infinite; }
   .fig.is-visible .f12-b { animation: fig-swap 6s ease -3s infinite; }
   .fig.is-visible .f12-ink { animation: fig-inkdraw 7s ease-out .5s infinite; }
+
+  /* The board, then the restart, then the board again - so the second window
+     arriving after the first is the thing the eye follows. */
+  .fig.is-visible .f13-before { animation: fig-pop 6.5s ease infinite both; }
+  .fig.is-visible .f13-restart { animation: fig-pop 6.5s ease .3s infinite both; }
+  .fig.is-visible .f13-after { animation: fig-pop 6.5s ease .6s infinite both; }
 }
 
 /* The container carries its ink out, holds, and is put back. */
@@ -1098,7 +1104,8 @@ footer a:hover { color: var(--ink); text-decoration: underline; }
 .fig .f6-1, .fig .f6-2, .fig .f6-3, .fig .f6-4,
 .fig .f7-b, .fig .f7-d,
 .fig .f8-a, .fig .f8-b, .fig .f8-c,
-.fig .f10-q, .fig .f10-a, .fig .f10-b, .fig .f10-c {
+.fig .f10-q, .fig .f10-a, .fig .f10-b, .fig .f10-c,
+.fig .f13-before, .fig .f13-restart, .fig .f13-after {
   transform-box: fill-box;
   transform-origin: center;
 }

--- a/src/SQLBI.Whiteboard/MainWindow.xaml.cs
+++ b/src/SQLBI.Whiteboard/MainWindow.xaml.cs
@@ -5050,7 +5050,7 @@ public partial class MainWindow : Window
             !item.State.ExitedCleanly &&
             item.BoardPath is not null &&
             item.State.BoardPath is not null &&
-            IsSameFile(item.State.BoardPath, filePath));
+            SessionStore.IsSameFile(item.State.BoardPath, filePath));
 
         if (match is null)
         {
@@ -5091,30 +5091,6 @@ public partial class MainWindow : Window
         await WriteSessionAsync(keepBoard: true, exitedCleanly: false);
         SessionStore.Forget(match.SlotId);
         return true;
-    }
-
-    /// <summary>
-    /// Whether two paths name the same file on this machine. Compared after expansion, since
-    /// the same board reaches the application as a full path from Explorer and as whatever
-    /// was typed from everywhere else.
-    /// </summary>
-    private static bool IsSameFile(string left, string right)
-    {
-        try
-        {
-            return string.Equals(
-                Path.GetFullPath(left),
-                Path.GetFullPath(right),
-                StringComparison.OrdinalIgnoreCase);
-        }
-        catch (ArgumentException)
-        {
-            return false;
-        }
-        catch (IOException)
-        {
-            return false;
-        }
     }
 
     private async Task LoadBoardAsync(string filePath)

--- a/src/SQLBI.Whiteboard/SessionStore.cs
+++ b/src/SQLBI.Whiteboard/SessionStore.cs
@@ -258,6 +258,42 @@ internal sealed class SessionStore : IDisposable
         }
     }
 
+    /// <summary>
+    /// Whether two paths name the same file on this machine.
+    /// </summary>
+    /// <remarks>
+    /// A board reaches the application as a full path from Explorer, as whatever was typed
+    /// on a command line, and as whatever a sidecar recorded when it was last open, so the
+    /// two sides are expanded before they are compared. <see cref="Path.GetFullPath(string)"/>
+    /// settles all of it, 8.3 short components included: it expands those against the
+    /// directory entries, so a slot holding <c>C:\MARCOR~1\board.wboard</c> does match the
+    /// same board opened by its long name. That only holds while the file is there to be
+    /// read, which is exactly when this is asked - the board being opened exists, and the
+    /// slot that matches it names that same file.
+    /// </remarks>
+    public static bool IsSameFile(string left, string right)
+    {
+        try
+        {
+            return string.Equals(
+                Path.GetFullPath(left),
+                Path.GetFullPath(right),
+                StringComparison.OrdinalIgnoreCase);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
     private static string PathFor(string slotId, string extension) =>
         Path.Combine(FolderPath, slotId + extension);
 

--- a/tests/SQLBI.Whiteboard.SmokeTests/Program.cs
+++ b/tests/SQLBI.Whiteboard.SmokeTests/Program.cs
@@ -534,7 +534,63 @@ Assert(
     vector.Length > 1000 && Encoding.ASCII.GetString(vector.ToArray(), 0, 5) == "%PDF-",
     "The vector page should be written as a PDF.");
 
+// Matching a session slot to the board it was holding is a string comparison over paths
+// that reached the application by different routes, so what it has to survive is the same
+// file spelled differently. The 8.3 case is the one Path.GetFullPath does not answer.
+{
+    // The directory name has to be long enough and mixed enough to earn a distinct 8.3
+    // name; the temp folder itself is often already the short form, which would make the
+    // comparison below trivially true.
+    var directory = Path.Combine(
+        Path.GetTempPath(),
+        $"WhiteboardSmokeSession-{Guid.NewGuid():n}");
+    Directory.CreateDirectory(directory);
+    var longPath = Path.Combine(directory, "Compression demo.wboard");
+    File.WriteAllText(longPath, "board");
+    try
+    {
+        Assert(
+            SessionStore.IsSameFile(longPath, longPath),
+            "A path must match itself.");
+        Assert(
+            SessionStore.IsSameFile(longPath, longPath.ToUpperInvariant()),
+            "Windows paths differing only in case name the same file.");
+        Assert(
+            SessionStore.IsSameFile(
+                longPath,
+                Path.Combine(directory, ".", Path.GetFileName(longPath))),
+            "A path with a redundant component names the same file.");
+        Assert(
+            !SessionStore.IsSameFile(longPath, longPath + ".other"),
+            "Two different files must not match.");
+
+        // On a volume with 8.3 names turned off this is the long path back again, and the
+        // case degrades to the first assertion rather than failing.
+        var shortPath = ShortPathOf(longPath);
+        Assert(
+            SessionStore.IsSameFile(shortPath, longPath),
+            "A short 8.3 path and its long form name the same file.");
+    }
+    finally
+    {
+        Directory.Delete(directory, recursive: true);
+    }
+}
+
 Console.WriteLine("SQLBI.Whiteboard smoke tests passed.");
+
+static string ShortPathOf(string path)
+{
+    var buffer = new StringBuilder(260);
+    var length = GetShortPathName(path, buffer, (uint)buffer.Capacity);
+    return length == 0 || length > buffer.Capacity ? path : buffer.ToString();
+}
+
+[System.Runtime.InteropServices.DllImport(
+    "kernel32.dll",
+    CharSet = System.Runtime.InteropServices.CharSet.Unicode,
+    SetLastError = true)]
+static extern uint GetShortPathName(string longPath, StringBuilder shortPath, uint bufferLength);
 
 // Whether the spans, and the text between them, put the source back together
 // unchanged. Nothing here rewrites a snippet; a span only says what covers it.


### PR DESCRIPTION
Two things, and one of them is a correction.

## The figure now moves

`Pick up where you left off` was the only figure on the page that sat still. It now uses the
same staggered `fig-pop` as f4, f8 and f10 — same 6.5s cycle, same 0 / .3 / .6 delays:

1. the board as you left it,
2. the restart arrow,
3. the board again.

So the second window arriving after the first is the thing the eye follows. It rests on both
windows for most of the loop, per the comment at the top of that CSS block, and inherits the
existing `is-visible` observer and the `prefers-reduced-motion` gate without touching either.

## The short-path limitation does not exist

I reported that `IsSameFile` would miss a match between `C:\Users\MARCOR~1\board.wboard` and
`C:\Users\MarcoRusso\board.wboard`. That was wrong. **`Path.GetFullPath` expands 8.3
components** against the directory entries, so the original code already handled it.

I found out by writing the fix: a `GetLongPathName` interop went in, and the new test passed
just as well with it disabled. Deriving a real short path with `GetShortPathName` and printing
what `GetFullPath` returns settled it — the long form comes back. The interop is removed; it
did nothing.

What survives is the part that has value:

- **`IsSameFile` moves from `MainWindow` to `SessionStore`**, where the smoke tests can reach
  it. That move is what made the question answerable instead of arguable.
- **A smoke test covers it**, deriving a genuine 8.3 path at run time rather than asserting
  against a hand-written one. It also covers case differences and a redundant path component.
  On a volume with 8.3 names turned off it degrades to comparing a path with itself rather
  than failing.
- **The remark on `IsSameFile`** records why it is correct and the one condition it rests on:
  the expansion needs the file to be there to read. That holds here, since the board being
  opened exists and the slot that matches it names that same file.

## No version bump

`VersionPrefix` stays at 1.5.0. Nothing here changes what the application does — a refactor,
a test, and a site figure. Say the word if you want 1.5.1 anyway and I will add it with an
honest entry.

Both smoke harnesses pass; the figure checked in light and dark, and frame-sampled mid-cycle
to confirm the order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)